### PR TITLE
Enhance DX12 debug layer with GPU-Based Validation support

### DIFF
--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -36,7 +36,7 @@ use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Once, OnceLock};
 use windows::core::Interface;
-use windows::Win32::Graphics::Direct3D12::{D3D12GetDebugInterface, ID3D12Debug};
+use windows::Win32::Graphics::Direct3D12::{D3D12GetDebugInterface, ID3D12Debug, ID3D12Debug1};
 use windows::Win32::Graphics::Dxgi::*;
 
 /// Adapter ID for the WARP device from [`IDXGIFactory4::EnumWarpAdapter`].
@@ -103,6 +103,22 @@ impl Dx12Backend {
                     if let Some(d) = debug_interface {
                         unsafe { d.EnableDebugLayer() };
                         tracing::info!("D3D12 debug layer enabled");
+
+                        // GPU-Based Validation: catches UAV/SRV descriptor mismatches,
+                        // resource state errors, and out-of-bounds access on the GPU timeline.
+                        // Very slow — enable with GOLDY_DX12_GBV=1.
+                        let enable_gbv = std::env::var("GOLDY_DX12_GBV")
+                            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+                        if enable_gbv {
+                            if let Ok(debug1) = d.cast::<ID3D12Debug1>() {
+                                unsafe { debug1.SetEnableGPUBasedValidation(true) };
+                                tracing::info!("D3D12 GPU-Based Validation (GBV) enabled");
+                            } else {
+                                tracing::warn!(
+                                    "ID3D12Debug1 not available — GPU-Based Validation unavailable"
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/src/backend/dx12/shader.rs
+++ b/src/backend/dx12/shader.rs
@@ -134,7 +134,9 @@ pub(super) fn ensure_stage_compiled(
     // Dump DXIL for debugging when GOLDY_DUMP_SHADERS is set
     if let Ok(dump_dir) = std::env::var("GOLDY_DUMP_SHADERS") {
         use std::io::Write;
-        let path = std::path::Path::new(&dump_dir).join(format!("{}_dx12.dxil", entry_point_name));
+        let dir = std::path::Path::new(&dump_dir);
+        let _ = std::fs::create_dir_all(dir);
+        let path = dir.join(format!("{}_h{}_dx12.dxil", entry_point_name, shader_handle));
         if let Ok(mut file) = std::fs::File::create(&path) {
             let _ = file.write_all(&bytecode);
             tracing::info!("Dumped DXIL bytecode to {}", path.display());

--- a/src/backend/vulkan/shader.rs
+++ b/src/backend/vulkan/shader.rs
@@ -163,7 +163,9 @@ pub(super) fn ensure_stage_compiled(
     // Dump SPIR-V for debugging when GOLDY_DUMP_SHADERS is set
     if let Ok(dump_dir) = std::env::var("GOLDY_DUMP_SHADERS") {
         use std::io::Write;
-        let path = std::path::Path::new(&dump_dir).join(format!(
+        let dir = std::path::Path::new(&dump_dir);
+        let _ = std::fs::create_dir_all(dir);
+        let path = dir.join(format!(
             "{}_h{}_vulkan.spv",
             entry_point_name, shader_handle
         ));


### PR DESCRIPTION
- Added support for GPU-Based Validation (GBV) in the DX12 backend, allowing for detection of descriptor mismatches and resource state errors on the GPU.
- Updated shader compilation functions to create necessary directories for dumping DXIL bytecode, improving debugging capabilities.
- Enhanced Vulkan shader compilation to ensure proper directory creation for SPIR-V dumps.