### PR TITLE
Add compute example and update rendering methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ After completing any task, run the CI checks locally:
 
 ```bash
 cargo fmt --all -- --check
+cargo clippy --no-default-features -- -D warnings
 cargo clippy -- -D warnings
 cargo test
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,10 @@ path = "examples/game_of_life.rs"
 name = "depth_quads"
 path = "examples/depth_quads.rs"
 
+[[example]]
+name = "compute_to_surface"
+path = "examples/compute_to_surface.rs"
+
 [[bin]]
 name = "update-screenshots"
 path = "tools/update_screenshots.rs"

--- a/docs/src/concepts/frames.md
+++ b/docs/src/concepts/frames.md
@@ -9,24 +9,29 @@ Goldy provides two complementary APIs for rendering output: **Surface** for zero
 ### Creating a Surface
 
 ```rust
-use goldy::{Surface, Device, DeviceType, Instance};
-use std::sync::Arc;
+use goldy::{Surface, Device, DeviceType, Instance, PresentMode, SurfaceConfig};
 
 let instance = Instance::new()?;
-let device = Arc::new(instance.create_device(DeviceType::DiscreteGpu)?);
+let device = instance.create_device(DeviceType::DiscreteGpu)?;
 
-// Create surface for a winit window
+// Simple — defaults to Auto present mode, no depth buffer
 let surface = Surface::new(&device, &window)?;
+
+// With vsync control and depth buffer
+let surface = Surface::new_with_config(&device, &window, SurfaceConfig {
+    present_mode: PresentMode::Fifo,  // vsync on
+    depth_format: Some(DepthFormat::Depth32Float),
+})?;
 ```
 
-### Render Loop
+### Render Loop (Graphics Pipeline)
+
+The traditional path using render commands:
 
 ```rust
 loop {
-    // Acquire next swapchain image
     let frame = surface.acquire()?;
     
-    // Record commands
     let mut encoder = CommandEncoder::new();
     {
         let mut pass = encoder.begin_render_pass();
@@ -36,13 +41,55 @@ loop {
         pass.draw(0..3, 0..1);
     }
     
-    // Render directly to swapchain (zero-copy!)
     frame.render(encoder)?;
-    
-    // Present to screen
-    surface.present(frame)?;
+    frame.present()?;  // Consumes the frame
 }
 ```
+
+### Render Loop (Compute Path)
+
+The compute path exposes the frame's texture for direct compute shader access. This is the path used by Ekrano:
+
+```rust
+loop {
+    let frame = surface.acquire()?;
+    let texture = frame.texture().expect("frame texture");
+    
+    let tex_idx = texture.bindless_index().unwrap();
+    let mut encoder = ComputeEncoder::new();
+    {
+        let mut pass = encoder.begin_compute_pass();
+        pass.set_pipeline(&compute_pipeline);
+        pass.set_push_constants_raw(&[uniform_idx, tex_idx]);
+        pass.dispatch(width / 8, height / 8, 1);
+    }
+    encoder.submit(&device)?.wait()?;
+    
+    frame.present()?;
+}
+```
+
+### Present Modes
+
+Control vsync behavior at creation time or dynamically:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `Fifo` | Vsync: wait for display refresh | Smooth display, capped at monitor Hz |
+| `Mailbox` | Triple-buffered: latest frame queued | Low latency + no tearing |
+| `Immediate` | No sync, may tear | Benchmarks, maximum throughput |
+| `Auto` | Goldy chooses (Mailbox → Fifo) | Default, good for most apps |
+
+```rust
+// Toggle vsync at runtime
+surface.set_present_mode(PresentMode::Immediate)?;
+println!("Current mode: {:?}", surface.present_mode());
+```
+
+**Backend mapping:**
+- **Metal:** `CAMetalLayer.displaySyncEnabled` (on/off only — no mailbox)
+- **Vulkan:** `VK_PRESENT_MODE_{FIFO,MAILBOX,IMMEDIATE}_KHR`
+- **DX12:** `IDXGISwapChain::Present` sync interval
 
 ### Resize Handling
 
@@ -52,6 +99,23 @@ fn handle_resize(&mut self, new_size: PhysicalSize<u32>) {
         self.surface.resize(new_size.width, new_size.height)?;
     }
 }
+```
+
+### Frame Lifetime
+
+`SurfaceFrame` follows Rust ownership semantics:
+
+- `acquire()` returns a `SurfaceFrame` that borrows the swapchain image
+- `texture()` returns a reference valid until `present()` is called
+- `present()` consumes `self` — the borrow checker prevents use-after-present
+- Dropping a frame without presenting cleans up the drawable (but wastes a frame)
+
+```rust
+let frame = surface.acquire()?;
+let tex = frame.texture().unwrap();
+// tex is valid here...
+frame.present()?;
+// tex is now invalid — Rust prevents accessing it after move
 ```
 
 ## RenderTarget (Headless/Streaming)
@@ -112,12 +176,13 @@ img.save("output.png")?;
 
 ## Surface vs RenderTarget
 
-| Use Case | API | CPU Copy |
-|----------|-----|----------|
-| Window display | `Surface` | No (zero-copy) |
-| Headless testing | `RenderTarget` | Yes (via `read_to_cpu()`) |
-| Video streaming | `RenderTarget` | When needed |
-| Image generation | `RenderTarget` | Yes |
+| Use Case | API | CPU Copy | Vsync |
+|----------|-----|----------|-------|
+| Window display | `Surface` | No (zero-copy) | Configurable |
+| Compute → display | `Surface` + `frame.texture()` | No | Configurable |
+| Headless testing | `RenderTarget` | Yes (via `read_to_cpu()`) | N/A |
+| Video streaming | `RenderTarget` | When needed | N/A |
+| Image generation | `RenderTarget` | Yes | N/A |
 
 ## Pixel Formats
 
@@ -134,7 +199,8 @@ TextureFormat::Rgba32Float     // Full precision (32-bit float)
 
 - No CPU memory allocation per frame
 - Renders directly to swapchain images
-- Optimal for real-time display
+- Frame pacing via `PresentMode` prevents GPU from running ahead
+- `frame.texture()` enables compute → display without a blit
 
 ### RenderTarget
 
@@ -158,14 +224,16 @@ Subsequent read_to_cpu():
 
 Both `frame.render()` and `target.render()` are synchronous—they wait for GPU completion. Surface uses proper frame pipelining with semaphores internally.
 
+When using `frame.texture()` with compute shaders, ensure your compute work completes before calling `frame.present()`. The `ComputeEncoder::submit().wait()` pattern handles this.
+
 ## Error Handling
 
 ```rust
 // Surface errors
 let frame = surface.acquire()?;  // May fail if swapchain outdated
-surface.present(frame)?;         // May need resize
+frame.present()?;                // May need resize
 
 // RenderTarget errors
-target.render(encoder)?;         // GPU command failure
-let pixels = target.read_to_cpu()?;  // Memory transfer failure
+target.render(encoder)?;              // GPU command failure
+let pixels = target.read_to_cpu()?;   // Memory transfer failure
 ```

--- a/examples/bouncing_lines.rs
+++ b/examples/bouncing_lines.rs
@@ -178,7 +178,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.window.request_redraw();
         Ok(())

--- a/examples/checkerboard.rs
+++ b/examples/checkerboard.rs
@@ -121,7 +121,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
         Ok(())
     }
 

--- a/examples/compute_particles.rs
+++ b/examples/compute_particles.rs
@@ -174,7 +174,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         // Request redraw for continuous animation
         self.window.request_redraw();

--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -39,22 +39,16 @@ struct Uniforms {
     float _padding;
 };
 
-[[vk::push_constant]]
-struct PushConstants {
-    uint uniforms_idx;
-    uint output_idx;
-};
-
 [shader("compute")]
 [numthreads(8, 8, 1)]
 void cs_main(uint3 tid : SV_DispatchThreadID) {
-    StructuredBuffer<Uniforms> ub = goldy_dyn_buf_ro(gGoldy, gGoldyDynamic.indices[0]);
+    ReadOnlyBuffer<Uniforms> ub = goldy_dyn_buf_ro<Uniforms>(0);
     Uniforms u = ub[0];
 
     if (tid.x >= u.width || tid.y >= u.height)
         return;
 
-    RWTexture2D<float4> output = goldy_dyn_storage_image(gGoldy, gGoldyDynamic.indices[1]);
+    RWTexture2D<float4> output = goldy_dyn_direct_spatial<float4>(1);
 
     float2 uv = float2(tid.xy) / float2(u.width, u.height);
 
@@ -128,7 +122,7 @@ impl App {
                 time: 0.0,
                 _padding: 0.0,
             }),
-            DataAccess::Broadcast,
+            DataAccess::Scattered,
         )?;
 
         self.state = Some(RenderState {

--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -1,0 +1,260 @@
+//! Compute-to-Surface example — pure compute rendering without a graphics pipeline.
+//!
+//! This example demonstrates the new Surface API where a compute shader
+//! writes directly to the swapchain texture via `frame.texture()`.
+//! No `RenderPipeline`, no `CommandEncoder`, no vertex buffers.
+//!
+//! Run with: cargo run --example compute_to_surface
+
+use anyhow::Result;
+use goldy::{
+    Buffer, ComputeEncoder, ComputePipeline, DataAccess, DeviceType, Instance, PresentMode,
+    ShaderModule, Surface, SurfaceConfig,
+};
+use std::sync::Arc;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
+    window::{Window, WindowId},
+};
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniforms {
+    width: u32,
+    height: u32,
+    time: f32,
+    _padding: f32,
+}
+
+const COMPUTE_SHADER: &str = r#"
+import goldy_exp;
+
+struct Uniforms {
+    uint width;
+    uint height;
+    float time;
+    float _padding;
+};
+
+[[vk::push_constant]]
+struct PushConstants {
+    uint uniforms_idx;
+    uint output_idx;
+};
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void cs_main(uint3 tid : SV_DispatchThreadID) {
+    StructuredBuffer<Uniforms> ub = goldy_dyn_buf_ro(gGoldy, gGoldyDynamic.indices[0]);
+    Uniforms u = ub[0];
+
+    if (tid.x >= u.width || tid.y >= u.height)
+        return;
+
+    RWTexture2D<float4> output = goldy_dyn_storage_image(gGoldy, gGoldyDynamic.indices[1]);
+
+    float2 uv = float2(tid.xy) / float2(u.width, u.height);
+
+    // Animated plasma effect
+    float t = u.time;
+    float v = 0.0;
+    v += sin(uv.x * 10.0 + t);
+    v += sin(uv.y * 10.0 + t * 0.5);
+    v += sin((uv.x + uv.y) * 10.0 + t * 0.7);
+    v += sin(sqrt(uv.x * uv.x + uv.y * uv.y) * 20.0 + t * 1.3);
+    v = v * 0.25 + 0.5;
+
+    float3 color = rainbow(v + t * 0.1);
+    output[tid.xy] = float4(color, 1.0);
+}
+"#;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    println!("Goldy — Compute to Surface Example");
+    println!("===================================");
+    println!("Press V to toggle vsync, Escape to exit\n");
+
+    let event_loop = EventLoop::new()?;
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let mut app = App::default();
+    event_loop.run_app(&mut app)?;
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct App {
+    state: Option<RenderState>,
+}
+
+struct RenderState {
+    window: Arc<Window>,
+    device: Arc<goldy::Device>,
+    surface: Surface,
+    compute_pipeline: ComputePipeline,
+    uniform_buffer: Buffer,
+    start_time: std::time::Instant,
+    vsync: bool,
+}
+
+impl App {
+    fn init(&mut self, window: Arc<Window>) -> Result<()> {
+        let instance = Instance::new()?;
+        let device = Arc::new(instance.create_device(DeviceType::DiscreteGpu)?);
+
+        let surface = Surface::new_with_config(
+            &device,
+            window.as_ref(),
+            SurfaceConfig {
+                present_mode: PresentMode::Fifo,
+                depth_format: None,
+            },
+        )?;
+
+        let shader = ShaderModule::from_slang(&device, COMPUTE_SHADER)?;
+        let compute_pipeline = ComputePipeline::new(&device, &shader)?;
+
+        let uniform_buffer = Buffer::with_data(
+            &device,
+            bytemuck::bytes_of(&Uniforms {
+                width: surface.width(),
+                height: surface.height(),
+                time: 0.0,
+                _padding: 0.0,
+            }),
+            DataAccess::Broadcast,
+        )?;
+
+        self.state = Some(RenderState {
+            window,
+            device,
+            surface,
+            compute_pipeline,
+            uniform_buffer,
+            start_time: std::time::Instant::now(),
+            vsync: true,
+        });
+
+        Ok(())
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.state.is_some() {
+            return;
+        }
+        let attrs = Window::default_attributes()
+            .with_title("Goldy — Compute to Surface")
+            .with_inner_size(winit::dpi::LogicalSize::new(800, 600));
+
+        let window = Arc::new(event_loop.create_window(attrs).unwrap());
+
+        if let Err(e) = self.init(window.clone()) {
+            tracing::error!("Failed to initialize: {}", e);
+            event_loop.exit();
+            return;
+        }
+
+        window.request_redraw();
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        let Some(state) = &mut self.state else {
+            return;
+        };
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::KeyboardInput { event, .. } if event.state.is_pressed() => {
+                match event.logical_key.as_ref() {
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
+                    Key::Character("v") => {
+                        state.vsync = !state.vsync;
+                        let mode = if state.vsync {
+                            PresentMode::Fifo
+                        } else {
+                            PresentMode::Immediate
+                        };
+                        if let Err(e) = state.surface.set_present_mode(mode) {
+                            eprintln!("Failed to set present mode: {e}");
+                        } else {
+                            println!(
+                                "Vsync: {} (present mode: {:?})",
+                                if state.vsync { "ON" } else { "OFF" },
+                                mode
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            WindowEvent::Resized(new_size) => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    let _ = state.surface.resize(new_size.width, new_size.height);
+                    state.window.request_redraw();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Err(e) = render_frame(state) {
+                    tracing::error!("Render error: {}", e);
+                }
+                state.window.request_redraw();
+            }
+            _ => {}
+        }
+    }
+}
+
+fn render_frame(state: &mut RenderState) -> Result<()> {
+    let (width, height) = state.surface.size();
+    if width == 0 || height == 0 {
+        return Ok(());
+    }
+
+    let elapsed = state.start_time.elapsed().as_secs_f32();
+
+    // Update uniforms
+    state.uniform_buffer.write(
+        0,
+        bytemuck::bytes_of(&Uniforms {
+            width,
+            height,
+            time: elapsed,
+            _padding: 0.0,
+        }),
+    )?;
+
+    // Acquire the surface frame and get its texture
+    let frame = state.surface.acquire()?;
+    let texture = frame
+        .texture()
+        .expect("Backend does not support surface frame textures");
+
+    // Dispatch the compute shader to write directly to the surface texture
+    let wg_x = width.div_ceil(8);
+    let wg_y = height.div_ceil(8);
+
+    let uniform_idx = state.uniform_buffer.bindless_index().unwrap();
+    let texture_idx = texture.bindless_index().unwrap();
+
+    let mut encoder = ComputeEncoder::new();
+    {
+        let mut pass = encoder.begin_compute_pass();
+        pass.set_pipeline(&state.compute_pipeline);
+        pass.set_push_constants_raw(&[uniform_idx, texture_idx]);
+        pass.dispatch(wg_x, wg_y, 1);
+    }
+    encoder.submit(&state.device)?.wait()?;
+
+    // Present — the compute shader already wrote the pixels
+    frame.present()?;
+
+    Ok(())
+}

--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -235,14 +235,14 @@ fn render_frame(state: &mut RenderState) -> Result<()> {
     let wg_x = width.div_ceil(8);
     let wg_y = height.div_ceil(8);
 
-    let uniform_idx = state.uniform_buffer.bindless_index().unwrap();
-    let texture_idx = texture.bindless_index().unwrap();
+    let uniform_handle = state.uniform_buffer.bindless_handle().unwrap();
+    let texture_handle = texture.bindless_handle().unwrap();
 
     let mut encoder = ComputeEncoder::new();
     {
         let mut pass = encoder.begin_compute_pass();
         pass.set_pipeline(&state.compute_pipeline);
-        pass.set_push_constants_raw(&[uniform_idx, texture_idx]);
+        pass.set_push_constants_typed(&[uniform_handle, texture_handle]);
         pass.dispatch(wg_x, wg_y, 1);
     }
     encoder.submit(&state.device)?.wait()?;

--- a/examples/depth_quads.rs
+++ b/examples/depth_quads.rs
@@ -196,7 +196,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         self.frame_count += 1;
         Ok(())

--- a/examples/digital_clock.rs
+++ b/examples/digital_clock.rs
@@ -131,7 +131,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -218,20 +218,20 @@ impl RenderState {
 
                 // Pass buffer indices via push constants.
                 // Order matters: [current_state, next_state] matching shader slots.
-                let (idx_read, idx_write) = if self.use_buffer_a {
+                let (read_handle, write_handle) = if self.use_buffer_a {
                     // A -> B: read from A, write to B
                     (
-                        self.view_a.bindless_index().unwrap(),
-                        self.view_b.bindless_index().unwrap(),
+                        self.view_a.bindless_handle().unwrap(),
+                        self.view_b.bindless_handle().unwrap(),
                     )
                 } else {
                     // B -> A: read from B, write to A
                     (
-                        self.view_b.bindless_index().unwrap(),
-                        self.view_a.bindless_index().unwrap(),
+                        self.view_b.bindless_handle().unwrap(),
+                        self.view_a.bindless_handle().unwrap(),
                     )
                 };
-                pass.set_push_constants_raw(&[idx_read, idx_write]);
+                pass.set_push_constants_typed(&[read_handle, write_handle]);
 
                 // Dispatch workgroups (8x8 threads per group)
                 let workgroups_x = GRID_WIDTH.div_ceil(8);
@@ -255,12 +255,12 @@ impl RenderState {
             pass.set_pipeline(&self.render_pipeline);
 
             // Read from the view that is now "current" (after the ping-pong swap).
-            let idx_current = if self.use_buffer_a {
-                self.view_a.bindless_index().unwrap()
+            let current_handle = if self.use_buffer_a {
+                self.view_a.bindless_handle().unwrap()
             } else {
-                self.view_b.bindless_index().unwrap()
+                self.view_b.bindless_handle().unwrap()
             };
-            pass.set_push_constants_raw(&[idx_current]);
+            pass.set_push_constants_typed(&[current_handle]);
 
             // Draw fullscreen triangle
             pass.draw(0..3, 0..1);

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -267,7 +267,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.window.request_redraw();
 

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -122,7 +122,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -200,7 +200,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.window.request_redraw();
         Ok(())

--- a/examples/mandelbrot.rs
+++ b/examples/mandelbrot.rs
@@ -122,7 +122,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/metaballs.rs
+++ b/examples/metaballs.rs
@@ -116,7 +116,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -372,7 +372,7 @@ impl WindowState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.vertex_buffers.push(vertex_buffer);
         Ok(())

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -253,7 +253,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.window.request_redraw();
         Ok(())

--- a/examples/plasma.rs
+++ b/examples/plasma.rs
@@ -116,7 +116,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/solid_cube.rs
+++ b/examples/solid_cube.rs
@@ -286,7 +286,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
         self.vertex_buffers.push(vertex_buffer);
         Ok(())
     }

--- a/examples/spinning_cube.rs
+++ b/examples/spinning_cube.rs
@@ -173,7 +173,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
         self.vertex_buffers.push(vertex_buffer);
         Ok(())
     }

--- a/examples/starfield.rs
+++ b/examples/starfield.rs
@@ -214,7 +214,7 @@ impl RenderState {
         }
 
         frame.render(encoder)?;
-        self.surface.present(frame)?;
+        frame.present()?;
 
         self.window.request_redraw();
         Ok(())

--- a/examples/textured_quad.rs
+++ b/examples/textured_quad.rs
@@ -225,9 +225,8 @@ impl App {
         let texture = self.texture.as_ref().unwrap();
         let sampler = self.sampler.as_ref().unwrap();
 
-        // Get bindless indices
-        let tex_idx = texture.bindless_index().unwrap_or(0);
-        let samp_idx = sampler.bindless_index().unwrap_or(0);
+        let tex_handle = texture.bindless_handle().unwrap();
+        let samp_handle = sampler.bindless_handle().unwrap();
 
         let frame = surface.acquire()?;
 
@@ -242,7 +241,7 @@ impl App {
             });
             pass.set_pipeline(pipeline);
             // Pass texture and sampler indices via push constants
-            pass.set_push_constants_raw(&[tex_idx, samp_idx]);
+            pass.set_push_constants_typed(&[tex_handle, samp_handle]);
             pass.set_vertex_buffer(0, vertex_buffer);
             pass.draw(0..6, 0..1);
         }

--- a/examples/textured_quad.rs
+++ b/examples/textured_quad.rs
@@ -248,7 +248,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
         Ok(())
     }
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -118,7 +118,7 @@ impl App {
         frame.render(encoder)?;
 
         // Present to screen
-        surface.present(frame)?;
+        frame.present()?;
 
         self.frame_count += 1;
         Ok(())

--- a/examples/tunnel.rs
+++ b/examples/tunnel.rs
@@ -116,7 +116,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         Ok(())
     }

--- a/examples/waveform.rs
+++ b/examples/waveform.rs
@@ -191,7 +191,7 @@ impl App {
         }
 
         frame.render(encoder)?;
-        surface.present(frame)?;
+        frame.present()?;
 
         // Keep this frame's buffers alive
         self.frame_buffers.push(channel_buffers);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -118,7 +118,7 @@ impl App {
         frame.render(encoder)?;
 
         // Present to screen
-        surface.present(frame)?;
+        frame.present()?;
 
         self.frame_count += 1;
         Ok(())

--- a/shaders/goldy_exp/access.slang
+++ b/shaders/goldy_exp/access.slang
@@ -157,8 +157,10 @@ GoldyDynamicSlots __goldy_get_dynamic() {
 #define GOLDY_DECLARE_DYNAMIC static const bool __goldy_dynamic_decl = true
 
 #elif defined(__METAL__)
-// Metal: Push constants for runtime slot indices
-[[vk::push_constant]] ConstantBuffer<GoldyDynamicSlots> gGoldyDynamic;
+// Metal: dynamic slot indices from `set_bytes` on buffer index 1 (see Rust PUSH_CONSTANTS_SLOT).
+// Do not use [[vk::push_constant]] here — it is invalid on the Metal target.
+[[buffer(1)]]
+ConstantBuffer<GoldyDynamicSlots> gGoldyDynamic;
 // Macro is no-op - gGoldyDynamic is already declared
 #define GOLDY_DECLARE_DYNAMIC static const bool __goldy_dynamic_decl = true
 #endif

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -19,6 +19,14 @@ pub(super) fn create(
     let cs_bytecode =
         shader::ensure_stage_compiled(state, compute_shader, crate::slang::SlangStage::Compute)?;
 
+    let push_constant_categories = state
+        .shaders
+        .get(&compute_shader)
+        .and_then(|s| s.reflection.as_ref())
+        .map(|r| r.push_constant_categories.clone())
+        .unwrap_or_default();
+    let shader_debug_name = format!("compute_shader#{compute_shader}");
+
     let logical_device = state
         .devices
         .get(&device_handle)
@@ -59,6 +67,8 @@ pub(super) fn create(
             pipeline_state,
             root_signature,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 
@@ -144,8 +154,7 @@ pub(super) fn submit(
         ]);
     }
 
-    // Track current pipeline (reserved for future use)
-    let mut _current_pipeline_handle: Option<ComputePipelineHandle> = None;
+    let mut current_pipeline_handle: Option<ComputePipelineHandle> = None;
 
     // Process commands
     for command in commands {
@@ -156,7 +165,7 @@ pub(super) fn submit(
                         command_list.SetComputeRootSignature(&pipeline_state.root_signature);
                         command_list.SetPipelineState(&pipeline_state.pipeline_state);
                     }
-                    _current_pipeline_handle = Some(*handle);
+                    current_pipeline_handle = Some(*handle);
                 }
             }
             ComputeCommand::SetPushConstants { buffers } => {
@@ -205,6 +214,34 @@ pub(super) fn submit(
                         break;
                     }
                     indices.indices[i] = idx;
+                }
+                unsafe {
+                    command_list.SetComputeRoot32BitConstants(
+                        0,
+                        types::MAX_ROOT_CONSTANT_INDICES as u32,
+                        indices.indices.as_ptr() as *const std::ffi::c_void,
+                        0,
+                    );
+                }
+            }
+            ComputeCommand::SetPushConstantsTyped {
+                handles: typed_handles,
+            } => {
+                if let Some(pipeline) =
+                    current_pipeline_handle.and_then(|h| state.compute_pipelines.get(&h))
+                {
+                    crate::backend::validate_typed_push_constants(
+                        typed_handles,
+                        &pipeline.push_constant_categories,
+                        &pipeline.shader_debug_name,
+                    )?;
+                }
+                let mut indices = types::BindlessIndices::default();
+                for (i, handle) in typed_handles.iter().enumerate() {
+                    if i >= types::MAX_ROOT_CONSTANT_INDICES {
+                        break;
+                    }
+                    indices.indices[i] = handle.index();
                 }
                 unsafe {
                     command_list.SetComputeRoot32BitConstants(

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -537,6 +537,10 @@ impl GpuBackend for Dx12Backend {
         surface::acquire(&mut self.state, surface_handle)
     }
 
+    fn surface_frame_texture(&self, surface: SurfaceHandle) -> Option<TextureHandle> {
+        surface::frame_texture(&self.state, surface)
+    }
+
     fn surface_render(
         &mut self,
         surface_handle: SurfaceHandle,

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -6,6 +6,35 @@ use crate::types::{DepthStencilState, PrimitiveTopology, TextureFormat, VertexBu
 use anyhow::{Context, Result};
 use windows::Win32::Graphics::{Direct3D12::*, Dxgi::Common::*};
 
+/// Collect per-push-constant-slot categories from shader reflection on the
+/// vertex+fragment pair. Fragment takes precedence.
+fn push_constant_expectations(
+    state: &Dx12State,
+    vertex_shader: ShaderHandle,
+    fragment_shader: ShaderHandle,
+) -> (Vec<Option<crate::types::BindlessCategory>>, String) {
+    let fs_cats = state
+        .shaders
+        .get(&fragment_shader)
+        .and_then(|s| s.reflection.as_ref())
+        .map(|r| r.push_constant_categories.clone())
+        .unwrap_or_default();
+    let cats = if !fs_cats.is_empty() {
+        fs_cats
+    } else {
+        state
+            .shaders
+            .get(&vertex_shader)
+            .and_then(|s| s.reflection.as_ref())
+            .map(|r| r.push_constant_categories.clone())
+            .unwrap_or_default()
+    };
+    (
+        cats,
+        format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})"),
+    )
+}
+
 /// Create a graphics pipeline state object.
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(super) fn create(
@@ -22,6 +51,9 @@ pub(super) fn create(
         shader::ensure_stage_compiled(state, vertex_shader, crate::slang::SlangStage::Vertex)?;
     let fs_bytecode =
         shader::ensure_stage_compiled(state, fragment_shader, crate::slang::SlangStage::Fragment)?;
+
+    let (push_constant_categories, shader_debug_name) =
+        push_constant_expectations(state, vertex_shader, fragment_shader);
 
     let logical_device = state
         .devices
@@ -171,6 +203,8 @@ pub(super) fn create(
             vertex_stride: vertex_layout.stride,
             topology,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 
@@ -194,6 +228,9 @@ pub(super) fn create_with_depth(
         shader::ensure_stage_compiled(state, vertex_shader, crate::slang::SlangStage::Vertex)?;
     let fs_bytecode =
         shader::ensure_stage_compiled(state, fragment_shader, crate::slang::SlangStage::Fragment)?;
+
+    let (push_constant_categories, shader_debug_name) =
+        push_constant_expectations(state, vertex_shader, fragment_shader);
 
     let logical_device = state
         .devices
@@ -355,6 +392,8 @@ pub(super) fn create_with_depth(
             vertex_stride: vertex_layout.stride,
             topology,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 

--- a/src/backend/dx12/render_commands.rs
+++ b/src/backend/dx12/render_commands.rs
@@ -15,10 +15,11 @@ pub(super) fn record(
     commands: &[RenderCommand],
     _device_handle: DeviceHandle,
     state: &Dx12State,
-) {
+) -> anyhow::Result<()> {
     // COM: same pointer as ID3D12GraphicsCommandList for method calls.
     let cmd: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(cmd) };
     let mut current_vertex_stride = 24u32; // Default stride
+    let mut current_pipeline: Option<&types::PipelineState> = None;
     for command in commands {
         match command {
             RenderCommand::Clear(_) => {
@@ -35,6 +36,7 @@ pub(super) fn record(
                         cmd.SetPipelineState(&pipeline.pipeline_state);
                         cmd.IASetPrimitiveTopology(topology_to_d3d12(pipeline.topology));
                     }
+                    current_pipeline = Some(pipeline);
                 }
             }
             RenderCommand::SetVertexBuffer {
@@ -109,6 +111,32 @@ pub(super) fn record(
                     );
                 }
             }
+            RenderCommand::SetPushConstantsTyped {
+                handles: typed_handles,
+            } => {
+                if let Some(pipeline) = current_pipeline {
+                    crate::backend::validate_typed_push_constants(
+                        typed_handles,
+                        &pipeline.push_constant_categories,
+                        &pipeline.shader_debug_name,
+                    )?;
+                }
+                let mut indices = types::BindlessIndices::default();
+                for (i, handle) in typed_handles.iter().enumerate() {
+                    if i >= types::MAX_ROOT_CONSTANT_INDICES {
+                        break;
+                    }
+                    indices.indices[i] = handle.index();
+                }
+                unsafe {
+                    cmd.SetGraphicsRoot32BitConstants(
+                        0,
+                        types::MAX_ROOT_CONSTANT_INDICES as u32,
+                        indices.indices.as_ptr() as *const _,
+                        0,
+                    );
+                }
+            }
             RenderCommand::Draw {
                 vertex_count,
                 instance_count,
@@ -141,4 +169,5 @@ pub(super) fn record(
             },
         }
     }
+    Ok(())
 }

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -361,7 +361,7 @@ pub(super) fn render(
     }
 
     // Execute render commands
-    render_commands::record(cmd, commands, device_handle, state);
+    render_commands::record(cmd, commands, device_handle, state)?;
 
     // RENDER_TARGET -> COPY_SOURCE for potential readback
     let to_copy = barriers::texture_barrier_full(

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -470,7 +470,7 @@ pub(super) fn render(
     }
 
     // Execute render commands
-    render_commands::record(cmd, commands, device_handle, state);
+    render_commands::record(cmd, commands, device_handle, state)?;
 
     // RENDER_TARGET -> PRESENT (enhanced barrier, per MS DirectX-Graphics-Samples).
     // SYNC_NONE + NO_ACCESS: no subsequent work on this resource in this command list.

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -4,9 +4,9 @@
 
 use super::barriers;
 use super::render_commands;
-use super::types::{FrameSync, LogicalDevice, SurfaceState, MAX_FRAMES_IN_FLIGHT};
-use super::utils::{depth_format_to_dxgi, dxgi_to_format};
-use super::{DeviceHandle, Dx12State, SurfaceHandle, SwapchainImageHandle};
+use super::types::{FrameSync, LogicalDevice, SurfaceState, TextureState, MAX_FRAMES_IN_FLIGHT};
+use super::utils::{depth_format_to_dxgi, dxgi_to_format, format_to_dxgi};
+use super::{DeviceHandle, Dx12State, SurfaceHandle, SwapchainImageHandle, TextureHandle};
 use crate::backend::RenderCommand;
 use crate::types::{Color, DepthFormat, TextureFormat};
 use anyhow::{Context, Result};
@@ -56,6 +56,10 @@ pub(super) fn create(
     let height = (rect.bottom - rect.top) as u32;
 
     // Create swapchain
+    // ALLOW_UNORDERED_ACCESS lets compute shaders write directly to back buffers
+    // via UAV descriptors (the compute-to-surface path).
+    // Not all adapters support this — if creation fails, consider removing this flag
+    // and falling back to a separate render target + copy.
     let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
         Width: width,
         Height: height,
@@ -65,7 +69,7 @@ pub(super) fn create(
             Count: 1,
             Quality: 0,
         },
-        BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_UNORDERED_ACCESS,
         BufferCount: MAX_FRAMES_IN_FLIGHT as u32,
         Scaling: DXGI_SCALING_STRETCH,
         SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
@@ -234,6 +238,7 @@ pub(super) fn create(
             current_frame: 0,
             current_image_index: None,
             frame_sync,
+            current_texture_handle: None,
         },
     );
 
@@ -243,19 +248,41 @@ pub(super) fn create(
 
 /// Destroy a surface.
 pub(super) fn destroy(state: &mut Dx12State, surface_handle: SurfaceHandle) {
+    // Clean up any outstanding surface texture
+    if let Some(tex_handle) = state
+        .surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
+    {
+        unregister_surface_texture(state, tex_handle);
+    }
+
     if let Some(surface_state) = state.surfaces.remove(&surface_handle) {
         if let Some(logical_device) = state.devices.get(&surface_state.device_handle) {
-            // Wait for GPU
             let _ = wait_for_gpu(logical_device);
         }
     }
 }
 
 /// Acquire the next swapchain image.
+///
+/// After acquiring, the back buffer is registered in the bindless descriptor
+/// heap as a UAV. The resulting `TextureHandle` is available via
+/// `frame_texture()` until `present()` is called.
 pub(super) fn acquire(
     state: &mut Dx12State,
     surface_handle: SurfaceHandle,
 ) -> Result<SwapchainImageHandle> {
+    // Clean up any previously acquired surface texture that wasn't presented
+    if let Some(tex_handle) = state
+        .surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
+    {
+        tracing::warn!("Previous surface texture was not presented; cleaning up");
+        unregister_surface_texture(state, tex_handle);
+    }
+
     let surface = state
         .surfaces
         .get_mut(&surface_handle)
@@ -264,7 +291,38 @@ pub(super) fn acquire(
     let image_index = unsafe { surface.swapchain.GetCurrentBackBufferIndex() };
     surface.current_image_index = Some(image_index);
 
+    let device_handle = surface.device_handle;
+    let resource = surface.render_targets[image_index as usize].clone();
+    let width = surface.width;
+    let height = surface.height;
+    let dxgi_format = surface.format;
+    let goldy_format = dxgi_to_format(dxgi_format).unwrap_or(TextureFormat::Bgra8Unorm);
+
+    let tex_handle = register_surface_texture(
+        state,
+        device_handle,
+        resource,
+        dxgi_format,
+        goldy_format,
+        width,
+        height,
+    )?;
+
+    let surface = state.surfaces.get_mut(&surface_handle).unwrap();
+    surface.current_texture_handle = Some(tex_handle);
+
     Ok(image_index as SwapchainImageHandle)
+}
+
+/// Get the texture handle for the currently acquired surface frame.
+pub(super) fn frame_texture(
+    state: &Dx12State,
+    surface_handle: SurfaceHandle,
+) -> Option<super::TextureHandle> {
+    state
+        .surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
 }
 
 /// Render commands to a surface.
@@ -456,11 +514,27 @@ pub(super) fn render(
 }
 
 /// Present a rendered surface.
+///
+/// Unregisters the transient surface texture from the bindless descriptor heap,
+/// then presents the swapchain image.
 pub(super) fn present(
     state: &mut Dx12State,
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
 ) -> Result<()> {
+    // Unregister the transient surface texture before presenting
+    if let Some(tex_handle) = state
+        .surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
+    {
+        unregister_surface_texture(state, tex_handle);
+    }
+
+    if let Some(surface) = state.surfaces.get_mut(&surface_handle) {
+        surface.current_texture_handle = None;
+    }
+
     let surface = state
         .surfaces
         .get(&surface_handle)
@@ -661,6 +735,7 @@ pub(super) fn resize(
     let surface = state.surfaces.get_mut(&surface_handle).unwrap();
     surface.current_frame = 0;
     surface.current_image_index = None;
+    surface.current_texture_handle = None;
 
     tracing::debug!("Resized surface to {}x{}", width, height);
     Ok(())
@@ -701,4 +776,139 @@ fn wait_for_gpu(device: &LogicalDevice) -> Result<()> {
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence")?;
     wait_for_fence(&device.fence, fence_value)
+}
+
+// ---------------------------------------------------------------------------
+// Transient surface texture registration
+// ---------------------------------------------------------------------------
+// These functions register/unregister back-buffer resources in the global
+// bindless descriptor heap so that compute shaders can write to them via
+// RWTexture2D. The ID3D12Resource is COM-cloned (refcount bump) on acquire
+// and released (refcount decrement) on present — the swapchain retains its
+// own reference throughout.
+
+/// Register a back-buffer resource as a transient storage texture.
+///
+/// Creates a UAV descriptor in the CBV/SRV/UAV heap and inserts a `TextureState`.
+/// Returns a `TextureHandle` that the caller stores in
+/// `SurfaceState::current_texture_handle`.
+#[allow(clippy::too_many_arguments)]
+fn register_surface_texture(
+    state: &mut Dx12State,
+    device_handle: DeviceHandle,
+    resource: ID3D12Resource,
+    dxgi_format: DXGI_FORMAT,
+    goldy_format: TextureFormat,
+    width: u32,
+    height: u32,
+) -> Result<TextureHandle> {
+    let handle = state.next_texture_handle;
+    state.next_texture_handle += 1;
+
+    let logical_device = state
+        .devices
+        .get_mut(&device_handle)
+        .context("Device no longer valid")?;
+
+    // Register a UAV descriptor so compute shaders can write to this texture.
+    // SRV is also registered so the texture can be read back if needed.
+    let srv_offset = logical_device.resource_registry.register_texture(handle);
+    let uav_offset = logical_device
+        .resource_registry
+        .register_texture_uav(handle);
+
+    // Create SRV descriptor
+    let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
+        Format: dxgi_format,
+        ViewDimension: D3D12_SRV_DIMENSION_TEXTURE2D,
+        Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+        Anonymous: D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
+            Texture2D: D3D12_TEX2D_SRV {
+                MostDetailedMip: 0,
+                MipLevels: 1,
+                PlaneSlice: 0,
+                ResourceMinLODClamp: 0.0,
+            },
+        },
+    };
+
+    let srv_cpu_handle = unsafe {
+        let mut h = logical_device
+            .cbv_srv_uav_heap
+            .GetCPUDescriptorHandleForHeapStart();
+        h.ptr += (srv_offset * logical_device.cbv_srv_uav_descriptor_size) as usize;
+        h
+    };
+    unsafe {
+        logical_device
+            .device
+            .CreateShaderResourceView(&resource, Some(&srv_desc), srv_cpu_handle);
+    }
+
+    // Create UAV descriptor for compute write access
+    let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
+        Format: dxgi_format,
+        ViewDimension: D3D12_UAV_DIMENSION_TEXTURE2D,
+        Anonymous: D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
+            Texture2D: D3D12_TEX2D_UAV {
+                MipSlice: 0,
+                PlaneSlice: 0,
+            },
+        },
+    };
+
+    let uav_cpu_handle = unsafe {
+        let mut h = logical_device
+            .cbv_srv_uav_heap
+            .GetCPUDescriptorHandleForHeapStart();
+        h.ptr += (uav_offset * logical_device.cbv_srv_uav_descriptor_size) as usize;
+        h
+    };
+    unsafe {
+        logical_device.device.CreateUnorderedAccessView(
+            Some(&resource),
+            None,
+            Some(&uav_desc),
+            uav_cpu_handle,
+        );
+    }
+
+    state.textures.insert(
+        handle,
+        TextureState {
+            device_handle,
+            width,
+            height,
+            format: goldy_format,
+            resource,
+            srv_offset,
+            bindless_offset: Some(uav_offset),
+            last_layout: D3D12_BARRIER_LAYOUT_PRESENT,
+        },
+    );
+
+    tracing::debug!(
+        "Registered surface texture {} ({}x{}, srv={}, uav={})",
+        handle,
+        width,
+        height,
+        srv_offset,
+        uav_offset,
+    );
+
+    Ok(handle)
+}
+
+/// Unregister a transient surface texture.
+///
+/// Removes the `TextureState` and unregisters from the resource registry.
+/// The `ID3D12Resource` COM refcount decrements when the `TextureState` is dropped,
+/// but the swapchain retains its own reference, so the back buffer stays alive.
+fn unregister_surface_texture(state: &mut Dx12State, tex_handle: TextureHandle) {
+    if let Some(tex_state) = state.textures.remove(&tex_handle) {
+        if let Some(dev) = state.devices.get_mut(&tex_state.device_handle) {
+            dev.resource_registry.unregister_texture(tex_handle);
+        }
+        tracing::debug!("Unregistered surface texture {}", tex_handle);
+    }
 }

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -254,6 +254,11 @@ pub(crate) struct PipelineState {
     pub topology: crate::types::PrimitiveTopology,
     /// ParameterBlock layouts from shader reflection (for bindless rendering)
     pub parameter_block_layouts: Vec<crate::slang::ParameterBlockLayout>,
+    /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
+    /// calls in the bound shader(s). Empty disables validation.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    pub shader_debug_name: String,
 }
 
 /// Compute pipeline state.
@@ -264,6 +269,11 @@ pub(crate) struct ComputePipelineState {
     pub root_signature: Direct3D12::ID3D12RootSignature,
     /// ParameterBlock layouts from shader reflection (for bindless rendering)
     pub parameter_block_layouts: Vec<crate::slang::ParameterBlockLayout>,
+    /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
+    /// calls in the bound compute shader. Empty disables validation.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    pub shader_debug_name: String,
 }
 
 /// GPU render target state with optional staging for CPU readback.

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -347,6 +347,10 @@ pub(crate) struct SurfaceState {
     pub current_image_index: Option<u32>,
     /// Per-frame synchronization resources
     pub frame_sync: Vec<FrameSync>,
+    /// Transient texture handle for the currently acquired back buffer,
+    /// registered in the bindless descriptor heap as a UAV so compute shaders
+    /// can write directly to the swapchain image.
+    pub current_texture_handle: Option<super::TextureHandle>,
 }
 
 /// Consolidated DX12 backend state.

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -48,6 +48,12 @@ pub(super) fn create(
         .new_compute_pipeline_state_with_function(&function)
         .map_err(|e| anyhow::anyhow!("Failed to create compute pipeline: {}", e))?;
 
+    let push_constant_categories = shader
+        .reflection
+        .as_ref()
+        .map(|r| r.push_constant_categories.clone())
+        .unwrap_or_default();
+
     let handle = state.next_compute_pipeline_handle;
     state.next_compute_pipeline_handle += 1;
 
@@ -57,6 +63,8 @@ pub(super) fn create(
             device_handle,
             pipeline,
             workgroup_size,
+            push_constant_categories,
+            shader_debug_name: "cs_main".to_string(),
         },
     );
 
@@ -194,6 +202,34 @@ fn record_commands_to_buffer(
                         break;
                     }
                     indices.indices[i] = idx;
+                }
+                let indices_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &indices as *const _ as *const u8,
+                        std::mem::size_of::<BindlessIndices>(),
+                    )
+                };
+                encoder.unwrap().set_bytes(
+                    PUSH_CONSTANTS_SLOT,
+                    indices_bytes.len() as u64,
+                    indices_bytes.as_ptr() as *const _,
+                );
+            }
+            ComputeCommand::SetPushConstantsTyped { handles } => {
+                ensure_compute!();
+                let pipeline = current_pipeline
+                    .context("SetPushConstantsTyped without a bound compute pipeline")?;
+                super::super::validate_typed_push_constants(
+                    handles,
+                    &pipeline.push_constant_categories,
+                    &pipeline.shader_debug_name,
+                )?;
+                let mut indices = BindlessIndices::default();
+                for (i, handle) in handles.iter().enumerate() {
+                    if i >= MAX_PUSH_CONSTANT_INDICES {
+                        break;
+                    }
+                    indices.indices[i] = handle.index();
                 }
                 let indices_bytes: &[u8] = unsafe {
                     std::slice::from_raw_parts(

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -96,6 +96,24 @@ fn begin_compute_encoder<'a>(
             );
         }
     }
+    // Declare textures resident for indirect access through the argument buffer.
+    //
+    // Heap-allocated textures are already covered by `use_heaps_for_compute`,
+    // but swapchain drawables (CAMetalLayer-owned `MTLTexture`s registered
+    // transiently in `state.textures`) are NOT in any Goldy-owned heap, so
+    // Metal Tier-2 bindless will read them as unresident unless we explicitly
+    // call `use_resource` on them before dispatch. Calling `use_resource` on
+    // already-heap-resident textures is safe and idempotent.
+    for tex_state in state.textures.values() {
+        if tex_state.device_handle == device_handle {
+            let usage = if tex_state.is_storage_image {
+                mtl::MTLResourceUsage::Read | mtl::MTLResourceUsage::Write
+            } else {
+                mtl::MTLResourceUsage::Read
+            };
+            encoder.use_resource(&tex_state.texture, usage);
+        }
+    }
     encoder.set_buffer(0, Some(&logical_device.argument_buffer), 0);
     encoder
 }

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -391,6 +391,10 @@ impl GpuBackend for MetalBackend {
         surface::acquire(&mut self.state, surface)
     }
 
+    fn surface_frame_texture(&self, surface: SurfaceHandle) -> Option<TextureHandle> {
+        surface::frame_texture(&self.state, surface)
+    }
+
     fn surface_render(
         &mut self,
         surface: SurfaceHandle,
@@ -418,6 +422,18 @@ impl GpuBackend for MetalBackend {
 
     fn surface_format(&self, surface: SurfaceHandle) -> TextureFormat {
         surface::format(&self.state, surface)
+    }
+
+    fn surface_set_present_mode(
+        &mut self,
+        surface: SurfaceHandle,
+        mode: crate::types::PresentMode,
+    ) -> Result<()> {
+        surface::set_present_mode(&mut self.state, surface, mode)
+    }
+
+    fn surface_present_mode(&self, surface: SurfaceHandle) -> crate::types::PresentMode {
+        surface::present_mode(&self.state, surface)
     }
 
     fn create_compute_pipeline(

--- a/src/backend/metal/pipeline.rs
+++ b/src/backend/metal/pipeline.rs
@@ -113,6 +113,22 @@ pub(super) fn create_with_depth(
         .new_render_pipeline_state(&descriptor)
         .map_err(|e| anyhow::anyhow!("Failed to create render pipeline: {}", e))?;
 
+    // Fragment shader is the primary source of push-constant access patterns
+    // (vertex shaders rarely use goldy_dyn_*); fall back to vertex if the
+    // fragment shader has no reflection.
+    let push_constant_categories = fs_shader
+        .reflection
+        .as_ref()
+        .map(|r| r.push_constant_categories.clone())
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            vs_shader
+                .reflection
+                .as_ref()
+                .map(|r| r.push_constant_categories.clone())
+        })
+        .unwrap_or_default();
+
     let handle = state.next_pipeline_handle;
     state.next_pipeline_handle += 1;
 
@@ -123,6 +139,8 @@ pub(super) fn create_with_depth(
             pipeline,
             depth_stencil: depth_stencil_state,
             primitive_type: topology_to_mtl(topology),
+            push_constant_categories,
+            shader_debug_name: "fs_main/vs_main".to_string(),
         },
     );
 

--- a/src/backend/metal/render_commands.rs
+++ b/src/backend/metal/render_commands.rs
@@ -9,6 +9,7 @@ use super::types::{
 use super::utils::index_format_to_mtl;
 use crate::types::IndexFormat;
 use ::metal as mtl;
+use anyhow::Result;
 use mtl::MTLPrimitiveType;
 use std::collections::HashMap;
 
@@ -18,9 +19,10 @@ pub(super) fn record(
     commands: &[RenderCommand],
     pipelines: &HashMap<PipelineHandle, PipelineState>,
     buffers: &HashMap<BufferHandle, super::types::BufferState>,
-) {
+) -> Result<()> {
     let mut current_index_buffer: Option<(BufferHandle, u64, IndexFormat)> = None;
     let mut current_primitive_type = MTLPrimitiveType::Triangle;
+    let mut current_pipeline: Option<&PipelineState> = None;
 
     for cmd in commands {
         match cmd {
@@ -32,6 +34,7 @@ pub(super) fn record(
                     if let Some(ds) = &pipeline.depth_stencil {
                         encoder.set_depth_stencil_state(ds);
                     }
+                    current_pipeline = Some(pipeline);
                 }
             }
             RenderCommand::SetVertexBuffer {
@@ -107,6 +110,43 @@ pub(super) fn record(
                     indices_bytes.as_ptr() as *const _,
                 );
             }
+            RenderCommand::SetPushConstantsTyped {
+                handles: typed_handles,
+            } => {
+                let (expectations, debug_name): (&[Option<crate::types::BindlessCategory>], &str) =
+                    match current_pipeline {
+                        Some(p) => (&p.push_constant_categories, p.shader_debug_name.as_str()),
+                        None => (&[], "<no pipeline bound>"),
+                    };
+                super::super::validate_typed_push_constants(
+                    typed_handles,
+                    expectations,
+                    debug_name,
+                )?;
+                let mut indices = BindlessIndices::default();
+                for (i, handle) in typed_handles.iter().enumerate() {
+                    if i >= MAX_PUSH_CONSTANT_INDICES {
+                        break;
+                    }
+                    indices.indices[i] = handle.index();
+                }
+                let indices_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &indices as *const _ as *const u8,
+                        std::mem::size_of::<BindlessIndices>(),
+                    )
+                };
+                encoder.set_vertex_bytes(
+                    PUSH_CONSTANTS_SLOT,
+                    indices_bytes.len() as u64,
+                    indices_bytes.as_ptr() as *const _,
+                );
+                encoder.set_fragment_bytes(
+                    PUSH_CONSTANTS_SLOT,
+                    indices_bytes.len() as u64,
+                    indices_bytes.as_ptr() as *const _,
+                );
+            }
             RenderCommand::Draw {
                 vertex_count,
                 instance_count,
@@ -150,6 +190,7 @@ pub(super) fn record(
             }
         }
     }
+    Ok(())
 }
 
 /// Create a render pass descriptor for the given texture.

--- a/src/backend/metal/render_target.rs
+++ b/src/backend/metal/render_target.rs
@@ -156,7 +156,7 @@ pub(super) fn render_to(
         height: render_target.height as u64,
     });
 
-    record(encoder, commands, &state.pipelines, &state.buffers);
+    record(encoder, commands, &state.pipelines, &state.buffers)?;
 
     encoder.end_encoding();
     command_buffer.commit();

--- a/src/backend/metal/shader.rs
+++ b/src/backend/metal/shader.rs
@@ -41,16 +41,17 @@ fn compile_stage_with_reflection(
 ) -> Result<(Library, Option<crate::slang::ShaderReflection>)> {
     let search_path_refs: Vec<&str> = search_paths.iter().map(|s| s.as_str()).collect();
 
-    let result = slang_compiler
-        .compile_bindless_with_reflection_and_defines(
-            slang_source,
-            ShaderTarget::Metal,
-            &[(entry_point, stage)],
-            &search_path_refs,
-            extra_defines,
-            layout_checks,
-            optimization_level,
-        )
+    let compile_outcome = slang_compiler.compile_bindless_with_reflection_and_defines(
+        slang_source,
+        ShaderTarget::Metal,
+        &[(entry_point, stage)],
+        &search_path_refs,
+        extra_defines,
+        layout_checks,
+        optimization_level,
+    );
+
+    let result = compile_outcome
         .with_context(|| format!("Failed to compile {} shader stage", entry_point))?;
 
     if !result.reflection.parameter_blocks.is_empty() {

--- a/src/backend/metal/surface.rs
+++ b/src/backend/metal/surface.rs
@@ -1,13 +1,24 @@
 //! Surface (window presentation) management logic.
+//!
+//! The acquire/render/present cycle is decoupled:
+//! - `acquire()` calls `nextDrawable` and registers the drawable's texture for bindless access
+//! - `frame_texture()` returns the registered texture handle
+//! - `render()` uses the already-acquired drawable (does NOT call `nextDrawable` again)
+//! - `present()` presents the drawable and unregisters the temporary texture
 
-use super::super::{DeviceHandle, RenderCommand, SurfaceHandle, SwapchainImageHandle};
+use super::super::{
+    DeviceHandle, RenderCommand, SurfaceHandle, SwapchainImageHandle, TextureHandle,
+};
 use super::render_commands::{create_render_pass, record};
-use super::types::{MetalState, SurfaceState, MAX_FRAMES_IN_FLIGHT};
+use super::types::{
+    MetalState, ResourceRegistry, SurfaceState, TextureState, ARGUMENT_BUFFER_SIZE,
+    MAX_FRAMES_IN_FLIGHT,
+};
 use super::utils::depth_format_to_mtl;
-use crate::types::{DepthFormat, TextureFormat};
+use crate::types::{DepthFormat, PresentMode, TextureFormat};
 use ::metal as mtl;
 use anyhow::{Context, Result};
-use cocoa::base::{id, nil, YES};
+use cocoa::base::{id, nil, NO, YES};
 use core_graphics_types::geometry::CGSize;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use mtl::{MTLPixelFormat, MTLStorageMode, MTLTextureUsage, TextureDescriptor};
@@ -41,7 +52,8 @@ pub(super) fn create(
         let layer: id = msg_send![class!(CAMetalLayer), layer];
         let () = msg_send![layer, setDevice: logical_device.device.as_ptr()];
         let () = msg_send![layer, setPixelFormat: MTLPixelFormat::BGRA8Unorm];
-        let () = msg_send![layer, setFramebufferOnly: YES];
+        // Don't set framebufferOnly so the texture can be used with compute
+        let () = msg_send![layer, setFramebufferOnly: NO];
 
         let () = msg_send![ns_view, setWantsLayer: YES];
         let () = msg_send![ns_view, setLayer: layer];
@@ -80,6 +92,9 @@ pub(super) fn create(
             depth_texture,
             current_frame: 0,
             layer: layer as *mut std::ffi::c_void,
+            current_drawable: None,
+            current_texture_handle: None,
+            present_mode: PresentMode::Auto,
         },
     );
     tracing::info!("Created Metal surface {}", handle);
@@ -88,14 +103,32 @@ pub(super) fn create(
 
 /// Destroy a surface.
 pub(super) fn destroy(state: &mut MetalState, surface: SurfaceHandle) {
+    // Clean up any acquired drawable texture before removing the surface
+    if let Some(surface_state) = state.surfaces.get(&surface) {
+        if let Some(tex_handle) = surface_state.current_texture_handle {
+            unregister_surface_texture(state, tex_handle);
+        }
+    }
     state.surfaces.remove(&surface);
 }
 
 /// Acquire the next swapchain image.
+///
+/// Calls `nextDrawable` on the CAMetalLayer and registers the drawable's
+/// texture in the bindless descriptor set. The texture handle is available
+/// via `frame_texture()` until `present()` is called.
 pub(super) fn acquire(
     state: &mut MetalState,
     surface: SurfaceHandle,
 ) -> Result<SwapchainImageHandle> {
+    // Clean up any previously acquired drawable that wasn't presented
+    if let Some(surface_state) = state.surfaces.get(&surface) {
+        if let Some(tex_handle) = surface_state.current_texture_handle {
+            tracing::warn!("Previous drawable was not presented; cleaning up");
+            unregister_surface_texture(state, tex_handle);
+        }
+    }
+
     let surface_state = state
         .surfaces
         .get_mut(&surface)
@@ -108,10 +141,44 @@ pub(super) fn acquire(
     surface_state.height = size.height as u32;
 
     surface_state.current_frame = (surface_state.current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+
+    // Get the next drawable from the layer
+    let drawable: id = unsafe { msg_send![layer, nextDrawable] };
+    if drawable == nil {
+        anyhow::bail!("Failed to get next drawable from CAMetalLayer");
+    }
+    unsafe {
+        let () = msg_send![drawable, retain];
+    }
+    surface_state.current_drawable = Some(drawable as *mut std::ffi::c_void);
+
+    // Get the drawable's texture and register it for bindless access
+    let texture_ptr: *mut Object = unsafe { msg_send![drawable, texture] };
+    let texture: &mtl::TextureRef = unsafe { &*(texture_ptr as *const mtl::TextureRef) };
+
+    let device_handle = surface_state.device_handle;
+    let width = surface_state.width;
+    let height = surface_state.height;
+    let format = surface_state.format;
+
+    let tex_handle =
+        register_surface_texture(state, device_handle, texture, width, height, format)?;
+
+    let surface_state = state.surfaces.get_mut(&surface).unwrap();
+    surface_state.current_texture_handle = Some(tex_handle);
+
     Ok(surface_state.current_frame as u64)
 }
 
-/// Render commands to the swapchain and present.
+/// Get the texture handle for the currently acquired surface frame.
+pub(super) fn frame_texture(state: &MetalState, surface: SurfaceHandle) -> Option<TextureHandle> {
+    state
+        .surfaces
+        .get(&surface)
+        .and_then(|s| s.current_texture_handle)
+}
+
+/// Render commands to the swapchain using the already-acquired drawable.
 pub(super) fn render(
     state: &mut MetalState,
     surface: SurfaceHandle,
@@ -123,17 +190,15 @@ pub(super) fn render(
         .get(&surface)
         .context("Invalid surface handle")?;
 
+    let drawable_ptr = surface_state
+        .current_drawable
+        .context("No drawable acquired — call surface_acquire first")?;
+    let drawable = drawable_ptr as id;
+
     let logical_device = state
         .devices
         .get(&surface_state.device_handle)
         .context("Device no longer valid")?;
-
-    let layer = surface_state.layer as id;
-
-    let drawable: id = unsafe { msg_send![layer, nextDrawable] };
-    if drawable == nil {
-        anyhow::bail!("Failed to get next drawable");
-    }
 
     let texture_ptr: *mut Object = unsafe { msg_send![drawable, texture] };
     let texture: &mtl::TextureRef = unsafe { &*(texture_ptr as *const mtl::TextureRef) };
@@ -196,20 +261,100 @@ pub(super) fn render(
     record(encoder, commands, &state.pipelines, &state.buffers);
 
     encoder.end_encoding();
-
-    let _: () = unsafe { msg_send![command_buffer.as_ptr(), presentDrawable: drawable] };
     command_buffer.commit();
 
     Ok(())
 }
 
-/// Present is a no-op; presentation happens in render.
+/// Present the acquired drawable and unregister its temporary texture.
+///
+/// This is the sole place where `presentDrawable:` is called. A lightweight
+/// command buffer is created to schedule the presentation. If `render()` was
+/// called first, Metal's serial queue ordering guarantees the render commands
+/// complete before the present is scheduled by the GPU.
 pub(super) fn present(
-    _state: &mut MetalState,
-    _surface: SurfaceHandle,
+    state: &mut MetalState,
+    surface: SurfaceHandle,
     _image: SwapchainImageHandle,
 ) -> Result<()> {
+    let surface_state = state
+        .surfaces
+        .get(&surface)
+        .context("Invalid surface handle")?;
+
+    let drawable_ptr = match surface_state.current_drawable {
+        Some(d) => d,
+        None => {
+            return Ok(());
+        }
+    };
+    let tex_handle = surface_state.current_texture_handle;
+    let device_handle = surface_state.device_handle;
+
+    let logical_device = state
+        .devices
+        .get(&device_handle)
+        .context("Device no longer valid")?;
+
+    let command_buffer = logical_device.command_queue.new_command_buffer();
+    let drawable = drawable_ptr as id;
+    let _: () = unsafe { msg_send![command_buffer.as_ptr(), presentDrawable: drawable] };
+    command_buffer.commit();
+
+    // Release the retained drawable
+    unsafe {
+        let () = msg_send![drawable, release];
+    }
+
+    // Unregister the temporary surface texture
+    if let Some(th) = tex_handle {
+        unregister_surface_texture(state, th);
+    }
+
+    // Clear the drawable state
+    let surface_state = state.surfaces.get_mut(&surface).unwrap();
+    surface_state.current_drawable = None;
+    surface_state.current_texture_handle = None;
+
     Ok(())
+}
+
+/// Set the present mode on the CAMetalLayer.
+pub(super) fn set_present_mode(
+    state: &mut MetalState,
+    surface: SurfaceHandle,
+    mode: PresentMode,
+) -> Result<()> {
+    let surface_state = state
+        .surfaces
+        .get_mut(&surface)
+        .context("Invalid surface handle")?;
+
+    let layer = surface_state.layer as id;
+    let sync_enabled = match mode {
+        PresentMode::Immediate => false,
+        PresentMode::Fifo | PresentMode::Mailbox | PresentMode::Auto => true,
+    };
+    unsafe {
+        let () = msg_send![layer, setDisplaySyncEnabled: sync_enabled];
+    }
+    surface_state.present_mode = mode;
+    tracing::debug!(
+        "Set surface {} present mode to {:?} (displaySyncEnabled={})",
+        surface,
+        mode,
+        sync_enabled
+    );
+    Ok(())
+}
+
+/// Get the current present mode.
+pub(super) fn present_mode(state: &MetalState, surface: SurfaceHandle) -> PresentMode {
+    state
+        .surfaces
+        .get(&surface)
+        .map(|s| s.present_mode)
+        .unwrap_or(PresentMode::Auto)
 }
 
 /// Resize the surface.
@@ -271,4 +416,90 @@ pub(super) fn format(state: &MetalState, surface: SurfaceHandle) -> TextureForma
         .get(&surface)
         .map(|s| s.format)
         .unwrap_or(TextureFormat::Bgra8Unorm)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers for transient surface texture management
+// ---------------------------------------------------------------------------
+
+/// Register a drawable's MTLTexture in the texture system for bindless access.
+///
+/// The texture is stored as a `TextureState` with a unique handle so it can be
+/// referenced via `texture_bindless_index` just like any other texture. It is
+/// registered as a storage image (Direct spatial access) since compute shaders
+/// need write access.
+fn register_surface_texture(
+    state: &mut MetalState,
+    device_handle: DeviceHandle,
+    texture: &mtl::TextureRef,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+) -> Result<TextureHandle> {
+    let handle = state.next_texture_handle;
+    state.next_texture_handle += 1;
+
+    let logical_device = state
+        .devices
+        .get_mut(&device_handle)
+        .context("Device no longer valid")?;
+
+    // Register as a storage image so compute shaders can write to it
+    let local_idx = logical_device
+        .resource_registry
+        .register_storage_image(handle);
+    let global_idx = ResourceRegistry::storage_image_global_index(local_idx);
+
+    // Encode the texture into the argument buffer
+    let encoded_length = logical_device.texture_encoder.encoded_length();
+    let offset = (global_idx as u64) * encoded_length;
+    if offset + encoded_length <= ARGUMENT_BUFFER_SIZE {
+        logical_device
+            .texture_encoder
+            .set_argument_buffer(&logical_device.argument_buffer, offset);
+        logical_device.texture_encoder.set_texture(0, texture);
+        tracing::trace!(
+            "Encoded surface texture {} at arg buffer offset {} (global slot {})",
+            handle,
+            offset,
+            global_idx
+        );
+    }
+
+    // Retain the MTLTexture so it stays valid while we hold a reference
+    let texture_obj: &mtl::Texture =
+        unsafe { &*(texture as *const mtl::TextureRef as *const mtl::Texture) };
+
+    state.textures.insert(
+        handle,
+        TextureState {
+            device_handle,
+            width,
+            height,
+            format,
+            texture: texture_obj.clone(),
+            arg_buffer_index: local_idx,
+        },
+    );
+
+    tracing::debug!(
+        "Registered surface texture {} ({}x{}, bindless local={} global={})",
+        handle,
+        width,
+        height,
+        local_idx,
+        global_idx,
+    );
+
+    Ok(handle)
+}
+
+/// Unregister a transient surface texture from the texture system.
+fn unregister_surface_texture(state: &mut MetalState, tex_handle: TextureHandle) {
+    if let Some(tex_state) = state.textures.remove(&tex_handle) {
+        if let Some(device) = state.devices.get_mut(&tex_state.device_handle) {
+            device.resource_registry.unregister_texture(tex_handle);
+        }
+        tracing::debug!("Unregistered surface texture {}", tex_handle);
+    }
 }

--- a/src/backend/metal/surface.rs
+++ b/src/backend/metal/surface.rs
@@ -36,7 +36,7 @@ pub(super) fn create(
 ) -> Result<SurfaceHandle> {
     let logical_device = state
         .devices
-        .get(&device_handle)
+        .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
     let window_handle = window
@@ -78,6 +78,14 @@ pub(super) fn create(
         logical_device.device.new_texture(&depth_desc)
     });
 
+    // Reserve a single persistent storage-image bindless slot for this surface's
+    // swapchain drawable. We re-encode the current frame's `MTLTexture` into this
+    // slot on every `acquire` rather than allocating a fresh slot per frame
+    // (which would leak the 64-slot storage-image window in ~1 second at 60 fps).
+    let bindless_storage_slot = logical_device
+        .resource_registry
+        .reserve_storage_image_slot();
+
     let handle = state.next_surface_handle;
     state.next_surface_handle += 1;
 
@@ -94,21 +102,42 @@ pub(super) fn create(
             layer: layer as *mut std::ffi::c_void,
             current_drawable: None,
             current_texture_handle: None,
+            bindless_storage_slot,
             present_mode: PresentMode::Auto,
         },
     );
-    tracing::info!("Created Metal surface {}", handle);
+    tracing::info!(
+        "Created Metal surface {} (bindless storage slot={})",
+        handle,
+        bindless_storage_slot
+    );
     Ok(handle)
 }
 
 /// Destroy a surface.
 pub(super) fn destroy(state: &mut MetalState, surface: SurfaceHandle) {
     // Clean up any acquired drawable texture before removing the surface
+    let (device_handle, slot) = match state.surfaces.get(&surface) {
+        Some(s) => (Some(s.device_handle), Some(s.bindless_storage_slot)),
+        None => (None, None),
+    };
+
     if let Some(surface_state) = state.surfaces.get(&surface) {
         if let Some(tex_handle) = surface_state.current_texture_handle {
             unregister_surface_texture(state, tex_handle);
         }
     }
+
+    // Release the persistent bindless storage-image slot back to the device
+    // registry's free list so another surface can claim it.
+    if let (Some(dev), Some(local)) = (device_handle, slot) {
+        if let Some(logical_device) = state.devices.get_mut(&dev) {
+            logical_device
+                .resource_registry
+                .release_storage_image_slot(local);
+        }
+    }
+
     state.surfaces.remove(&surface);
 }
 
@@ -160,9 +189,17 @@ pub(super) fn acquire(
     let width = surface_state.width;
     let height = surface_state.height;
     let format = surface_state.format;
+    let bindless_slot = surface_state.bindless_storage_slot;
 
-    let tex_handle =
-        register_surface_texture(state, device_handle, texture, width, height, format)?;
+    let tex_handle = register_surface_texture(
+        state,
+        device_handle,
+        texture,
+        width,
+        height,
+        format,
+        bindless_slot,
+    )?;
 
     let surface_state = state.surfaces.get_mut(&surface).unwrap();
     surface_state.current_texture_handle = Some(tex_handle);
@@ -298,7 +335,8 @@ pub(super) fn present(
 
     let command_buffer = logical_device.command_queue.new_command_buffer();
     let drawable = drawable_ptr as id;
-    let _: () = unsafe { msg_send![command_buffer.as_ptr(), presentDrawable: drawable] };
+    let drawable_ref: &mtl::DrawableRef = unsafe { &*(drawable as *const mtl::DrawableRef) };
+    command_buffer.present_drawable(drawable_ref);
     command_buffer.commit();
 
     // Release the retained drawable
@@ -422,12 +460,20 @@ pub(super) fn format(state: &MetalState, surface: SurfaceHandle) -> TextureForma
 // Internal helpers for transient surface texture management
 // ---------------------------------------------------------------------------
 
-/// Register a drawable's MTLTexture in the texture system for bindless access.
+/// Register the current drawable's MTLTexture at the surface's pre-reserved
+/// bindless storage-image slot, so it's visible to compute shaders via
+/// `goldy_dyn_direct_spatial<T>(n)` and to the public API via
+/// [`SurfaceFrame::texture`].
 ///
-/// The texture is stored as a `TextureState` with a unique handle so it can be
-/// referenced via `texture_bindless_index` just like any other texture. It is
-/// registered as a storage image (Direct spatial access) since compute shaders
-/// need write access.
+/// The slot (`bindless_slot`) is allocated once in `create()` and released
+/// in `destroy()`, so only the *texture object* at offset
+/// `storage_image_global_index(bindless_slot) * encoded_length` is rewritten
+/// per frame. This is the "transient allocation path that doesn't leak
+/// indices" anticipated by `abstract-gpu-surface.md` (risk #2).
+///
+/// The drawable `MTLTexture` is owned via [`ForeignType::from_ptr`] after an
+/// explicit `retain` (never cast `&TextureRef` → `&Texture` and `clone()` —
+/// that was UB / PAC faults).
 fn register_surface_texture(
     state: &mut MetalState,
     device_handle: DeviceHandle,
@@ -435,40 +481,41 @@ fn register_surface_texture(
     width: u32,
     height: u32,
     format: TextureFormat,
+    bindless_slot: u32,
 ) -> Result<TextureHandle> {
     let handle = state.next_texture_handle;
     state.next_texture_handle += 1;
 
-    let logical_device = state
-        .devices
-        .get_mut(&device_handle)
-        .context("Device no longer valid")?;
-
-    // Register as a storage image so compute shaders can write to it
-    let local_idx = logical_device
-        .resource_registry
-        .register_storage_image(handle);
-    let global_idx = ResourceRegistry::storage_image_global_index(local_idx);
-
-    // Encode the texture into the argument buffer
-    let encoded_length = logical_device.texture_encoder.encoded_length();
-    let offset = (global_idx as u64) * encoded_length;
-    if offset + encoded_length <= ARGUMENT_BUFFER_SIZE {
-        logical_device
-            .texture_encoder
-            .set_argument_buffer(&logical_device.argument_buffer, offset);
-        logical_device.texture_encoder.set_texture(0, texture);
-        tracing::trace!(
-            "Encoded surface texture {} at arg buffer offset {} (global slot {})",
-            handle,
-            offset,
-            global_idx
-        );
+    let raw = texture.as_ptr();
+    unsafe {
+        let () = msg_send![raw as id, retain];
     }
+    let texture_owned = unsafe { mtl::Texture::from_ptr(raw) };
 
-    // Retain the MTLTexture so it stays valid while we hold a reference
-    let texture_obj: &mtl::Texture =
-        unsafe { &*(texture as *const mtl::TextureRef as *const mtl::Texture) };
+    let global_idx = {
+        let logical_device = state
+            .devices
+            .get_mut(&device_handle)
+            .context("Device no longer valid")?;
+
+        logical_device
+            .resource_registry
+            .bind_storage_image_slot(handle, bindless_slot);
+        let global = ResourceRegistry::storage_image_global_index(bindless_slot);
+
+        let encoded_length = logical_device.texture_encoder.encoded_length();
+        let offset = (global as u64) * encoded_length;
+        if offset + encoded_length <= ARGUMENT_BUFFER_SIZE {
+            logical_device
+                .texture_encoder
+                .set_argument_buffer(&logical_device.argument_buffer, offset);
+            logical_device
+                .texture_encoder
+                .set_texture(0, texture_owned.as_ref());
+        }
+
+        global
+    };
 
     state.textures.insert(
         handle,
@@ -477,29 +524,34 @@ fn register_surface_texture(
             width,
             height,
             format,
-            texture: texture_obj.clone(),
-            arg_buffer_index: local_idx,
+            texture: texture_owned,
+            arg_buffer_index: bindless_slot,
+            is_storage_image: true,
+            slot_owned_externally: true,
         },
     );
 
     tracing::debug!(
-        "Registered surface texture {} ({}x{}, bindless local={} global={})",
+        "Encoded surface drawable into texture {} ({}x{}, bindless storage local={}, global={})",
         handle,
         width,
         height,
-        local_idx,
+        bindless_slot,
         global_idx,
     );
 
     Ok(handle)
 }
 
-/// Unregister a transient surface texture from the texture system.
+/// Unregister the per-frame TextureHandle for the drawable, releasing the
+/// owned `MTLTexture` (via `Drop` → `release`) and clearing the handle→slot
+/// map entry. The surface's bindless slot itself is NOT released here — it
+/// stays reserved across frames until the surface is destroyed.
 fn unregister_surface_texture(state: &mut MetalState, tex_handle: TextureHandle) {
     if let Some(tex_state) = state.textures.remove(&tex_handle) {
         if let Some(device) = state.devices.get_mut(&tex_state.device_handle) {
             device.resource_registry.unregister_texture(tex_handle);
         }
-        tracing::debug!("Unregistered surface texture {}", tex_handle);
+        tracing::debug!("Unregistered surface drawable texture {}", tex_handle);
     }
 }

--- a/src/backend/metal/surface.rs
+++ b/src/backend/metal/surface.rs
@@ -295,7 +295,7 @@ pub(super) fn render(
         height: surface_state.height as u64,
     });
 
-    record(encoder, commands, &state.pipelines, &state.buffers);
+    record(encoder, commands, &state.pipelines, &state.buffers)?;
 
     encoder.end_encoding();
     command_buffer.commit();

--- a/src/backend/metal/texture.rs
+++ b/src/backend/metal/texture.rs
@@ -93,6 +93,8 @@ pub(super) fn create(
             format,
             texture,
             arg_buffer_index,
+            is_storage_image,
+            slot_owned_externally: false,
         },
     );
 
@@ -258,11 +260,26 @@ pub(super) fn read_to_cpu(
     Ok(())
 }
 
-/// Destroy a texture.
+/// Destroy a texture and return its bindless slot to the registry's free list.
+///
+/// If `slot_owned_externally` is set (e.g. a swapchain drawable whose slot is
+/// owned by `SurfaceState`), the slot is NOT released here — the owner manages
+/// it across frames.
 pub(super) fn destroy(state: &mut MetalState, texture_handle: TextureHandle) {
     if let Some(texture) = state.textures.remove(&texture_handle) {
         if let Some(device) = state.devices.get_mut(&texture.device_handle) {
             device.resource_registry.unregister_texture(texture_handle);
+            if !texture.slot_owned_externally {
+                if texture.is_storage_image {
+                    device
+                        .resource_registry
+                        .release_storage_image_slot(texture.arg_buffer_index);
+                } else {
+                    device
+                        .resource_registry
+                        .release_texture_slot(texture.arg_buffer_index);
+                }
+            }
         }
     }
 }

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -551,6 +551,11 @@ pub(crate) struct PipelineState {
     pub pipeline: RenderPipelineState,
     pub depth_stencil: Option<MTLDepthStencilState>,
     pub primitive_type: MTLPrimitiveType,
+    /// Per-push-constant-slot category expected by the fragment/vertex shader,
+    /// inferred from `goldy_dyn_*(N)` calls. Empty disables validation.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    pub shader_debug_name: String,
 }
 
 /// Compute pipeline state.
@@ -559,6 +564,14 @@ pub(crate) struct ComputePipelineState {
     pub pipeline: MTLComputePipelineState,
     /// Thread group size from [numthreads(x, y, z)] attribute
     pub workgroup_size: [u32; 3],
+    /// Per-push-constant-slot category expected by the compute shader, inferred
+    /// from the shader's `goldy_dyn_*(N)` calls during Slang compile. Empty or
+    /// all-`None` disables validation. See
+    /// [`crate::slang::ShaderReflection::push_constant_categories`].
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    /// Defaults to `"cs_main"` for compute pipelines.
+    pub shader_debug_name: String,
 }
 
 /// GPU render target state with optional staging for CPU readback.

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -341,6 +341,21 @@ pub(crate) struct ResourceRegistry {
     next_texture_index: u32,
     next_storage_image_index: u32,
     next_sampler_index: u32,
+    /// Free list of previously-released storage-image LOCAL indices.
+    ///
+    /// Populated by `release_storage_image_slot()` (used when a Surface is
+    /// destroyed). `register_storage_image()` / `reserve_storage_image_slot()`
+    /// pop from this list before bumping `next_storage_image_index`, so
+    /// transient bindless slots (per-frame swapchain drawables) don't leak
+    /// across the 64-slot storage-image window.
+    free_storage_image_slots: Vec<u32>,
+    /// Symmetric free list for sampled (Interpolated / `Texture2D`) slots.
+    ///
+    /// Populated by `release_texture_slot()` when a regular texture is
+    /// destroyed; `register_texture()` consults it before bumping
+    /// `next_texture_index`. Prevents slot exhaustion when textures are
+    /// created and destroyed repeatedly at runtime.
+    free_texture_slots: Vec<u32>,
     pub buffer_indices: HashMap<BufferHandle, u32>,
     pub texture_indices: HashMap<TextureHandle, u32>,
     pub sampler_indices: HashMap<SamplerHandle, u32>,
@@ -359,6 +374,8 @@ impl ResourceRegistry {
             next_storage_image_index: 3 * MAX_RESOURCES_PER_CATEGORY,
             // Samplers at indices 256-319, bytes 2048-2559
             next_sampler_index: 4 * MAX_RESOURCES_PER_CATEGORY,
+            free_storage_image_slots: Vec::new(),
+            free_texture_slots: Vec::new(),
             buffer_indices: HashMap::new(),
             texture_indices: HashMap::new(),
             sampler_indices: HashMap::new(),
@@ -393,12 +410,25 @@ impl ResourceRegistry {
 
     /// Register a sampled texture (Interpolated / Texture2D) — returns the LOCAL index (0-63).
     /// Use `texture_global_index()` to get the argument buffer encoding offset.
+    ///
+    /// Reuses a freed slot if available (see `release_texture_slot`).
     pub fn register_texture(&mut self, handle: TextureHandle) -> u32 {
-        let global_index = self.next_texture_index;
-        let local_index = global_index - 2 * MAX_RESOURCES_PER_CATEGORY;
-        self.next_texture_index += 1;
+        let local_index = if let Some(free) = self.free_texture_slots.pop() {
+            free
+        } else {
+            let global_index = self.next_texture_index;
+            let local = global_index - 2 * MAX_RESOURCES_PER_CATEGORY;
+            self.next_texture_index += 1;
+            local
+        };
         self.texture_indices.insert(handle, local_index);
         local_index
+    }
+
+    /// Return a sampled-texture LOCAL index to the free list so it can be
+    /// reused by a subsequent `register_texture`.
+    pub fn release_texture_slot(&mut self, local_index: u32) {
+        self.free_texture_slots.push(local_index);
     }
 
     /// Returns the global argument buffer index for a sampled texture.
@@ -408,11 +438,45 @@ impl ResourceRegistry {
 
     /// Register a storage image (Direct / RWTexture2D) — returns the LOCAL index (0-63).
     /// Use `storage_image_global_index()` to get the argument buffer encoding offset.
+    ///
+    /// Reuses a freed slot if available (see `release_storage_image_slot`).
     pub fn register_storage_image(&mut self, handle: TextureHandle) -> u32 {
+        let local_index = self.allocate_storage_image_local();
+        self.texture_indices.insert(handle, local_index);
+        local_index
+    }
+
+    /// Reserve a storage-image LOCAL index without binding it to a TextureHandle.
+    ///
+    /// Used for transient bindless slots that outlive any single `TextureHandle`
+    /// but belong to a long-lived owner (e.g. a `Surface` that re-encodes a
+    /// fresh drawable into the same slot every frame). The owner must release
+    /// the slot via [`Self::release_storage_image_slot`] when destroyed.
+    pub fn reserve_storage_image_slot(&mut self) -> u32 {
+        self.allocate_storage_image_local()
+    }
+
+    /// Associate a TextureHandle with a previously-reserved storage-image
+    /// LOCAL index so `texture_bindless_index()` / `Texture::bindless_index()`
+    /// resolves to the right slot. Does not bump any counters.
+    pub fn bind_storage_image_slot(&mut self, handle: TextureHandle, local_index: u32) {
+        self.texture_indices.insert(handle, local_index);
+    }
+
+    /// Return a storage-image LOCAL index to the free list so it can be
+    /// reused by a subsequent `register_storage_image` / `reserve_storage_image_slot`.
+    pub fn release_storage_image_slot(&mut self, local_index: u32) {
+        self.free_storage_image_slots.push(local_index);
+    }
+
+    /// Pop a free slot if any, otherwise bump the monotonic counter.
+    fn allocate_storage_image_local(&mut self) -> u32 {
+        if let Some(local) = self.free_storage_image_slots.pop() {
+            return local;
+        }
         let global_index = self.next_storage_image_index;
         let local_index = global_index - 3 * MAX_RESOURCES_PER_CATEGORY;
         self.next_storage_image_index += 1;
-        self.texture_indices.insert(handle, local_index);
         local_index
     }
 
@@ -518,8 +582,17 @@ pub(crate) struct TextureState {
     pub height: u32,
     pub format: TextureFormat,
     pub texture: MTLTexture,
-    /// Index in the global argument buffer (always present — heap required).
+    /// LOCAL index (0..MAX_RESOURCES_PER_CATEGORY) in the texture category this
+    /// texture was registered in (`storageImages[]` when `is_storage_image`,
+    /// otherwise `textures[]`).
     pub arg_buffer_index: u32,
+    /// Which bindless region the `arg_buffer_index` belongs to; needed at
+    /// destroy time to release the slot back to the correct free list.
+    pub is_storage_image: bool,
+    /// When true, the slot is owned by a long-lived entity (e.g. a `Surface`
+    /// that re-encodes its drawable each frame) and should NOT be released
+    /// when this `TextureState` is dropped. The owner manages slot lifetime.
+    pub slot_owned_externally: bool,
 }
 
 /// GPU sampler state.
@@ -552,6 +625,14 @@ pub(crate) struct SurfaceState {
     pub current_drawable: Option<*mut std::ffi::c_void>,
     /// Texture handle for the current drawable's texture (registered for bindless access)
     pub current_texture_handle: Option<TextureHandle>,
+    /// Persistent bindless storage-image LOCAL index reserved at surface create
+    /// and re-encoded with the current drawable's `MTLTexture` on every `acquire`.
+    ///
+    /// This avoids leaking a fresh slot per frame (the storage-image window is
+    /// only `MAX_RESOURCES_PER_CATEGORY` = 64 slots, so a per-frame allocation
+    /// would exhaust it in ~1 second at 60 fps). Released back to the device's
+    /// `ResourceRegistry` free list when the surface is destroyed.
+    pub bindless_storage_slot: u32,
     /// Current present mode
     pub present_mode: crate::types::PresentMode,
 }

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -548,6 +548,12 @@ pub(crate) struct SurfaceState {
     pub current_frame: usize,
     /// The CAMetalLayer (stored as raw pointer for objc interop)
     pub layer: *mut std::ffi::c_void,
+    /// The currently acquired CAMetalDrawable (set during acquire, cleared on present)
+    pub current_drawable: Option<*mut std::ffi::c_void>,
+    /// Texture handle for the current drawable's texture (registered for bindless access)
+    pub current_texture_handle: Option<TextureHandle>,
+    /// Current present mode
+    pub present_mode: crate::types::PresentMode,
 }
 
 // Safety: Metal objects are thread-safe when properly synchronized

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -122,6 +122,7 @@ struct MockSurface {
     height: u32,
     format: TextureFormat,
     next_image: SwapchainImageHandle,
+    current_texture_handle: Option<TextureHandle>,
 }
 
 impl MockBackend {
@@ -601,6 +602,7 @@ impl GpuBackend for MockBackend {
                 height: 600,
                 format: self.default_surface_format, // Use configured format
                 next_image: 1,
+                current_texture_handle: None,
             },
         );
 
@@ -619,7 +621,37 @@ impl GpuBackend for MockBackend {
 
         let image = surf.next_image;
         surf.next_image += 1;
+
+        // Create a mock texture for the surface frame
+        let tex_handle = self.next_texture_handle;
+        self.next_texture_handle += 1;
+        let bindless_index = self.next_bindless_index;
+        self.next_bindless_index += 1;
+        let width = surf.width;
+        let height = surf.height;
+        let format = surf.format;
+        let device_handle = surf.device_handle;
+        surf.current_texture_handle = Some(tex_handle);
+
+        self.textures.insert(
+            tex_handle,
+            MockTexture {
+                device_handle,
+                width,
+                height,
+                format,
+                data: vec![0; (width * height * format.bytes_per_pixel()) as usize],
+                bindless_index,
+            },
+        );
+
         Ok(image)
+    }
+
+    fn surface_frame_texture(&self, surface: SurfaceHandle) -> Option<TextureHandle> {
+        self.surfaces
+            .get(&surface)
+            .and_then(|s| s.current_texture_handle)
     }
 
     fn surface_render(
@@ -641,8 +673,14 @@ impl GpuBackend for MockBackend {
         surface: SurfaceHandle,
         _image: SwapchainImageHandle,
     ) -> Result<()> {
-        if !self.surfaces.contains_key(&surface) {
-            anyhow::bail!("Invalid surface handle");
+        let surf = self
+            .surfaces
+            .get_mut(&surface)
+            .ok_or_else(|| anyhow::anyhow!("Invalid surface handle"))?;
+
+        // Clean up the transient surface texture
+        if let Some(tex_handle) = surf.current_texture_handle.take() {
+            self.textures.remove(&tex_handle);
         }
 
         self.surface_present_count += 1;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -34,11 +34,68 @@ pub mod mock;
 pub mod metal;
 
 use crate::types::{
-    BackendType, Color, DataAccess, DepthFormat, DepthStencilState, DeviceType, IndexFormat,
-    PresentMode, PrimitiveTopology, SamplerDesc, SpatialAccess, TextureFlags, TextureFormat,
-    VertexBufferLayout,
+    BackendType, BindlessHandle, Color, DataAccess, DepthFormat, DepthStencilState, DeviceType,
+    IndexFormat, PresentMode, PrimitiveTopology, SamplerDesc, SpatialAccess, TextureFlags,
+    TextureFormat, VertexBufferLayout,
 };
 use anyhow::Result;
+
+#[cfg(any(
+    test,
+    feature = "vulkan",
+    all(feature = "dx12", target_os = "windows"),
+    all(feature = "metal", target_os = "macos"),
+))]
+use crate::types::BindlessCategory;
+
+/// Validate a typed push-constant array against per-slot category expectations
+/// reported by shader reflection.
+///
+/// `expectations[i]` is the category that slot `i` must have according to the
+/// shader's `goldy_dyn_*` call with literal slot index `i`. `None` means
+/// "reflection couldn't infer — skip validation for this slot" (e.g. the slot
+/// is only accessed via a dynamic index that regex analysis can't resolve).
+///
+/// Returns an error naming the offending slot(s) on mismatch. Designed to run
+/// on the dispatch hot path; allocates only on the error path.
+#[cfg(any(
+    test,
+    feature = "vulkan",
+    all(feature = "dx12", target_os = "windows"),
+    all(feature = "metal", target_os = "macos"),
+))]
+pub(crate) fn validate_typed_push_constants(
+    handles: &[BindlessHandle],
+    expectations: &[Option<BindlessCategory>],
+    shader_name: &str,
+) -> Result<()> {
+    let mut mismatches: Vec<String> = Vec::new();
+    for (slot, handle) in handles.iter().enumerate() {
+        let Some(expected) = expectations.get(slot).copied().flatten() else {
+            continue;
+        };
+        if !handle.category().is_compatible_with(expected) {
+            mismatches.push(format!(
+                "slot {slot}: shader expects `{}` (via goldy_dyn_{}(_)) but got `{}` handle (index {})",
+                expected.name(),
+                expected.name(),
+                handle.category().name(),
+                handle.index()
+            ));
+        }
+    }
+    if mismatches.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "push-constant category mismatch in shader `{shader_name}`:\n  {}\n\
+             Hint: use `Buffer::bindless_handle()` / `Texture::bindless_handle()` \
+             rather than `.bindless_index()` so the resource's category flows \
+             through to the push-constant setter.",
+            mismatches.join("\n  ")
+        );
+    }
+}
 
 // Re-export raw_window_handle for Surface API users
 pub use raw_window_handle;
@@ -100,7 +157,14 @@ pub enum RenderCommand {
     SetPushConstants { buffers: Vec<BufferHandle> },
     /// Set push constants with raw u32 indices (fully bindless mode).
     /// Use this for textures/samplers or when you already have the indices.
+    ///
+    /// **Prefer [`RenderCommand::SetPushConstantsTyped`]** — the raw form
+    /// bypasses per-slot category validation.
     SetPushConstantsRaw { indices: Vec<u32> },
+    /// Set push constants with typed [`BindlessHandle`]s. Backends validate
+    /// each handle's [`BindlessCategory`]
+    /// against the bound shader's reflection and emit the raw indices.
+    SetPushConstantsTyped { handles: Vec<BindlessHandle> },
     /// Draw primitives (non-indexed).
     Draw {
         vertex_count: u32,
@@ -127,7 +191,14 @@ pub enum ComputeCommand {
     /// Set push constants (fully bindless mode - buffer indices passed directly).
     SetPushConstants { buffers: Vec<BufferHandle> },
     /// Set push constants with raw u32 indices (for textures/samplers or mixed resources).
+    ///
+    /// **Prefer [`ComputeCommand::SetPushConstantsTyped`]** — the raw form
+    /// bypasses per-slot category validation.
     SetPushConstantsRaw { indices: Vec<u32> },
+    /// Set push constants with typed [`BindlessHandle`]s. Backends validate
+    /// each handle's [`BindlessCategory`]
+    /// against the bound shader's reflection and emit the raw indices.
+    SetPushConstantsTyped { handles: Vec<BindlessHandle> },
     /// Dispatch compute workgroups.
     Dispatch {
         workgroups_x: u32,
@@ -585,5 +656,82 @@ pub fn create_backend(backend_type: BackendType) -> Result<Box<dyn GpuBackend>> 
             Ok(Box::new(metal::MetalBackend::new()?))
         }
         _ => anyhow::bail!("Backend {:?} not available on this platform", backend_type),
+    }
+}
+
+#[cfg(test)]
+mod typed_push_constant_validation_tests {
+    use super::validate_typed_push_constants;
+    use crate::types::{BindlessCategory, BindlessHandle};
+
+    #[test]
+    fn ok_when_categories_match() {
+        let handles = [
+            BindlessHandle::new(BindlessCategory::Broadcast, 3),
+            BindlessHandle::new(BindlessCategory::Scattered, 7),
+        ];
+        let expectations = [
+            Some(BindlessCategory::Broadcast),
+            Some(BindlessCategory::Scattered),
+        ];
+        validate_typed_push_constants(&handles, &expectations, "test_shader").unwrap();
+    }
+
+    #[test]
+    fn ok_when_expectations_shorter_than_handles() {
+        // Shader only reflected the first slot; extra handles aren't validated.
+        let handles = [
+            BindlessHandle::new(BindlessCategory::Broadcast, 1),
+            BindlessHandle::new(BindlessCategory::Scattered, 2),
+        ];
+        let expectations = [Some(BindlessCategory::Broadcast)];
+        validate_typed_push_constants(&handles, &expectations, "test_shader").unwrap();
+    }
+
+    #[test]
+    fn ok_when_slot_expectation_is_none() {
+        // `None` means reflection couldn't infer — skip validation.
+        let handles = [BindlessHandle::new(BindlessCategory::Scattered, 1)];
+        let expectations = [None];
+        validate_typed_push_constants(&handles, &expectations, "test_shader").unwrap();
+    }
+
+    #[test]
+    fn err_when_category_mismatches() {
+        // The compute_to_surface bug: slot 0 is a Scattered storage buffer but
+        // the user passes a Broadcast-only uniform handle.
+        let handles = [BindlessHandle::new(BindlessCategory::Broadcast, 42)];
+        let expectations = [Some(BindlessCategory::Scattered)];
+        let err = validate_typed_push_constants(&handles, &expectations, "compute_to_surface_cs")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("compute_to_surface_cs"),
+            "shader name in err: {err}"
+        );
+        assert!(err.contains("slot 0"), "slot index in err: {err}");
+        assert!(err.contains("scattered"), "expected category in err: {err}");
+        assert!(err.contains("broadcast"), "got category in err: {err}");
+        assert!(err.contains("42"), "handle index in err: {err}");
+    }
+
+    #[test]
+    fn err_lists_all_mismatching_slots() {
+        let handles = [
+            BindlessHandle::new(BindlessCategory::Broadcast, 1),
+            BindlessHandle::new(BindlessCategory::Scattered, 2),
+            BindlessHandle::new(BindlessCategory::Sampler, 3),
+        ];
+        let expectations = [
+            Some(BindlessCategory::Broadcast), // ok
+            Some(BindlessCategory::Texture),   // mismatch
+            Some(BindlessCategory::Sampler),   // ok
+        ];
+        let err = validate_typed_push_constants(&handles, &expectations, "sh")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("slot 1"), "slot 1 must appear: {err}");
+        // Exactly one mismatch reported.
+        assert_eq!(err.matches("slot ").count(), 1, "only one mismatch: {err}");
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -35,7 +35,8 @@ pub mod metal;
 
 use crate::types::{
     BackendType, Color, DataAccess, DepthFormat, DepthStencilState, DeviceType, IndexFormat,
-    PrimitiveTopology, SamplerDesc, SpatialAccess, TextureFlags, TextureFormat, VertexBufferLayout,
+    PresentMode, PrimitiveTopology, SamplerDesc, SpatialAccess, TextureFlags, TextureFormat,
+    VertexBufferLayout,
 };
 use anyhow::Result;
 
@@ -365,7 +366,17 @@ pub trait GpuBackend: Send + Sync {
     fn destroy_surface(&mut self, surface: SurfaceHandle);
 
     /// Acquire the next swapchain image to render to.
+    ///
+    /// After acquire, the frame's texture is available via [`GpuBackend::surface_frame_texture`].
     fn surface_acquire(&mut self, surface: SurfaceHandle) -> Result<SwapchainImageHandle>;
+
+    /// Get the texture handle for the currently acquired surface frame.
+    ///
+    /// Returns `None` if no frame is currently acquired (i.e. `surface_acquire`
+    /// has not been called or `surface_present` has already been called).
+    /// The returned texture is registered in the bindless descriptor set and
+    /// can be used with compute or render passes.
+    fn surface_frame_texture(&self, surface: SurfaceHandle) -> Option<TextureHandle>;
 
     /// Render commands to a swapchain image.
     fn surface_render(
@@ -391,6 +402,21 @@ pub trait GpuBackend: Send + Sync {
     /// Get the texture format used by a surface's swapchain.
     /// Use this to ensure your render pipeline matches the surface format.
     fn surface_format(&self, surface: SurfaceHandle) -> TextureFormat;
+
+    /// Set the present mode for a surface.
+    /// Returns an error if the mode is not supported by the backend.
+    fn surface_set_present_mode(
+        &mut self,
+        _surface: SurfaceHandle,
+        _mode: PresentMode,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Get the current present mode for a surface.
+    fn surface_present_mode(&self, _surface: SurfaceHandle) -> PresentMode {
+        PresentMode::Auto
+    }
 
     // Compute pipeline management
     /// Create a compute pipeline from a compute shader.

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -8,12 +8,15 @@ use ash::vk;
 use std::collections::HashMap;
 
 /// Create a compute pipeline.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn create(
     devices: &HashMap<DeviceHandle, LogicalDevice>,
     compute_pipelines: &mut HashMap<ComputePipelineHandle, ComputePipelineState>,
     next_compute_pipeline_handle: &mut ComputePipelineHandle,
     device_handle: DeviceHandle,
     cs_module: vk::ShaderModule,
+    push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    shader_debug_name: String,
 ) -> Result<ComputePipelineHandle> {
     let logical_device = devices
         .get(&device_handle)
@@ -62,6 +65,8 @@ pub(super) fn create(
             layout: pipeline_layout,
             owns_layout,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 
@@ -214,6 +219,33 @@ pub(super) fn submit(
                             break;
                         }
                         indices.indices[i] = idx;
+                    }
+                    unsafe {
+                        logical_device.device.cmd_push_constants(
+                            cmd,
+                            pipeline.layout,
+                            vk::ShaderStageFlags::COMPUTE,
+                            0,
+                            bytemuck::bytes_of(&indices),
+                        );
+                    }
+                }
+            }
+            ComputeCommand::SetPushConstantsTyped {
+                handles: typed_handles,
+            } => {
+                if let Some(pipeline) = current_pipeline.and_then(|p| compute_pipelines.get(&p)) {
+                    crate::backend::validate_typed_push_constants(
+                        typed_handles,
+                        &pipeline.push_constant_categories,
+                        &pipeline.shader_debug_name,
+                    )?;
+                    let mut indices = BindlessIndices::default();
+                    for (i, handle) in typed_handles.iter().enumerate() {
+                        if i >= types::MAX_PUSH_CONSTANT_INDICES {
+                            break;
+                        }
+                        indices.indices[i] = handle.index();
                     }
                     unsafe {
                         logical_device.device.cmd_push_constants(

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -495,8 +495,9 @@ impl GpuBackend for VulkanBackend {
         surface::destroy(
             &self.state.entry,
             &self.state.instance,
-            &self.state.devices,
+            &mut self.state.devices,
             &mut self.state.surfaces,
+            &mut self.state.textures,
             surface_handle,
         );
     }
@@ -506,8 +507,14 @@ impl GpuBackend for VulkanBackend {
             &self.state.instance,
             &mut self.state.devices,
             &mut self.state.surfaces,
+            &mut self.state.textures,
+            &mut self.state.next_texture_handle,
             surface_handle,
         )
+    }
+
+    fn surface_frame_texture(&self, surface: SurfaceHandle) -> Option<TextureHandle> {
+        surface::frame_texture(&self.state.surfaces, surface)
     }
 
     fn surface_render(
@@ -544,6 +551,7 @@ impl GpuBackend for VulkanBackend {
             &self.state.instance,
             &mut self.state.devices,
             &mut self.state.surfaces,
+            &mut self.state.textures,
             surface_handle,
             _image,
         )

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -32,6 +32,35 @@ use ash::{khr, vk};
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
 
+/// Collect per-push-constant-slot categories for a render pipeline by looking
+/// up reflection data on the bound vertex/fragment shaders. Fragment shader
+/// expectations take precedence (that's where `goldy_dyn_*` is typically used);
+/// vertex shader data is used as a fallback when fragment has none.
+fn render_push_constant_expectations(
+    shaders: &HashMap<ShaderHandle, ShaderState>,
+    vertex_shader: ShaderHandle,
+    fragment_shader: ShaderHandle,
+) -> (Vec<Option<crate::types::BindlessCategory>>, String) {
+    let fs_cats = shaders
+        .get(&fragment_shader)
+        .and_then(|s| s.reflection.as_ref())
+        .map(|r| r.push_constant_categories.clone())
+        .unwrap_or_default();
+    let cats = if !fs_cats.is_empty() {
+        fs_cats
+    } else {
+        shaders
+            .get(&vertex_shader)
+            .and_then(|s| s.reflection.as_ref())
+            .map(|r| r.push_constant_categories.clone())
+            .unwrap_or_default()
+    };
+    (
+        cats,
+        format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})"),
+    )
+}
+
 /// Vulkan backend.
 pub struct VulkanBackend {
     state: VulkanState,
@@ -392,6 +421,9 @@ impl GpuBackend for VulkanBackend {
         let fs_module =
             self.ensure_shader_stage_compiled(fragment_shader, crate::slang::SlangStage::Fragment)?;
 
+        let (push_constant_categories, shader_debug_name) =
+            render_push_constant_expectations(&self.state.shaders, vertex_shader, fragment_shader);
+
         pipeline::create(
             &self.state.devices,
             &mut self.state.pipelines,
@@ -402,6 +434,8 @@ impl GpuBackend for VulkanBackend {
             vertex_layout,
             topology,
             target_format,
+            push_constant_categories,
+            shader_debug_name,
         )
     }
 
@@ -456,7 +490,7 @@ impl GpuBackend for VulkanBackend {
                     &self.state.pipelines,
                     &self.state.buffers,
                     current_pipeline,
-                );
+                )
             },
         )
     }
@@ -537,7 +571,7 @@ impl GpuBackend for VulkanBackend {
                     &self.state.pipelines,
                     &self.state.buffers,
                     current_pipeline,
-                );
+                )
             },
         )
     }
@@ -598,6 +632,9 @@ impl GpuBackend for VulkanBackend {
         let fs_module =
             self.ensure_shader_stage_compiled(fragment_shader, crate::slang::SlangStage::Fragment)?;
 
+        let (push_constant_categories, shader_debug_name) =
+            render_push_constant_expectations(&self.state.shaders, vertex_shader, fragment_shader);
+
         pipeline::create_with_depth(
             &self.state.devices,
             &mut self.state.pipelines,
@@ -609,6 +646,8 @@ impl GpuBackend for VulkanBackend {
             topology,
             target_format,
             depth_stencil,
+            push_constant_categories,
+            shader_debug_name,
         )
     }
 
@@ -757,12 +796,28 @@ impl GpuBackend for VulkanBackend {
         let cs_module =
             self.ensure_shader_stage_compiled(compute_shader, crate::slang::SlangStage::Compute)?;
 
+        let (push_constant_categories, shader_debug_name) = self
+            .state
+            .shaders
+            .get(&compute_shader)
+            .map(|s| {
+                let cats = s
+                    .reflection
+                    .as_ref()
+                    .map(|r| r.push_constant_categories.clone())
+                    .unwrap_or_default();
+                (cats, format!("compute_shader#{compute_shader}"))
+            })
+            .unwrap_or_default();
+
         compute::create(
             &self.state.devices,
             &mut self.state.compute_pipelines,
             &mut self.state.next_compute_pipeline_handle,
             device_handle,
             cs_module,
+            push_constant_categories,
+            shader_debug_name,
         )
     }
 

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -24,6 +24,8 @@ pub(super) fn create(
     vertex_layout: &VertexBufferLayout,
     topology: PrimitiveTopology,
     target_format: TextureFormat,
+    push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    shader_debug_name: String,
 ) -> Result<PipelineHandle> {
     let logical_device = devices
         .get(&device_handle)
@@ -153,6 +155,8 @@ pub(super) fn create(
             layout,
             owns_layout,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 
@@ -173,6 +177,8 @@ pub(super) fn create_with_depth(
     topology: PrimitiveTopology,
     target_format: TextureFormat,
     depth_stencil: Option<&DepthStencilState>,
+    push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    shader_debug_name: String,
 ) -> Result<PipelineHandle> {
     let logical_device = devices
         .get(&device_handle)
@@ -345,6 +351,8 @@ pub(super) fn create_with_depth(
             layout,
             owns_layout,
             parameter_block_layouts: Vec::new(),
+            push_constant_categories,
+            shader_debug_name,
         },
     );
 

--- a/src/backend/vulkan/render_commands.rs
+++ b/src/backend/vulkan/render_commands.rs
@@ -17,7 +17,7 @@ pub(super) fn record(
     pipelines: &std::collections::HashMap<PipelineHandle, types::PipelineState>,
     buffers: &std::collections::HashMap<BufferHandle, types::BufferState>,
     current_pipeline: &mut Option<PipelineHandle>,
-) {
+) -> anyhow::Result<()> {
     for command in commands {
         match command {
             RenderCommand::Clear(_) => {
@@ -115,6 +115,33 @@ pub(super) fn record(
                     }
                 }
             }
+            RenderCommand::SetPushConstantsTyped {
+                handles: typed_handles,
+            } => {
+                if let Some(pipeline) = current_pipeline.and_then(|p| pipelines.get(&p)) {
+                    crate::backend::validate_typed_push_constants(
+                        typed_handles,
+                        &pipeline.push_constant_categories,
+                        &pipeline.shader_debug_name,
+                    )?;
+                    let mut indices = BindlessIndices::default();
+                    for (i, handle) in typed_handles.iter().enumerate() {
+                        if i >= MAX_PUSH_CONSTANT_INDICES {
+                            break;
+                        }
+                        indices.indices[i] = handle.index();
+                    }
+                    unsafe {
+                        logical_device.device.cmd_push_constants(
+                            cmd,
+                            pipeline.layout,
+                            vk::ShaderStageFlags::ALL,
+                            0,
+                            bytemuck::bytes_of(&indices),
+                        );
+                    }
+                }
+            }
             RenderCommand::SetIndexBuffer {
                 buffer,
                 offset,
@@ -163,4 +190,5 @@ pub(super) fn record(
             },
         }
     }
+    Ok(())
 }

--- a/src/backend/vulkan/render_target.rs
+++ b/src/backend/vulkan/render_target.rs
@@ -393,7 +393,12 @@ pub(super) fn render_to<F>(
     record_commands_fn: F,
 ) -> Result<()>
 where
-    F: FnOnce(vk::CommandBuffer, &[RenderCommand], &LogicalDevice, &mut Option<PipelineHandle>),
+    F: FnOnce(
+        vk::CommandBuffer,
+        &[RenderCommand],
+        &LogicalDevice,
+        &mut Option<PipelineHandle>,
+    ) -> Result<()>,
 {
     let logical_device = devices
         .get(&device_handle)
@@ -565,7 +570,7 @@ where
     let mut current_pipeline: Option<PipelineHandle> = None;
 
     // Execute render commands using provided callback
-    record_commands_fn(cmd, commands, logical_device, &mut current_pipeline);
+    record_commands_fn(cmd, commands, logical_device, &mut current_pipeline)?;
 
     // End dynamic rendering
     unsafe { logical_device.device.cmd_end_rendering(cmd) };

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -557,7 +557,12 @@ pub(super) fn render<F>(
     record_commands_fn: F,
 ) -> Result<()>
 where
-    F: FnOnce(vk::CommandBuffer, &[RenderCommand], &LogicalDevice, &mut Option<PipelineHandle>),
+    F: FnOnce(
+        vk::CommandBuffer,
+        &[RenderCommand],
+        &LogicalDevice,
+        &mut Option<PipelineHandle>,
+    ) -> Result<()>,
 {
     let surface_state = surfaces
         .get(&surface_handle)
@@ -727,7 +732,7 @@ where
     let mut current_pipeline: Option<PipelineHandle> = None;
 
     // Execute render commands using provided callback
-    record_commands_fn(cmd, commands, logical_device, &mut current_pipeline);
+    record_commands_fn(cmd, commands, logical_device, &mut current_pipeline)?;
 
     // End dynamic rendering
     unsafe { logical_device.device.cmd_end_rendering(cmd) };

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -1,8 +1,10 @@
 //! Surface and swapchain management for window presentation.
 
-use super::types::{self, FrameSync, LogicalDevice, SurfaceState, MAX_FRAMES_IN_FLIGHT};
+use super::types::{
+    self, FrameSync, LogicalDevice, SurfaceState, TextureState, MAX_FRAMES_IN_FLIGHT,
+};
 use super::utils::{depth_aspect_mask, depth_format_to_vk, find_memory_type};
-use super::{DeviceHandle, PipelineHandle, SurfaceHandle, SwapchainImageHandle};
+use super::{DeviceHandle, PipelineHandle, SurfaceHandle, SwapchainImageHandle, TextureHandle};
 use crate::backend::RenderCommand;
 use crate::types::{Color, DepthFormat, TextureFormat};
 use anyhow::{Context, Result};
@@ -166,7 +168,7 @@ pub(super) fn create(
         .image_color_space(format.color_space)
         .image_extent(extent)
         .image_array_layers(1)
-        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
+        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::STORAGE)
         .image_sharing_mode(vk::SharingMode::EXCLUSIVE)
         .pre_transform(capabilities.current_transform)
         .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
@@ -328,6 +330,7 @@ pub(super) fn create(
             depth_image,
             depth_memory,
             depth_view,
+            current_texture_handle: None,
         },
     );
 
@@ -344,10 +347,19 @@ pub(super) fn create(
 pub(super) fn destroy(
     entry: &Entry,
     instance: &Instance,
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
+    textures: &mut HashMap<TextureHandle, TextureState>,
     surface_handle: SurfaceHandle,
 ) {
+    // Clean up any outstanding surface texture
+    if let Some(tex_handle) = surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
+    {
+        unregister_surface_texture(devices, textures, tex_handle);
+    }
+
     if let Some(surface_state) = surfaces.remove(&surface_handle) {
         if let Some(logical_device) = devices.get(&surface_state.device_handle) {
             unsafe {
@@ -392,12 +404,26 @@ pub(super) fn destroy(
 }
 
 /// Acquire the next swapchain image for rendering.
+///
+/// After acquiring, the swapchain image is registered in the bindless descriptor
+/// set as a storage image. The resulting `TextureHandle` is available via
+/// `frame_texture()` until `present()` is called.
 pub(super) fn acquire(
     instance: &Instance,
     devices: &mut HashMap<DeviceHandle, LogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
+    textures: &mut HashMap<TextureHandle, TextureState>,
+    next_texture_handle: &mut TextureHandle,
     surface_handle: SurfaceHandle,
 ) -> Result<SwapchainImageHandle> {
+    // Clean up any previously acquired surface texture that wasn't presented
+    if let Some(surface_state) = surfaces.get(&surface_handle) {
+        if let Some(tex_handle) = surface_state.current_texture_handle {
+            tracing::warn!("Previous surface texture was not presented; cleaning up");
+            unregister_surface_texture(devices, textures, tex_handle);
+        }
+    }
+
     // Get surface state and current frame index
     let (device_handle, _current_frame, swapchain, in_flight_fence, image_available_semaphore) = {
         let surface_state = surfaces
@@ -468,10 +494,35 @@ pub(super) fn acquire(
             // Update surface state
             let surface_state = surfaces.get_mut(&surface_handle).unwrap();
             surface_state.current_image_index = Some(image_index);
+
+            // Register the swapchain image as a storage texture for compute access.
+            // The image view is created for GENERAL layout so compute shaders can write
+            // via RWTexture2D in bindless.
+            let image = surface_state.swapchain_images[image_index as usize];
+            let width = surface_state.width;
+            let height = surface_state.height;
+            let vk_format = surface_state.format;
+            let goldy_format =
+                super::utils::vk_to_format(vk_format).unwrap_or(TextureFormat::Bgra8UnormSrgb);
+
+            let tex_handle = register_surface_texture(
+                devices,
+                textures,
+                next_texture_handle,
+                device_handle,
+                image,
+                vk_format,
+                goldy_format,
+                width,
+                height,
+            )?;
+
+            let surface_state = surfaces.get_mut(&surface_handle).unwrap();
+            surface_state.current_texture_handle = Some(tex_handle);
+
             Ok(image_index as SwapchainImageHandle)
         }
         Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
-            // Swapchain is out of date - caller should resize and retry
             tracing::info!("Swapchain out of date - resize required");
             anyhow::bail!("Surface out of date - call resize() and retry")
         }
@@ -483,6 +534,16 @@ pub(super) fn acquire(
             anyhow::bail!("Failed to acquire swapchain image: {:?}", e)
         }
     }
+}
+
+/// Get the texture handle for the currently acquired surface frame.
+pub(super) fn frame_texture(
+    surfaces: &HashMap<SurfaceHandle, SurfaceState>,
+    surface_handle: SurfaceHandle,
+) -> Option<TextureHandle> {
+    surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
 }
 
 /// Render commands to the surface's current swapchain image.
@@ -723,16 +784,30 @@ where
 }
 
 /// Present the rendered image to the screen.
+///
+/// Unregisters the transient surface texture from the bindless descriptor set,
+/// then queues the swapchain image for presentation.
 pub(super) fn present(
     instance: &Instance,
     devices: &mut HashMap<DeviceHandle, LogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
+    textures: &mut HashMap<TextureHandle, TextureState>,
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
 ) -> Result<()> {
+    // Unregister the transient surface texture before presenting
+    if let Some(tex_handle) = surfaces
+        .get(&surface_handle)
+        .and_then(|s| s.current_texture_handle)
+    {
+        unregister_surface_texture(devices, textures, tex_handle);
+    }
+
     let surface_state = surfaces
         .get_mut(&surface_handle)
         .context("Invalid surface handle")?;
+
+    surface_state.current_texture_handle = None;
 
     let image_index = surface_state
         .current_image_index
@@ -772,10 +847,7 @@ pub(super) fn present(
     // Handle suboptimal or out of date
     match result {
         Ok(_) => Ok(()),
-        Err(vk::Result::ERROR_OUT_OF_DATE_KHR) | Err(vk::Result::SUBOPTIMAL_KHR) => {
-            // TODO: Signal that resize is needed
-            Ok(())
-        }
+        Err(vk::Result::ERROR_OUT_OF_DATE_KHR) | Err(vk::Result::SUBOPTIMAL_KHR) => Ok(()),
         Err(e) => Err(anyhow::anyhow!("Failed to present: {:?}", e)),
     }
 }
@@ -865,7 +937,7 @@ pub(super) fn resize(
         .image_color_space(vk::ColorSpaceKHR::SRGB_NONLINEAR)
         .image_extent(extent)
         .image_array_layers(1)
-        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
+        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::STORAGE)
         .image_sharing_mode(vk::SharingMode::EXCLUSIVE)
         .pre_transform(capabilities.current_transform)
         .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
@@ -977,6 +1049,7 @@ pub(super) fn resize(
         surface_state.height = extent.height;
         surface_state.current_frame = 0;
         surface_state.current_image_index = None;
+        surface_state.current_texture_handle = None;
         surface_state.depth_image = new_depth_image;
         surface_state.depth_memory = new_depth_memory;
         surface_state.depth_view = new_depth_view;
@@ -1006,4 +1079,137 @@ pub(super) fn format(
         .get(&surface_handle)
         .and_then(|s| super::utils::vk_to_format(s.format))
         .unwrap_or(TextureFormat::Bgra8UnormSrgb) // Safe fallback
+}
+
+// ---------------------------------------------------------------------------
+// Transient surface texture registration
+// ---------------------------------------------------------------------------
+// These functions register/unregister swapchain images in the global bindless
+// descriptor set so that compute shaders can write to them via RWTexture2D.
+// The image view and descriptor are created on acquire and torn down on present.
+// The underlying VkImage is owned by the swapchain — we must NOT destroy it.
+
+/// Register a swapchain image as a transient storage texture.
+///
+/// Creates a VkImageView with GENERAL layout intent and writes a storage-image
+/// descriptor into the bindless set. Returns a TextureHandle that the caller
+/// stores in `SurfaceState::current_texture_handle`.
+#[allow(clippy::too_many_arguments)]
+fn register_surface_texture(
+    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    textures: &mut HashMap<TextureHandle, TextureState>,
+    next_texture_handle: &mut TextureHandle,
+    device_handle: DeviceHandle,
+    image: vk::Image,
+    vk_format: vk::Format,
+    goldy_format: TextureFormat,
+    width: u32,
+    height: u32,
+) -> Result<TextureHandle> {
+    let handle = *next_texture_handle;
+    *next_texture_handle += 1;
+
+    let logical_device = devices
+        .get_mut(&device_handle)
+        .context("Device no longer valid")?;
+
+    // Create an image view for compute storage access
+    let view_info = vk::ImageViewCreateInfo::default()
+        .image(image)
+        .view_type(vk::ImageViewType::TYPE_2D)
+        .format(vk_format)
+        .subresource_range(vk::ImageSubresourceRange {
+            aspect_mask: vk::ImageAspectFlags::COLOR,
+            base_mip_level: 0,
+            level_count: 1,
+            base_array_layer: 0,
+            layer_count: 1,
+        });
+
+    let view = unsafe { logical_device.device.create_image_view(&view_info, None) }
+        .context("Failed to create surface texture image view")?;
+
+    // Register as a storage image in the bindless descriptor set
+    let is_storage_image = true;
+    let bindless_index = logical_device
+        .resource_registry
+        .register_texture(handle, is_storage_image);
+
+    // Write the storage-image descriptor
+    if let Some(descriptor_set) = logical_device.bindless_descriptor_set {
+        let image_info = vk::DescriptorImageInfo::default()
+            .image_view(view)
+            .image_layout(vk::ImageLayout::GENERAL);
+
+        let write = vk::WriteDescriptorSet::default()
+            .dst_set(descriptor_set)
+            .dst_binding(types::bindless_bindings::STORAGE_IMAGES)
+            .dst_array_element(bindless_index)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .image_info(std::slice::from_ref(&image_info));
+
+        unsafe {
+            logical_device
+                .device
+                .update_descriptor_sets(std::slice::from_ref(&write), &[]);
+        }
+
+        tracing::trace!(
+            "Registered surface texture {} at storage image bindless index {}",
+            handle,
+            bindless_index,
+        );
+    }
+
+    textures.insert(
+        handle,
+        TextureState {
+            device_handle,
+            width,
+            height,
+            format: goldy_format,
+            image,
+            // Swapchain images don't have separately allocated memory — null sentinel
+            memory: vk::DeviceMemory::null(),
+            view,
+            staging_buffer: None,
+            staging_memory: None,
+            bindless_index: Some(bindless_index),
+            current_layout: vk::ImageLayout::GENERAL,
+        },
+    );
+
+    tracing::debug!(
+        "Registered surface texture {} ({}x{}, bindless={})",
+        handle,
+        width,
+        height,
+        bindless_index,
+    );
+
+    Ok(handle)
+}
+
+/// Unregister a transient surface texture.
+///
+/// Removes the TextureState, destroys the image view, and unregisters from
+/// the bindless resource registry. Does NOT destroy the VkImage (owned by the
+/// swapchain).
+fn unregister_surface_texture(
+    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    textures: &mut HashMap<TextureHandle, TextureState>,
+    tex_handle: TextureHandle,
+) {
+    if let Some(tex_state) = textures.remove(&tex_handle) {
+        if let Some(device) = devices.get_mut(&tex_state.device_handle) {
+            device.resource_registry.unregister_texture(tex_handle);
+
+            // Destroy the image view we created in register_surface_texture.
+            // The VkImage itself belongs to the swapchain — do NOT destroy it.
+            unsafe {
+                device.device.destroy_image_view(tex_state.view, None);
+            }
+        }
+        tracing::debug!("Unregistered surface texture {}", tex_handle);
+    }
 }

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -266,6 +266,11 @@ pub(crate) struct PipelineState {
     /// ParameterBlock layouts from shader reflection (for bindless rendering)
     #[allow(dead_code)]
     pub parameter_block_layouts: Vec<crate::slang::ParameterBlockLayout>,
+    /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
+    /// calls in the bound shader(s). Empty disables validation.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    pub shader_debug_name: String,
 }
 
 /// Compute pipeline state.
@@ -278,6 +283,11 @@ pub(crate) struct ComputePipelineState {
     /// ParameterBlock layouts from shader reflection (for bindless rendering)
     #[allow(dead_code)]
     pub parameter_block_layouts: Vec<crate::slang::ParameterBlockLayout>,
+    /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
+    /// calls in the bound compute shader. Empty disables validation.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Human-readable identifier used in category-mismatch error messages.
+    pub shader_debug_name: String,
 }
 
 /// GPU render target state with optional staging for CPU readback.

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -363,6 +363,10 @@ pub(crate) struct SurfaceState {
     pub current_image_index: Option<u32>,
     /// Per-frame synchronization resources
     pub frame_sync: Vec<FrameSync>,
+    /// Transient texture handle for the currently acquired swapchain image,
+    /// registered in the bindless descriptor set as a storage image so compute
+    /// shaders can write directly to the swapchain image.
+    pub current_texture_handle: Option<super::TextureHandle>,
 }
 
 /// Pending buffer operations for command recording.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,7 +2,7 @@
 
 use crate::backend::{BufferHandle, GpuBackend};
 use crate::device::Device;
-use crate::types::DataAccess;
+use crate::types::{BindlessCategory, BindlessHandle, DataAccess};
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
@@ -143,9 +143,37 @@ impl Buffer {
     ///
     /// Returns `Some(index)` if this buffer is registered in the global descriptor set.
     /// All buffers with Scattered or Broadcast access are registered.
+    ///
+    /// **Prefer [`Buffer::bindless_handle`]** for new code: the typed handle
+    /// captures the buffer's [`DataAccess`] category so push-constant setters
+    /// can catch category mismatches (e.g. binding a `Broadcast` buffer to a
+    /// slot read via `goldy_dyn_buf_ro`) at dispatch time instead of silently
+    /// producing garbage reads.
     pub fn bindless_index(&self) -> Option<u32> {
         let backend = self.backend.lock().unwrap();
         backend.buffer_bindless_index(self.handle)
+    }
+
+    /// Get this buffer's typed bindless descriptor handle.
+    ///
+    /// The returned handle carries both the raw u32 index and the
+    /// [`BindlessCategory`] implied by the buffer's [`DataAccess`]:
+    /// `Scattered` → [`BindlessCategory::Scattered`],
+    /// `Broadcast` → [`BindlessCategory::Broadcast`].
+    pub fn bindless_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::from(self.access), i))
+    }
+
+    /// Get this buffer's typed bindless handle for read-only structured-buffer
+    /// access (maps to `goldy_dyn_buf_ro` / `StructuredBuffer<T>`).
+    ///
+    /// Uses the SRV index on DX12, which may differ from the UAV index.
+    /// Always returns a [`BindlessCategory::Scattered`] handle since
+    /// `goldy_dyn_buf_ro` reads from the storage-buffer pool on every backend.
+    pub fn bindless_srv_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_srv_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::Scattered, i))
     }
 
     /// Get the buffer's SRV (read-only) bindless index for `StructuredBuffer<T>` / `goldy_dyn_buf_ro` access.
@@ -267,10 +295,27 @@ impl BufferView {
         backend.buffer_bindless_index(self.handle)
     }
 
+    /// Get the view's typed bindless handle.
+    ///
+    /// Views are always created on top of `DataAccess::Scattered` backing storage
+    /// (the only access pattern for which sub-ranges make sense), so the handle
+    /// is always tagged [`BindlessCategory::Scattered`].
+    pub fn bindless_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::Scattered, i))
+    }
+
     /// Get the view's SRV (read-only) bindless index.
     pub fn bindless_srv_index(&self) -> Option<u32> {
         let backend = self.backend.lock().unwrap();
         backend.buffer_bindless_srv_index(self.handle)
+    }
+
+    /// Get the view's typed bindless handle for read-only structured-buffer
+    /// access (same as `goldy_dyn_buf_ro`, [`BindlessCategory::Scattered`]).
+    pub fn bindless_srv_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_srv_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::Scattered, i))
     }
 
     /// Get the handle of the backing buffer that owns this view's memory.

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -4,6 +4,7 @@ use crate::backend::{ComputeCommand, ComputePipelineHandle, GpuBackend};
 use crate::buffer::Buffer;
 use crate::device::Device;
 use crate::shader::ShaderModule;
+use crate::types::BindlessHandle;
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
@@ -181,8 +182,10 @@ impl<'a> ComputePass<'a> {
 
     /// Set push constants with raw u32 indices (for textures/samplers or mixed resources).
     ///
-    /// Use this when you need to pass texture/sampler bindless indices or a mix of
-    /// buffer and texture indices. The shader receives these indices directly.
+    /// **Prefer [`ComputePass::set_push_constants_typed`]** for new code — the
+    /// raw form skips per-slot category validation, so binding a uniform-buffer
+    /// index into a slot the shader reads via `goldy_dyn_buf_ro` will silently
+    /// produce garbage reads rather than erroring at dispatch time.
     ///
     /// # Example
     /// ```ignore
@@ -194,6 +197,33 @@ impl<'a> ComputePass<'a> {
             .commands
             .push(ComputeCommand::SetPushConstantsRaw {
                 indices: indices.to_vec(),
+            });
+    }
+
+    /// Set push constants from typed [`BindlessHandle`]s.
+    ///
+    /// Each handle carries both the raw index and the resource's
+    /// [`crate::types::BindlessCategory`]. At dispatch time
+    /// the backend cross-checks these against the bound shader's reflection
+    /// and returns an error if any slot's category disagrees with how the
+    /// shader reads it (e.g. binding a
+    /// [`BindlessCategory::Broadcast`](crate::types::BindlessCategory::Broadcast)
+    /// handle to a slot accessed via `goldy_dyn_buf_ro`, which reads the
+    /// storage-buffer pool). When the shader provides no expectation for a slot
+    /// (e.g. computed slot indices that regex analysis can't resolve),
+    /// validation is skipped for that slot.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let uniforms = uniform_buf.bindless_handle().unwrap();    // Broadcast
+    /// let output  = output_tex.bindless_handle().unwrap();      // StorageImage
+    /// pass.set_push_constants_typed(&[uniforms, output]);
+    /// ```
+    pub fn set_push_constants_typed(&mut self, handles: &[BindlessHandle]) {
+        self.encoder
+            .commands
+            .push(ComputeCommand::SetPushConstantsTyped {
+                handles: handles.to_vec(),
             });
     }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3,7 +3,7 @@
 use crate::backend::RenderCommand;
 use crate::buffer::{Buffer, BufferSource};
 use crate::pipeline::RenderPipeline;
-use crate::types::{Color, IndexFormat};
+use crate::types::{BindlessHandle, Color, IndexFormat};
 
 /// Command encoder for recording GPU commands.
 ///
@@ -121,8 +121,8 @@ impl<'a> RenderPass<'a> {
 
     /// Set push constants with raw u32 indices.
     ///
-    /// Use this for textures and samplers, or when you already have the resource indices.
-    /// The indices are pushed in order to the shader's push/root constants.
+    /// **Prefer [`RenderPass::set_push_constants_typed`]** for new code — the
+    /// raw form bypasses per-slot category validation.
     ///
     /// # Example
     /// ```ignore
@@ -136,6 +136,27 @@ impl<'a> RenderPass<'a> {
             .commands
             .push(RenderCommand::SetPushConstantsRaw {
                 indices: indices.to_vec(),
+            });
+    }
+
+    /// Set push constants from typed [`BindlessHandle`]s.
+    ///
+    /// Each handle carries both the raw index and the
+    /// [`crate::types::BindlessCategory`] implied by the
+    /// resource. At dispatch time the backend validates each slot against the
+    /// bound shader's reflection and returns an error on mismatch.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let tex = texture.bindless_handle().unwrap();  // Texture
+    /// let samp = sampler.bindless_handle().unwrap(); // Sampler
+    /// pass.set_push_constants_typed(&[tex, samp]);
+    /// ```
+    pub fn set_push_constants_typed(&mut self, handles: &[BindlessHandle]) {
+        self.encoder
+            .commands
+            .push(RenderCommand::SetPushConstantsTyped {
+                handles: handles.to_vec(),
             });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub use slang::{layout_validation_enabled, LayoutCheck, StructFieldLayout, Struc
 pub use surface::{Surface, SurfaceFrame};
 pub use texture::Texture;
 pub use types::*;
+pub use types::{PresentMode, SurfaceConfig};
 
 #[cfg(all(feature = "dx12", target_os = "windows"))]
 pub use backend::dx12::WARP_ADAPTER_ID;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,7 +5,7 @@
 
 use crate::backend::{GpuBackend, SamplerHandle};
 use crate::device::Device;
-use crate::types::SamplerDesc;
+use crate::types::{BindlessCategory, BindlessHandle, SamplerDesc};
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
@@ -132,9 +132,20 @@ impl Sampler {
     ///
     /// Returns `Some(index)` if this sampler is registered.
     /// Returns `None` otherwise.
+    ///
+    /// **Prefer [`Sampler::bindless_handle`]** for new code; the typed handle
+    /// lets push-constant setters validate that a slot expected to be a sampler
+    /// (via `goldy_dyn_filter`) is actually bound to a `Sampler`.
     pub fn bindless_index(&self) -> Option<u32> {
         let backend = self.backend.lock().unwrap();
         backend.sampler_bindless_index(self.handle)
+    }
+
+    /// Get this sampler's typed bindless handle
+    /// ([`BindlessCategory::Sampler`]).
+    pub fn bindless_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::Sampler, i))
     }
 }
 

--- a/src/slang/compiler.rs
+++ b/src/slang/compiler.rs
@@ -81,11 +81,167 @@ pub struct ParameterBlockLayout {
     pub fields: Vec<FieldLayout>,
 }
 
+/// Scan Slang source for `goldy_dyn_*(N)` calls with literal integer slot
+/// arguments and build a per-slot vector of the
+/// [`crate::types::BindlessCategory`] the shader expects at
+/// each push-constant slot. Slots accessed via dynamic/computed indices (e.g.
+/// `goldy_dyn_scattered(i)`) are left as `None`.
+///
+/// Multiple categories for the same slot are treated as a conflict and collapse
+/// to `None` so the error surface is the `SetPushConstantsTyped` validator,
+/// which can produce a context-rich diagnostic rather than a shader-load
+/// failure.
+///
+/// Comments and preprocessor-disabled blocks are not stripped; this is a
+/// best-effort conservative heuristic. False positives (a category inferred
+/// for a slot the user no longer uses) only constrain what handle type the
+/// user can bind — the user's recourse is to update the shader or bind the
+/// right handle type. False negatives (slot left as `None`) silently fall back
+/// to no validation for that slot, matching pre-reflection behavior.
+pub fn analyze_push_constant_categories_from_source(
+    source: &str,
+) -> Vec<Option<crate::types::BindlessCategory>> {
+    use crate::types::BindlessCategory;
+
+    // Function name -> category it reads at the nth push-constant slot.
+    // Keep in sync with `shaders/goldy_exp/access.slang` — this list MUST
+    // match the public `goldy_dyn_*` surface exactly.
+    const DYN_FUNCS: &[(&str, BindlessCategory)] = &[
+        ("goldy_dyn_scattered", BindlessCategory::Scattered),
+        ("goldy_dyn_buf_ro", BindlessCategory::Scattered),
+        ("goldy_dyn_byte_address", BindlessCategory::Scattered),
+        ("goldy_dyn_broadcast", BindlessCategory::Broadcast),
+        ("goldy_dyn_direct_spatial", BindlessCategory::StorageImage),
+        ("goldy_dyn_interpolated", BindlessCategory::Texture),
+        ("goldy_dyn_filter", BindlessCategory::Sampler),
+    ];
+
+    // Observed category per slot; `Conflict` means ≥ 2 incompatible categories.
+    #[derive(Copy, Clone, PartialEq)]
+    enum Slot {
+        Unknown,
+        One(BindlessCategory),
+        Conflict,
+    }
+    let mut slots = [Slot::Unknown; 16];
+
+    for (fn_name, category) in DYN_FUNCS {
+        let mut search_from = 0usize;
+        while let Some(rel) = source[search_from..].find(fn_name) {
+            let abs = search_from + rel;
+            search_from = abs + fn_name.len();
+
+            // Require a word boundary before the match so `goldy_dyn_scattered`
+            // doesn't trigger on `__goldy_dyn_scattered_impl`.
+            if abs > 0 {
+                let prev = source.as_bytes()[abs - 1];
+                if prev.is_ascii_alphanumeric() || prev == b'_' {
+                    continue;
+                }
+            }
+
+            // Skip an optional `<...>` generic argument list.
+            let mut cursor = search_from;
+            let bytes = source.as_bytes();
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            if cursor < bytes.len() && bytes[cursor] == b'<' {
+                let mut depth = 1i32;
+                cursor += 1;
+                while cursor < bytes.len() && depth > 0 {
+                    match bytes[cursor] {
+                        b'<' => depth += 1,
+                        b'>' => depth -= 1,
+                        _ => {}
+                    }
+                    cursor += 1;
+                }
+            }
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+
+            // Expect `(` then a decimal literal then `)` (or `,`/whitespace
+            // before `)`). Anything else -> unresolvable, leave slot unknown.
+            if cursor >= bytes.len() || bytes[cursor] != b'(' {
+                continue;
+            }
+            cursor += 1;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            let num_start = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            if cursor == num_start {
+                continue;
+            }
+            // Only accept a clean `N)` or `N )` — anything else (identifiers,
+            // arithmetic, casts) leaves the slot unknown on purpose.
+            let mut end = cursor;
+            while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                end += 1;
+            }
+            if end >= bytes.len() || (bytes[end] != b')' && bytes[end] != b'u') {
+                continue;
+            }
+            // Accept `Nu` / `N u` (Slang unsigned suffix) -> must then close.
+            if bytes[end] == b'u' {
+                end += 1;
+                while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                    end += 1;
+                }
+                if end >= bytes.len() || bytes[end] != b')' {
+                    continue;
+                }
+            }
+
+            let Ok(n) = source[num_start..cursor].parse::<usize>() else {
+                continue;
+            };
+            if n >= slots.len() {
+                continue;
+            }
+            slots[n] = match slots[n] {
+                Slot::Unknown => Slot::One(*category),
+                Slot::One(prev) if prev.is_compatible_with(*category) => Slot::One(prev),
+                _ => Slot::Conflict,
+            };
+        }
+    }
+
+    // Trim trailing Unknown slots so short shaders don't carry 16-long vectors.
+    let mut last_known = 0usize;
+    for (i, s) in slots.iter().enumerate() {
+        if !matches!(s, Slot::Unknown) {
+            last_known = i + 1;
+        }
+    }
+    slots[..last_known]
+        .iter()
+        .map(|s| match s {
+            Slot::One(c) => Some(*c),
+            Slot::Unknown | Slot::Conflict => None,
+        })
+        .collect()
+}
+
 /// Complete reflection information for a compiled shader
 #[derive(Debug, Clone, Default)]
 pub struct ShaderReflection {
     /// All parameter blocks found in the shader
     pub parameter_blocks: Vec<ParameterBlockLayout>,
+    /// Per push-constant slot (index = slot number), the
+    /// [`crate::types::BindlessCategory`] the shader reads
+    /// that slot as, or `None` if reflection couldn't infer it (e.g. the slot
+    /// was only accessed via a dynamic index). Populated by source-level
+    /// analysis of `goldy_dyn_*(N)` calls in the Slang source; may be sparse
+    /// up to `MAX_PUSH_CONSTANT_INDICES`. Used by
+    /// [`crate::types::BindlessHandle`]-typed push-constant setters to catch
+    /// category mismatches at dispatch time.
+    pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
 }
 
 /// Byte layout of a Slang `struct` under uniform / constant-buffer rules (`SlangLayoutRules::Default`).
@@ -607,7 +763,9 @@ impl SlangCompiler {
                 let data = unsafe { std::slice::from_raw_parts(data_ptr, data_size) }.to_vec();
                 unsafe { blob_release(blob) };
 
-                let reflection = slf.extract_reflection(request)?;
+                let mut reflection = slf.extract_reflection(request)?;
+                reflection.push_constant_categories =
+                    analyze_push_constant_categories_from_source(source);
 
                 if !layout_checks.is_empty() {
                     slf.validate_owned_layout_checks(request, layout_checks)?;
@@ -834,7 +992,10 @@ impl SlangCompiler {
                 .sum::<usize>()
         );
 
-        Ok(ShaderReflection { parameter_blocks })
+        Ok(ShaderReflection {
+            parameter_blocks,
+            push_constant_categories: Vec::new(),
+        })
     }
 
     /// Extract layout information for a ParameterBlock.
@@ -1303,5 +1464,114 @@ impl Drop for SlangCompiler {
         if !self.global_session.is_null() {
             unsafe { global_session_release(self.global_session) };
         }
+    }
+}
+
+#[cfg(test)]
+mod push_constant_source_analysis_tests {
+    use super::analyze_push_constant_categories_from_source;
+    use crate::types::BindlessCategory;
+
+    #[test]
+    fn single_scattered_slot() {
+        let src = "StorageBuffer<uint> b = goldy_dyn_scattered<uint>(0);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert_eq!(cats, vec![Some(BindlessCategory::Scattered)]);
+    }
+
+    #[test]
+    fn mixed_broadcast_and_scattered() {
+        let src = r#"
+            MyUniforms u = goldy_dyn_broadcast<MyUniforms>(0);
+            StorageBuffer<int> b = goldy_dyn_scattered<int>(2);
+        "#;
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert_eq!(
+            cats,
+            vec![
+                Some(BindlessCategory::Broadcast),
+                None,
+                Some(BindlessCategory::Scattered),
+            ]
+        );
+    }
+
+    #[test]
+    fn buf_ro_maps_to_scattered() {
+        let src = "ReadOnlyBuffer<Particle> p = goldy_dyn_buf_ro<Particle>(1);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert_eq!(cats, vec![None, Some(BindlessCategory::Scattered)]);
+    }
+
+    #[test]
+    fn storage_image_and_texture_and_sampler() {
+        let src = r#"
+            RWTexture2D<float4> img = goldy_dyn_direct_spatial<float4>(0);
+            Texture2D<float4> tex = goldy_dyn_interpolated<float4>(1);
+            SamplerState s = goldy_dyn_filter(2);
+        "#;
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert_eq!(
+            cats,
+            vec![
+                Some(BindlessCategory::StorageImage),
+                Some(BindlessCategory::Texture),
+                Some(BindlessCategory::Sampler),
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_index_leaves_slot_unknown() {
+        // `i` is not a literal — we must not report a category.
+        let src = "StorageBuffer<uint> b = goldy_dyn_scattered<uint>(i);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert!(cats.is_empty());
+    }
+
+    #[test]
+    fn conflicting_uses_collapse_to_none() {
+        let src = r#"
+            MyUniforms u = goldy_dyn_broadcast<MyUniforms>(0);
+            StorageBuffer<int> b = goldy_dyn_scattered<int>(0);
+        "#;
+        let cats = analyze_push_constant_categories_from_source(src);
+        // Slot 0 saw conflicting categories; forced to None so the dispatch-time
+        // validator reports a clean error instead of a stale expectation.
+        assert_eq!(cats, vec![None]);
+    }
+
+    #[test]
+    fn slot_suffixed_with_u_is_accepted() {
+        let src = "let x = goldy_dyn_broadcast<MyUniforms>(3u).time;";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert_eq!(
+            cats,
+            vec![None, None, None, Some(BindlessCategory::Broadcast)]
+        );
+    }
+
+    #[test]
+    fn word_boundary_prevents_prefix_match() {
+        // A hypothetical wrapper shouldn't be counted as `goldy_dyn_scattered`.
+        let src = "StorageBuffer<uint> b = __my_goldy_dyn_scattered<uint>(0);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert!(cats.is_empty());
+    }
+
+    #[test]
+    fn slot_above_16_is_ignored() {
+        let src = "let b = goldy_dyn_scattered<uint>(99);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        assert!(cats.is_empty());
+    }
+
+    #[test]
+    fn trims_trailing_unknown_slots() {
+        let src = "let u = goldy_dyn_broadcast<MyUniforms>(2);";
+        let cats = analyze_push_constant_categories_from_source(src);
+        // 3 slots total: None, None, Some(Broadcast) — nothing after 2.
+        assert_eq!(cats.len(), 3);
+        assert_eq!(cats[2], Some(BindlessCategory::Broadcast));
     }
 }

--- a/src/slang/mod.rs
+++ b/src/slang/mod.rs
@@ -45,8 +45,8 @@ pub mod ffi;
 pub mod loader;
 
 pub use compiler::{
-    layout_validation_enabled, CompiledShader, CompiledShaderWithReflection, FieldLayout,
-    LayoutCheck, OwnedLayoutCheck, ParameterBlockLayout, ResourceKind, ShaderReflection,
-    ShaderTarget, SlangCompiler, StructFieldLayout, StructLayout,
+    analyze_push_constant_categories_from_source, layout_validation_enabled, CompiledShader,
+    CompiledShaderWithReflection, FieldLayout, LayoutCheck, OwnedLayoutCheck, ParameterBlockLayout,
+    ResourceKind, ShaderReflection, ShaderTarget, SlangCompiler, StructFieldLayout, StructLayout,
 };
 pub use ffi::SlangStage;

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -3,7 +3,7 @@
 //! This module provides zero-copy GPU presentation to windows.
 //! Use `Surface` to render directly to a window without CPU readback.
 //!
-//! # Example
+//! # Render-command path (graphics pipelines)
 //!
 //! ```rust,no_run
 //! use goldy::{Instance, DeviceType, Surface, TextureFormat, CommandEncoder, Color};
@@ -25,15 +25,26 @@
 //! }
 //!
 //! frame.render(encoder)?;
-//! surface.present(frame)?;
+//! frame.present()?;
 //! # Ok(())
 //! # }
+//! ```
+//!
+//! # Compute path (e.g. Ekrano)
+//!
+//! ```rust,no_run,ignore
+//! let frame = surface.acquire()?;
+//! // frame.texture() returns the swapchain image as a Texture that can be
+//! // used with compute passes, the compute graph, or render_to_texture.
+//! renderer.render_to_texture(&device, &scene, frame.texture(), &params)?;
+//! frame.present()?;
 //! ```
 
 use crate::backend::{GpuBackend, SurfaceHandle, SwapchainImageHandle};
 use crate::device::Device;
 use crate::encoder::CommandEncoder;
-use crate::types::TextureFormat;
+use crate::texture::Texture;
+use crate::types::{PresentMode, SurfaceConfig, TextureFormat};
 use anyhow::Result;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::sync::{Arc, Mutex};
@@ -52,41 +63,34 @@ pub struct Surface {
 
 /// A frame acquired from a surface, ready for rendering.
 ///
-/// When you're done rendering to this frame, call `Surface::present()`
-/// to display it.
+/// After acquiring a frame, you can either:
+/// - Use `render()` to execute render commands (graphics pipeline path)
+/// - Use `texture()` to get the frame's texture for compute or external rendering
+///
+/// When done, call `present()` to display the frame. Dropping without
+/// presenting will clean up resources but the frame won't be shown.
 pub struct SurfaceFrame {
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     surface_handle: SurfaceHandle,
     image_handle: SwapchainImageHandle,
+    texture: Option<Texture>,
     width: u32,
     height: u32,
+    presented: bool,
 }
 
 impl Surface {
     /// Create a new surface for the given window.
     ///
-    /// # Arguments
-    ///
-    /// * `device` - The GPU device to use for rendering
-    /// * `window` - The window to present to (must implement `HasWindowHandle + HasDisplayHandle`)
-    ///
-    /// # Platform Support
-    ///
-    /// - **Windows**: Uses `VK_KHR_win32_surface`
-    /// - **Linux**: Uses `VK_KHR_wayland_surface` (X11 not supported)
-    /// - **macOS**: Uses native Metal with `CAMetalLayer`
+    /// Uses default configuration (Auto present mode, no depth buffer).
     pub fn new<W>(device: &Device, window: &W) -> Result<Self>
     where
         W: HasWindowHandle + HasDisplayHandle,
     {
-        Self::new_with_depth(device, window, None)
+        Self::new_with_config(device, window, SurfaceConfig::default())
     }
 
     /// Create a new surface with an optional depth buffer for 3D rendering.
-    ///
-    /// When `depth_format` is `Some`, a depth buffer is created and depth testing
-    /// is enabled for pipelines that specify `depth_stencil`. Use this for 3D games
-    /// (e.g. DOOM) that require correct occlusion.
     pub fn new_with_depth<W>(
         device: &Device,
         window: &W,
@@ -95,9 +99,24 @@ impl Surface {
     where
         W: HasWindowHandle + HasDisplayHandle,
     {
+        Self::new_with_config(
+            device,
+            window,
+            SurfaceConfig {
+                depth_format,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Create a new surface with full configuration.
+    pub fn new_with_config<W>(device: &Device, window: &W, config: SurfaceConfig) -> Result<Self>
+    where
+        W: HasWindowHandle + HasDisplayHandle,
+    {
         let handle = {
             let mut backend = device.backend.lock().unwrap();
-            backend.create_surface(device.handle, window, window, depth_format)?
+            backend.create_surface(device.handle, window, window, config.depth_format)?
         };
 
         let (width, height) = {
@@ -105,7 +124,19 @@ impl Surface {
             backend.surface_size(handle)
         };
 
-        tracing::debug!(width, height, ?depth_format, "Surface created");
+        // Apply present mode if non-default
+        if config.present_mode != PresentMode::Auto {
+            let mut backend = device.backend.lock().unwrap();
+            backend.surface_set_present_mode(handle, config.present_mode)?;
+        }
+
+        tracing::debug!(
+            width,
+            height,
+            ?config.depth_format,
+            ?config.present_mode,
+            "Surface created"
+        );
 
         Ok(Self {
             backend: Arc::clone(&device.backend),
@@ -118,29 +149,48 @@ impl Surface {
     /// Acquire the next frame to render to.
     ///
     /// This blocks until a frame is available from the swapchain.
-    /// The returned `SurfaceFrame` can be rendered to and then presented.
+    /// The returned `SurfaceFrame` exposes the frame's texture and must
+    /// be presented (or dropped) before acquiring the next frame.
     pub fn acquire(&self) -> Result<SurfaceFrame> {
-        let image_handle = {
+        let (image_handle, texture) = {
             let mut backend = self.backend.lock().unwrap();
-            backend.surface_acquire(self.handle)?
+            let image_handle = backend.surface_acquire(self.handle)?;
+
+            let (w, h) = backend.surface_size(self.handle);
+            let format = backend.surface_format(self.handle);
+
+            let texture = backend
+                .surface_frame_texture(self.handle)
+                .map(|tex_handle| {
+                    Texture::borrowed(Arc::clone(&self.backend), tex_handle, w, h, format)
+                });
+
+            (image_handle, texture)
+        };
+
+        // Update cached dimensions from the backend (may change after resize)
+        let (w, h) = {
+            let backend = self.backend.lock().unwrap();
+            backend.surface_size(self.handle)
         };
 
         Ok(SurfaceFrame {
             backend: Arc::clone(&self.backend),
             surface_handle: self.handle,
             image_handle,
-            width: self.width,
-            height: self.height,
+            texture,
+            width: w,
+            height: h,
+            presented: false,
         })
     }
 
-    /// Present a rendered frame to the screen.
+    /// Present a rendered frame to the screen (legacy API).
     ///
-    /// This submits the frame to be displayed and returns immediately.
-    /// The actual display may happen asynchronously depending on vsync settings.
-    pub fn present(&self, frame: SurfaceFrame) -> Result<()> {
-        let mut backend = self.backend.lock().unwrap();
-        backend.surface_present(frame.surface_handle, frame.image_handle)
+    /// Prefer using `frame.present()` instead, which consumes the frame
+    /// and provides better ergonomics.
+    pub fn present(&self, mut frame: SurfaceFrame) -> Result<()> {
+        frame.do_present()
     }
 
     /// Resize the surface.
@@ -179,41 +229,24 @@ impl Surface {
     }
 
     /// Get the swapchain texture format.
-    ///
-    /// Use this to set `RenderPipelineDesc::target_format` when rendering
-    /// to this surface. The format is determined by the GPU and display
-    /// during surface creation.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use goldy::{Surface, RenderPipelineDesc};
-    /// # fn example(surface: &Surface) {
-    /// let desc = RenderPipelineDesc {
-    ///     target_format: surface.format(),
-    ///     ..Default::default()
-    /// };
-    /// # }
-    /// ```
     pub fn format(&self) -> TextureFormat {
         let backend = self.backend.lock().unwrap();
         backend.surface_format(self.handle)
     }
 
+    /// Set the present mode (vsync strategy).
+    pub fn set_present_mode(&mut self, mode: PresentMode) -> Result<()> {
+        let mut backend = self.backend.lock().unwrap();
+        backend.surface_set_present_mode(self.handle, mode)
+    }
+
+    /// Get the current present mode.
+    pub fn present_mode(&self) -> PresentMode {
+        let backend = self.backend.lock().unwrap();
+        backend.surface_present_mode(self.handle)
+    }
+
     /// Validate that a pipeline is compatible with this surface.
-    ///
-    /// Returns `Ok(())` if the pipeline's target format matches the surface format,
-    /// or an error with a helpful message if they don't match.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use goldy::{Surface, RenderPipelineDesc, TextureFormat};
-    /// # fn example(surface: &Surface, desc: &RenderPipelineDesc) -> anyhow::Result<()> {
-    /// surface.validate_pipeline_format(desc.target_format)?;
-    /// # Ok(())
-    /// # }
-    /// ```
     pub fn validate_pipeline_format(&self, pipeline_format: TextureFormat) -> Result<()> {
         let surface_format = self.format();
         if pipeline_format != surface_format {
@@ -241,7 +274,19 @@ impl Drop for Surface {
 }
 
 impl SurfaceFrame {
-    /// Render commands to this frame.
+    /// Get the frame's texture for rendering.
+    ///
+    /// The returned texture is the swapchain image, registered for bindless
+    /// access. You can pass it to compute shaders, the compute graph, or
+    /// `render_to_texture`. Call `present()` when done.
+    ///
+    /// Returns `None` if the backend does not support exposing the frame
+    /// texture (e.g. Vulkan/DX12 — not yet implemented).
+    pub fn texture(&self) -> Option<&Texture> {
+        self.texture.as_ref()
+    }
+
+    /// Render commands to this frame (graphics pipeline path).
     ///
     /// This executes the commands recorded in the encoder to the swapchain image.
     pub fn render(&self, encoder: CommandEncoder) -> Result<()> {
@@ -249,6 +294,27 @@ impl SurfaceFrame {
 
         let mut backend = self.backend.lock().unwrap();
         backend.surface_render(self.surface_handle, self.image_handle, &commands)
+    }
+
+    /// Present this frame to the display.
+    ///
+    /// Consumes the frame — the borrow checker prevents use-after-present.
+    pub fn present(mut self) -> Result<()> {
+        self.do_present()
+    }
+
+    fn do_present(&mut self) -> Result<()> {
+        if self.presented {
+            return Ok(());
+        }
+        self.presented = true;
+
+        // Drop the borrowed texture before presenting so it isn't accessed
+        // after the drawable is returned to the layer.
+        self.texture = None;
+
+        let mut backend = self.backend.lock().unwrap();
+        backend.surface_present(self.surface_handle, self.image_handle)
     }
 
     /// Get the frame width.
@@ -259,6 +325,15 @@ impl SurfaceFrame {
     /// Get the frame height.
     pub fn height(&self) -> u32 {
         self.height
+    }
+}
+
+impl Drop for SurfaceFrame {
+    fn drop(&mut self) {
+        if !self.presented {
+            // Frame was dropped without present — clean up the acquired drawable
+            let _ = self.do_present();
+        }
     }
 }
 
@@ -340,7 +415,6 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let surface = Surface::new(&device, &window).unwrap();
 
-        // Default mock format is Bgra8UnormSrgb
         assert_eq!(surface.format(), TextureFormat::Bgra8UnormSrgb);
     }
 
@@ -350,7 +424,6 @@ mod tests {
 
         let device = create_test_device();
         let window = MockWindow::new(800, 600);
-        // Surface with depth buffer for 3D rendering (e.g. DOOM)
         let surface =
             Surface::new_with_depth(&device, &window, Some(DepthFormat::Depth24Plus)).unwrap();
 
@@ -373,7 +446,6 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let mut surface = Surface::new(&device, &window).unwrap();
 
-        // Resize to new dimensions
         surface.resize(1920, 1080).unwrap();
 
         assert_eq!(surface.width(), 1920);
@@ -387,10 +459,8 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let mut surface = Surface::new(&device, &window).unwrap();
 
-        // Resize to zero (minimized window) should be ignored
         surface.resize(0, 0).unwrap();
 
-        // Dimensions should remain unchanged
         assert_eq!(surface.width(), 800);
         assert_eq!(surface.height(), 600);
     }
@@ -403,7 +473,6 @@ mod tests {
 
         surface.resize(0, 600).unwrap();
 
-        // Dimensions should remain unchanged
         assert_eq!(surface.width(), 800);
         assert_eq!(surface.height(), 600);
     }
@@ -416,9 +485,69 @@ mod tests {
 
         surface.resize(800, 0).unwrap();
 
-        // Dimensions should remain unchanged
         assert_eq!(surface.width(), 800);
         assert_eq!(surface.height(), 600);
+    }
+
+    #[test]
+    fn test_surface_acquire_and_present_new_api() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&device, &window).unwrap();
+
+        let frame = surface.acquire().unwrap();
+
+        assert_eq!(frame.width(), 800);
+        assert_eq!(frame.height(), 600);
+
+        // Frame should have a texture (mock backend supports it)
+        assert!(frame.texture().is_some());
+
+        frame.present().unwrap();
+    }
+
+    #[test]
+    fn test_surface_acquire_and_present_legacy_api() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&device, &window).unwrap();
+
+        let frame = surface.acquire().unwrap();
+        surface.present(frame).unwrap();
+    }
+
+    #[test]
+    fn test_surface_frame_texture_has_correct_dimensions() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&device, &window).unwrap();
+
+        let frame = surface.acquire().unwrap();
+        let texture = frame.texture().unwrap();
+
+        // Mock backend creates surfaces with 800x600
+        assert_eq!(texture.width(), 800);
+        assert_eq!(texture.height(), 600);
+
+        frame.present().unwrap();
+    }
+
+    #[test]
+    fn test_surface_frame_render_and_present() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&device, &window).unwrap();
+
+        let frame = surface.acquire().unwrap();
+
+        let mut encoder = crate::encoder::CommandEncoder::new();
+        {
+            let mut pass = encoder.begin_render_pass();
+            pass.clear(crate::types::Color::RED);
+        }
+
+        frame.render(encoder).unwrap();
+        frame.present().unwrap();
     }
 
     #[test]
@@ -432,7 +561,6 @@ mod tests {
 
         let frame = surface.acquire().unwrap();
 
-        // Render with both a color clear and a depth clear
         let mut encoder = crate::encoder::CommandEncoder::new();
         {
             let mut pass = encoder.begin_render_pass();
@@ -441,23 +569,7 @@ mod tests {
         }
 
         frame.render(encoder).unwrap();
-        surface.present(frame).unwrap();
-    }
-
-    #[test]
-    fn test_surface_acquire_and_present() {
-        let device = create_test_device();
-        let window = MockWindow::new(800, 600);
-        let surface = Surface::new(&device, &window).unwrap();
-
-        // Acquire a frame
-        let frame = surface.acquire().unwrap();
-
-        assert_eq!(frame.width(), 800);
-        assert_eq!(frame.height(), 600);
-
-        // Present the frame
-        surface.present(frame).unwrap();
+        frame.present().unwrap();
     }
 
     #[test]
@@ -466,30 +578,10 @@ mod tests {
         let window = MockWindow::new(640, 480);
         let surface = Surface::new(&device, &window).unwrap();
 
-        // Simulate multiple frames
         for _ in 0..5 {
             let frame = surface.acquire().unwrap();
-            surface.present(frame).unwrap();
+            frame.present().unwrap();
         }
-    }
-
-    #[test]
-    fn test_surface_frame_render() {
-        let device = create_test_device();
-        let window = MockWindow::new(800, 600);
-        let surface = Surface::new(&device, &window).unwrap();
-
-        let frame = surface.acquire().unwrap();
-
-        // Create a command encoder and render
-        let mut encoder = crate::encoder::CommandEncoder::new();
-        {
-            let mut pass = encoder.begin_render_pass();
-            pass.clear(crate::types::Color::RED);
-        }
-
-        frame.render(encoder).unwrap();
-        surface.present(frame).unwrap();
     }
 
     #[test]
@@ -498,7 +590,6 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let surface = Surface::new(&device, &window).unwrap();
 
-        // This should succeed - format matches
         let result = surface.validate_pipeline_format(TextureFormat::Bgra8UnormSrgb);
         assert!(result.is_ok());
     }
@@ -509,11 +600,9 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let surface = Surface::new(&device, &window).unwrap();
 
-        // This should fail - format doesn't match
         let result = surface.validate_pipeline_format(TextureFormat::Rgba8Unorm);
         assert!(result.is_err());
 
-        // Error message should be helpful
         let err = result.unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Pipeline format mismatch"));
@@ -527,14 +616,41 @@ mod tests {
         let window = MockWindow::new(800, 600);
         let surface = Surface::new(&device, &window).unwrap();
 
-        // Should succeed with matching format
         assert!(surface
             .validate_pipeline_format(TextureFormat::Rgba8Unorm)
             .is_ok());
 
-        // Should fail with non-matching format
         assert!(surface
             .validate_pipeline_format(TextureFormat::Bgra8UnormSrgb)
             .is_err());
+    }
+
+    #[test]
+    fn test_surface_with_config() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new_with_config(
+            &device,
+            &window,
+            SurfaceConfig {
+                present_mode: PresentMode::Immediate,
+                depth_format: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(surface.width(), 800);
+        assert_eq!(surface.height(), 600);
+    }
+
+    #[test]
+    fn test_surface_frame_drop_without_present() {
+        let device = create_test_device();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&device, &window).unwrap();
+
+        // Acquire and drop without presenting — should not panic
+        let _frame = surface.acquire().unwrap();
+        // frame is dropped here, triggering cleanup
     }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -6,7 +6,7 @@
 
 use crate::backend::{GpuBackend, TextureHandle};
 use crate::device::Device;
-use crate::types::{SpatialAccess, TextureFlags, TextureFormat};
+use crate::types::{BindlessCategory, BindlessHandle, SpatialAccess, TextureFlags, TextureFormat};
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
@@ -21,6 +21,9 @@ pub struct Texture {
     width: u32,
     height: u32,
     format: TextureFormat,
+    /// Access pattern chosen at creation time. Determines the bindless category
+    /// (`Interpolated` → `Texture`, `Direct` → `StorageImage`).
+    access: SpatialAccess,
     /// Whether this texture owns the underlying GPU resource.
     /// Borrowed textures (e.g. surface frame drawables) skip destroy on drop.
     owned: bool,
@@ -72,6 +75,7 @@ impl Texture {
             width,
             height,
             format,
+            access,
             owned: true,
         })
     }
@@ -246,9 +250,29 @@ impl Texture {
     ///
     /// Returns `Some(index)` if this texture is registered.
     /// Returns `None` otherwise.
+    ///
+    /// **Prefer [`Texture::bindless_handle`]** for new code: the typed handle
+    /// distinguishes storage-image slots (`SpatialAccess::Direct`) from
+    /// sampled-texture slots (`SpatialAccess::Interpolated`), which on Metal
+    /// map to different argument-buffer pools.
     pub fn bindless_index(&self) -> Option<u32> {
         let backend = self.backend.lock().unwrap();
         backend.texture_bindless_index(self.handle)
+    }
+
+    /// Get this texture's typed bindless descriptor handle.
+    ///
+    /// The category is derived from the texture's [`SpatialAccess`]:
+    /// `Interpolated` → [`BindlessCategory::Texture`],
+    /// `Direct` → [`BindlessCategory::StorageImage`].
+    pub fn bindless_handle(&self) -> Option<BindlessHandle> {
+        self.bindless_index()
+            .map(|i| BindlessHandle::new(BindlessCategory::from(self.access), i))
+    }
+
+    /// Get the access pattern this texture was created with.
+    pub fn access(&self) -> SpatialAccess {
+        self.access
     }
 
     /// Create a borrowed texture wrapping an externally-owned GPU resource.
@@ -256,6 +280,9 @@ impl Texture {
     /// The returned `Texture` provides the same read/query API but does **not**
     /// destroy the underlying resource when dropped. Used for transient resources
     /// like surface frame drawables whose lifetime is managed elsewhere.
+    ///
+    /// Swapchain drawables on surfaces with compute-to-surface support are
+    /// writable, so we tag them as `SpatialAccess::Direct` (storage image).
     pub(crate) fn borrowed(
         backend: Arc<Mutex<Box<dyn GpuBackend>>>,
         handle: TextureHandle,
@@ -269,6 +296,7 @@ impl Texture {
             width,
             height,
             format,
+            access: SpatialAccess::Direct,
             owned: false,
         }
     }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -21,6 +21,9 @@ pub struct Texture {
     width: u32,
     height: u32,
     format: TextureFormat,
+    /// Whether this texture owns the underlying GPU resource.
+    /// Borrowed textures (e.g. surface frame drawables) skip destroy on drop.
+    owned: bool,
 }
 
 impl Texture {
@@ -69,6 +72,7 @@ impl Texture {
             width,
             height,
             format,
+            owned: true,
         })
     }
 
@@ -246,10 +250,35 @@ impl Texture {
         let backend = self.backend.lock().unwrap();
         backend.texture_bindless_index(self.handle)
     }
+
+    /// Create a borrowed texture wrapping an externally-owned GPU resource.
+    ///
+    /// The returned `Texture` provides the same read/query API but does **not**
+    /// destroy the underlying resource when dropped. Used for transient resources
+    /// like surface frame drawables whose lifetime is managed elsewhere.
+    pub(crate) fn borrowed(
+        backend: Arc<Mutex<Box<dyn GpuBackend>>>,
+        handle: TextureHandle,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) -> Self {
+        Self {
+            backend,
+            handle,
+            width,
+            height,
+            format,
+            owned: false,
+        }
+    }
 }
 
 impl Drop for Texture {
     fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
         tracing::trace!(
             width = self.width,
             height = self.height,

--- a/src/types.rs
+++ b/src/types.rs
@@ -143,6 +143,107 @@ pub enum DataAccess {
     Broadcast,
 }
 
+/// Category of a bindless descriptor slot.
+///
+/// Goldy's bindless argument buffers / descriptor heaps are organized into
+/// separate pools per access pattern. A resource's bindless index is only
+/// meaningful relative to its category — e.g. a `Scattered` slot #3 and a
+/// `Broadcast` slot #3 refer to different physical entries on Metal
+/// (`storageBuffers[3]` vs `uniformBuffers[3]`) even though the `u32`
+/// indices are identical.
+///
+/// Capturing the category alongside the index lets the CPU API and the
+/// shader-side `goldy_exp` access functions be type-checked against each
+/// other — see [`BindlessHandle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BindlessCategory {
+    /// Storage-buffer slot. Consumed by `goldy_dyn_scattered<T>` / `goldy_dyn_buf_ro<T>`
+    /// (both shader functions index the same pool).
+    Scattered,
+    /// Uniform / constant-buffer slot. Consumed by `goldy_dyn_broadcast<T>`.
+    Broadcast,
+    /// Storage-image (writable texture) slot. Consumed by `goldy_dyn_direct_spatial<T>`.
+    StorageImage,
+    /// Sampled-texture slot. Consumed by `goldy_dyn_interpolated<T>`.
+    Texture,
+    /// Sampler slot. Consumed by `goldy_dyn_filter`.
+    Sampler,
+}
+
+impl BindlessCategory {
+    /// Short human-readable name for diagnostics.
+    pub fn name(self) -> &'static str {
+        match self {
+            BindlessCategory::Scattered => "scattered",
+            BindlessCategory::Broadcast => "broadcast",
+            BindlessCategory::StorageImage => "storage_image",
+            BindlessCategory::Texture => "texture",
+            BindlessCategory::Sampler => "sampler",
+        }
+    }
+
+    /// True if this handle can satisfy a shader slot declared as `expected`.
+    ///
+    /// `Scattered` and `Broadcast` are strictly distinct (different pools on Metal,
+    /// different descriptor types on Vulkan/DX12). `StorageImage`, `Texture`, and
+    /// `Sampler` are likewise non-interchangeable.
+    pub fn is_compatible_with(self, expected: BindlessCategory) -> bool {
+        self == expected
+    }
+}
+
+impl From<DataAccess> for BindlessCategory {
+    fn from(access: DataAccess) -> Self {
+        match access {
+            DataAccess::Scattered => BindlessCategory::Scattered,
+            DataAccess::Broadcast => BindlessCategory::Broadcast,
+        }
+    }
+}
+
+impl From<SpatialAccess> for BindlessCategory {
+    fn from(access: SpatialAccess) -> Self {
+        match access {
+            SpatialAccess::Interpolated => BindlessCategory::Texture,
+            SpatialAccess::Direct => BindlessCategory::StorageImage,
+        }
+    }
+}
+
+/// A typed bindless descriptor handle: `(category, index)`.
+///
+/// Goldy's resources (`Buffer`, `Texture`, `Sampler`) expose `bindless_handle()`
+/// which returns one of these. Push-constant setters that accept `BindlessHandle`
+/// can be validated against the shader's reflection: a
+/// [`BindlessCategory::Broadcast`] handle bound to a slot the shader reads
+/// through `goldy_dyn_buf_ro` (`Scattered`) is a type error caught at dispatch
+/// time rather than silently producing a garbage read.
+///
+/// The raw u32 index is recoverable via [`BindlessHandle::index`] — the typed
+/// wrapper is zero-cost at runtime when validation is disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BindlessHandle {
+    pub category: BindlessCategory,
+    pub index: u32,
+}
+
+impl BindlessHandle {
+    /// Build a handle from a category and raw index.
+    pub const fn new(category: BindlessCategory, index: u32) -> Self {
+        Self { category, index }
+    }
+
+    /// Raw descriptor index for this handle.
+    pub const fn index(self) -> u32 {
+        self.index
+    }
+
+    /// Category this handle was tagged with at creation.
+    pub const fn category(self) -> BindlessCategory {
+        self.category
+    }
+}
+
 /// Presentation mode controlling how frames are displayed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum PresentMode {

--- a/src/types.rs
+++ b/src/types.rs
@@ -143,6 +143,32 @@ pub enum DataAccess {
     Broadcast,
 }
 
+/// Presentation mode controlling how frames are displayed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum PresentMode {
+    /// Vsync: wait for display refresh. No tearing, capped at display Hz.
+    /// Maps to Metal `displaySyncEnabled=YES`, Vulkan `FIFO`, DX12 `Present(1)`.
+    Fifo,
+    /// Triple-buffered: latest frame queued, older frames dropped. Low latency + no tearing.
+    /// Maps to Vulkan `MAILBOX`. Falls back to Fifo on Metal and some DX12 configurations.
+    Mailbox,
+    /// No sync: present immediately. May tear. Maximum throughput for benchmarks.
+    /// Maps to Metal `displaySyncEnabled=NO`, Vulkan `IMMEDIATE`, DX12 `Present(0)`.
+    Immediate,
+    /// Let Goldy choose (Mailbox if available, then Fifo).
+    #[default]
+    Auto,
+}
+
+/// Configuration for surface creation.
+#[derive(Debug, Clone, Default)]
+pub struct SurfaceConfig {
+    /// Presentation mode (vsync strategy).
+    pub present_mode: PresentMode,
+    /// Optional depth buffer for 3D rendering.
+    pub depth_format: Option<DepthFormat>,
+}
+
 /// Spatial access pattern for textures/images.
 ///
 /// This describes how the texture will be accessed:


### PR DESCRIPTION
- Introduced a new example for compute operations: `compute_to_surface.rs`.
- Updated existing examples to use the new `frame.present()` method for rendering, improving code consistency and clarity.
- Enhanced documentation for the `Surface` and `SurfaceFrame` APIs to reflect changes in rendering and presentation logic.