### PR TITLE
Refactor compute shader and surface handling for improved rendering

### DIFF
--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -45,24 +45,28 @@ void cs_main(uint3 tid : SV_DispatchThreadID) {
     ReadOnlyBuffer<Uniforms> ub = goldy_dyn_buf_ro<Uniforms>(0);
     Uniforms u = ub[0];
 
+    RWTexture2D<float4> output = goldy_dyn_direct_spatial<float4>(1);
+
     if (tid.x >= u.width || tid.y >= u.height)
         return;
 
-    RWTexture2D<float4> output = goldy_dyn_direct_spatial<float4>(1);
+    float2 uv = float2(float(tid.x) / float(u.width),
+                       float(tid.y) / float(u.height));
+    float2 p = uv * 2.0 - 1.0;
+    p.x *= float(u.width) / float(u.height);
 
-    float2 uv = float2(tid.xy) / float2(u.width, u.height);
-
-    // Animated plasma effect
     float t = u.time;
     float v = 0.0;
-    v += sin(uv.x * 10.0 + t);
-    v += sin(uv.y * 10.0 + t * 0.5);
-    v += sin((uv.x + uv.y) * 10.0 + t * 0.7);
-    v += sin(sqrt(uv.x * uv.x + uv.y * uv.y) * 20.0 + t * 1.3);
-    v = v * 0.25 + 0.5;
+    v += sin(p.x * 6.0 + t);
+    v += sin(p.y * 6.0 + t * 1.3);
+    v += sin((p.x + p.y) * 4.0 + t * 0.7);
+    v += sin(length(p) * 8.0 - t * 2.0);
+    v *= 0.25;
 
-    float3 color = rainbow(v + t * 0.1);
-    output[tid.xy] = float4(color, 1.0);
+    float3 col = float3(0.5 + 0.5 * sin(v * 3.14159 + 0.0),
+                        0.5 + 0.5 * sin(v * 3.14159 + 2.094),
+                        0.5 + 0.5 * sin(v * 3.14159 + 4.188));
+    output[tid.xy] = float4(col, 1.0);
 }
 "#;
 
@@ -114,14 +118,21 @@ impl App {
         let shader = ShaderModule::from_slang(&device, COMPUTE_SHADER)?;
         let compute_pipeline = ComputePipeline::new(&device, &shader)?;
 
+        // NOTE: pass a typed `&[Uniforms]`, NOT `bytemuck::bytes_of(&u)`.
+        // `Buffer::with_data::<T>` uses `size_of::<T>()` as the structured-buffer
+        // stride. Passing `&[u8]` gave stride=1, which on DX12 caused
+        // `rawBufferLoad` of any field past offset 0 to return 0 (out-of-bounds
+        // for a stride-1 structured buffer) — turning `u.height` into 0 and
+        // triggering the `if (tid.y >= u.height) return;` guard for every
+        // thread on the `compute_to_surface` path.
         let uniform_buffer = Buffer::with_data(
             &device,
-            bytemuck::bytes_of(&Uniforms {
+            &[Uniforms {
                 width: surface.width(),
                 height: surface.height(),
                 time: 0.0,
                 _padding: 0.0,
-            }),
+            }],
             DataAccess::Scattered,
         )?;
 
@@ -235,8 +246,18 @@ fn render_frame(state: &mut RenderState) -> Result<()> {
     let wg_x = width.div_ceil(8);
     let wg_y = height.div_ceil(8);
 
-    let uniform_handle = state.uniform_buffer.bindless_handle().unwrap();
-    let texture_handle = texture.bindless_handle().unwrap();
+    // The shader accesses the uniform buffer via `goldy_dyn_buf_ro<Uniforms>(0)` which
+    // maps to `StructuredBuffer<Uniforms>` — an SRV on DX12. `bindless_srv_handle()`
+    // returns the SRV index on DX12 (distinct from the UAV index) and falls back to
+    // the unified storage-buffer index on Vulkan / Metal, so it's correct on every
+    // backend.
+    let uniform_handle = state
+        .uniform_buffer
+        .bindless_srv_handle()
+        .expect("Uniform buffer has no bindless SRV handle");
+    let texture_handle = texture
+        .bindless_handle()
+        .expect("Surface texture has no bindless handle");
 
     let mut encoder = ComputeEncoder::new();
     {

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -680,7 +680,6 @@ pub(super) fn bindless_srv_index(state: &Dx12State, buffer_handle: BufferHandle)
 ///
 /// For DEFAULT heap buffers (storage), creates a readback buffer and copies.
 /// For UPLOAD heap buffers (uniform), reads directly via Map.
-
 pub(super) fn read_to_cpu(
     state: &mut Dx12State,
     device_handle: DeviceHandle,

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -4,11 +4,12 @@
 
 use super::barriers;
 use super::render_commands;
-use super::types::{FrameSync, LogicalDevice, SurfaceState, TextureState, MAX_FRAMES_IN_FLIGHT};
-use super::utils::{depth_format_to_dxgi, dxgi_to_format, format_to_dxgi};
+use super::texture;
+use super::types::{FrameSync, LogicalDevice, SurfaceState, MAX_FRAMES_IN_FLIGHT};
+use super::utils::{depth_format_to_dxgi, dxgi_to_format};
 use super::{DeviceHandle, Dx12State, SurfaceHandle, SwapchainImageHandle, TextureHandle};
 use crate::backend::RenderCommand;
-use crate::types::{Color, DepthFormat, TextureFormat};
+use crate::types::{Color, DepthFormat, SpatialAccess, TextureFlags, TextureFormat};
 use anyhow::{Context, Result};
 use raw_window_handle::RawWindowHandle;
 use windows::{
@@ -55,11 +56,10 @@ pub(super) fn create(
     let width = (rect.right - rect.left) as u32;
     let height = (rect.bottom - rect.top) as u32;
 
-    // Create swapchain
-    // ALLOW_UNORDERED_ACCESS lets compute shaders write directly to back buffers
-    // via UAV descriptors (the compute-to-surface path).
-    // Not all adapters support this — if creation fails, consider removing this flag
-    // and falling back to a separate render target + copy.
+    // Create swapchain (render-target usage only).
+    // DXGI/D3D12 rejects `DXGI_USAGE_UNORDERED_ACCESS` on flip-model swapchain buffers;
+    // `CreateSwapChainForHwnd` fails (e.g. HRESULT 0x887A698F). Compute-to-surface must
+    // use an intermediate UAV texture + copy, not a UAV on the swapchain image.
     let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
         Width: width,
         Height: height,
@@ -69,7 +69,7 @@ pub(super) fn create(
             Count: 1,
             Quality: 0,
         },
-        BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_UNORDERED_ACCESS,
+        BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
         BufferCount: MAX_FRAMES_IN_FLIGHT as u32,
         Scaling: DXGI_SCALING_STRETCH,
         SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
@@ -216,6 +216,7 @@ pub(super) fn create(
             command_list,
             command_allocator,
             fence_value: 0,
+            render_pass_submitted: false,
         });
     }
 
@@ -239,6 +240,7 @@ pub(super) fn create(
             current_image_index: None,
             frame_sync,
             current_texture_handle: None,
+            compute_scratch_textures: vec![None; MAX_FRAMES_IN_FLIGHT],
         },
     );
 
@@ -248,13 +250,30 @@ pub(super) fn create(
 
 /// Destroy a surface.
 pub(super) fn destroy(state: &mut Dx12State, surface_handle: SurfaceHandle) {
-    // Clean up any outstanding surface texture
-    if let Some(tex_handle) = state
+    let scratch_handles: Vec<TextureHandle> = state
+        .surfaces
+        .get(&surface_handle)
+        .map(|s| {
+            s.compute_scratch_textures
+                .iter()
+                .filter_map(|x| *x)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if state
         .surfaces
         .get(&surface_handle)
         .and_then(|s| s.current_texture_handle)
+        .is_some()
     {
-        unregister_surface_texture(state, tex_handle);
+        tracing::warn!(
+            "Surface destroyed with an acquired frame; scratch textures freed separately"
+        );
+    }
+
+    for h in scratch_handles {
+        texture::destroy(state, h);
     }
 
     if let Some(surface_state) = state.surfaces.remove(&surface_handle) {
@@ -266,21 +285,20 @@ pub(super) fn destroy(state: &mut Dx12State, surface_handle: SurfaceHandle) {
 
 /// Acquire the next swapchain image.
 ///
-/// After acquiring, the back buffer is registered in the bindless descriptor
-/// heap as a UAV. The resulting `TextureHandle` is available via
-/// `frame_texture()` until `present()` is called.
+/// Binds a per-buffer **compute scratch** texture (UAV-capable) for `frame.texture()`.
+/// Swapchain back buffers cannot be UAVs on D3D12; `present` copies scratch → back buffer
+/// when no graphics `surface_render` ran this frame.
 pub(super) fn acquire(
     state: &mut Dx12State,
     surface_handle: SurfaceHandle,
 ) -> Result<SwapchainImageHandle> {
-    // Clean up any previously acquired surface texture that wasn't presented
-    if let Some(tex_handle) = state
+    if state
         .surfaces
         .get(&surface_handle)
         .and_then(|s| s.current_texture_handle)
+        .is_some()
     {
-        tracing::warn!("Previous surface texture was not presented; cleaning up");
-        unregister_surface_texture(state, tex_handle);
+        tracing::warn!("Previous surface frame was not presented; continuing acquire");
     }
 
     let surface = state
@@ -288,24 +306,27 @@ pub(super) fn acquire(
         .get_mut(&surface_handle)
         .context("Invalid surface handle")?;
 
+    let cf = surface.current_frame;
+    surface.frame_sync[cf].render_pass_submitted = false;
+
     let image_index = unsafe { surface.swapchain.GetCurrentBackBufferIndex() };
     surface.current_image_index = Some(image_index);
 
     let device_handle = surface.device_handle;
-    let resource = surface.render_targets[image_index as usize].clone();
     let width = surface.width;
     let height = surface.height;
     let dxgi_format = surface.format;
     let goldy_format = dxgi_to_format(dxgi_format).unwrap_or(TextureFormat::Bgra8Unorm);
+    let idx = image_index as usize;
 
-    let tex_handle = register_surface_texture(
+    let tex_handle = ensure_compute_scratch_texture(
         state,
-        device_handle,
-        resource,
-        dxgi_format,
-        goldy_format,
+        surface_handle,
+        idx,
         width,
         height,
+        goldy_format,
+        device_handle,
     )?;
 
     let surface = state.surfaces.get_mut(&surface_handle).unwrap();
@@ -510,47 +531,171 @@ pub(super) fn render(
         dev.fence_value += 1;
     }
 
+    if let Some(surf) = state.surfaces.get_mut(&surface_handle) {
+        surf.frame_sync[current_frame].render_pass_submitted = true;
+    }
+
     Ok(())
 }
 
 /// Present a rendered surface.
 ///
-/// Unregisters the transient surface texture from the bindless descriptor heap,
-/// then presents the swapchain image.
+/// Graphics path: waits for the last graphics submit then presents.
+/// Compute-only path: copies the scratch UAV texture to the swapchain back buffer, then presents.
 pub(super) fn present(
     state: &mut Dx12State,
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
 ) -> Result<()> {
-    // Unregister the transient surface texture before presenting
-    if let Some(tex_handle) = state
-        .surfaces
-        .get(&surface_handle)
-        .and_then(|s| s.current_texture_handle)
-    {
-        unregister_surface_texture(state, tex_handle);
+    let (
+        device_handle,
+        _image_index,
+        current_frame,
+        scratch_handle,
+        backbuffer,
+        render_pass_submitted,
+    ) = {
+        let surface = state
+            .surfaces
+            .get(&surface_handle)
+            .context("Invalid surface handle")?;
+        let image_index = surface
+            .current_image_index
+            .context("No image to present - call surface_acquire first")?
+            as usize;
+        let scratch_handle = surface
+            .current_texture_handle
+            .context("No acquired surface texture")?;
+        let expected = surface
+            .compute_scratch_textures
+            .get(image_index)
+            .copied()
+            .flatten();
+        if expected != Some(scratch_handle) {
+            anyhow::bail!("DX12 surface present: scratch texture handle mismatch");
+        }
+        let render_pass_submitted = surface.frame_sync[surface.current_frame].render_pass_submitted;
+        (
+            surface.device_handle,
+            image_index,
+            surface.current_frame,
+            scratch_handle,
+            surface.render_targets[image_index].clone(),
+            render_pass_submitted,
+        )
+    };
+
+    if let Some(s) = state.surfaces.get_mut(&surface_handle) {
+        s.current_texture_handle = None;
     }
 
-    if let Some(surface) = state.surfaces.get_mut(&surface_handle) {
-        surface.current_texture_handle = None;
-    }
+    let logical_device = state
+        .devices
+        .get(&device_handle)
+        .context("Surface's device is invalid")?;
 
-    let surface = state
-        .surfaces
-        .get(&surface_handle)
-        .context("Invalid surface handle")?;
-
-    let device_handle = surface.device_handle;
-
-    // Wait for render to complete before presenting
-    {
-        let logical_device = state
-            .devices
-            .get(&device_handle)
-            .context("Surface's device is invalid")?;
-
+    if render_pass_submitted {
         let fence_value = logical_device.fence_value.saturating_sub(1);
         wait_for_fence(&logical_device.fence, fence_value)?;
+    } else {
+        let scratch_res = state
+            .textures
+            .get(&scratch_handle)
+            .context("Scratch texture not found")?
+            .resource
+            .clone();
+
+        let (cmd7, cmd_alloc) = {
+            let surface = state.surfaces.get(&surface_handle).unwrap();
+            let frame = &surface.frame_sync[current_frame];
+            (frame.command_list.clone(), frame.command_allocator.clone())
+        };
+
+        unsafe { cmd_alloc.Reset() }
+            .context("Failed to reset command allocator for present copy")?;
+        let cmd_gfx: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(&cmd7) };
+        unsafe { cmd_gfx.Reset(&cmd_alloc, None) }
+            .context("Failed to reset command list for present copy")?;
+
+        // Flip-discard swapchain: the acquired buffer's contents are undefined until written.
+        // `D3D12_BARRIER_LAYOUT_PRESENT` and `COMMON` share the same numeric value in windows-rs
+        // (both 0), so treat the destination as UNDEFINED before COPY_DEST.
+        unsafe { cmd_gfx.DiscardResource(&backbuffer, None) };
+
+        let mut prep_barriers = vec![
+            barriers::texture_barrier_full(
+                &scratch_res,
+                D3D12_BARRIER_SYNC_ALL,
+                D3D12_BARRIER_SYNC_COPY,
+                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS,
+                D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+            ),
+            barriers::texture_barrier_full(
+                &backbuffer,
+                D3D12_BARRIER_SYNC_NONE,
+                D3D12_BARRIER_SYNC_COPY,
+                D3D12_BARRIER_ACCESS_NO_ACCESS,
+                D3D12_BARRIER_ACCESS_COPY_DEST,
+                D3D12_BARRIER_LAYOUT_UNDEFINED,
+                D3D12_BARRIER_LAYOUT_COPY_DEST,
+            ),
+        ];
+        unsafe { barriers::barrier_textures(&cmd7, &prep_barriers) };
+        unsafe { barriers::drop_texture_barriers(&mut prep_barriers) };
+
+        unsafe { cmd_gfx.CopyResource(&backbuffer, &scratch_res) };
+
+        let mut post_barriers = vec![
+            barriers::texture_barrier_full(
+                &backbuffer,
+                D3D12_BARRIER_SYNC_COPY,
+                D3D12_BARRIER_SYNC_NONE,
+                D3D12_BARRIER_ACCESS_COPY_DEST,
+                D3D12_BARRIER_ACCESS_NO_ACCESS,
+                D3D12_BARRIER_LAYOUT_COPY_DEST,
+                D3D12_BARRIER_LAYOUT_PRESENT,
+            ),
+            barriers::texture_barrier_full(
+                &scratch_res,
+                D3D12_BARRIER_SYNC_COPY,
+                D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+                D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS,
+            ),
+        ];
+        unsafe { barriers::barrier_textures(&cmd7, &post_barriers) };
+        unsafe { barriers::drop_texture_barriers(&mut post_barriers) };
+
+        unsafe { cmd_gfx.Close() }.context("Failed to close present copy command list")?;
+
+        let cmd_list: ID3D12CommandList = cmd_gfx.cast().context("Failed to cast command list")?;
+        unsafe {
+            logical_device
+                .command_queue
+                .ExecuteCommandLists(&[Some(cmd_list)]);
+        }
+
+        let fence_value = logical_device.fence_value;
+        unsafe {
+            logical_device
+                .command_queue
+                .Signal(&logical_device.fence, fence_value)
+        }
+        .context("Failed to signal fence after present copy")?;
+
+        wait_for_fence(&logical_device.fence, fence_value)?;
+
+        if let Some(dev) = state.devices.get_mut(&device_handle) {
+            dev.fence_value += 1;
+        }
+
+        if let Some(tex) = state.textures.get_mut(&scratch_handle) {
+            tex.last_layout = D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS;
+        }
     }
 
     // Present
@@ -591,6 +736,18 @@ pub(super) fn resize(
             .get(&device_handle)
             .context("Surface's device is invalid")?;
         let _ = wait_for_gpu(logical_device);
+    }
+
+    let scratch_destroy: Vec<TextureHandle> = {
+        let surface = state.surfaces.get_mut(&surface_handle).unwrap();
+        surface
+            .compute_scratch_textures
+            .iter_mut()
+            .filter_map(|slot| slot.take())
+            .collect()
+    };
+    for h in scratch_destroy {
+        texture::destroy(state, h);
     }
 
     // Release old render targets, depth buffer, and resize swapchain
@@ -736,9 +893,58 @@ pub(super) fn resize(
     surface.current_frame = 0;
     surface.current_image_index = None;
     surface.current_texture_handle = None;
+    surface.compute_scratch_textures = vec![None; MAX_FRAMES_IN_FLIGHT];
 
     tracing::debug!("Resized surface to {}x{}", width, height);
     Ok(())
+}
+
+/// Ensure a UAV scratch texture exists for swapchain buffer index `idx`.
+fn ensure_compute_scratch_texture(
+    state: &mut Dx12State,
+    surface_handle: SurfaceHandle,
+    idx: usize,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+    device_handle: DeviceHandle,
+) -> Result<TextureHandle> {
+    let reuse = {
+        let surface = state
+            .surfaces
+            .get(&surface_handle)
+            .context("Invalid surface handle")?;
+        let slot = surface.compute_scratch_textures.get(idx).copied().flatten();
+        if let Some(h) = slot {
+            if let Some(tex) = state.textures.get(&h) {
+                if tex.width == width && tex.height == height && tex.format == format {
+                    return Ok(h);
+                }
+            }
+            Some(h)
+        } else {
+            None
+        }
+    };
+
+    if let Some(old) = reuse {
+        texture::destroy(state, old);
+        let surface = state.surfaces.get_mut(&surface_handle).unwrap();
+        surface.compute_scratch_textures[idx] = None;
+    }
+
+    let h = texture::create(
+        state,
+        device_handle,
+        width,
+        height,
+        format,
+        SpatialAccess::Direct,
+        TextureFlags::empty(),
+    )?;
+    let surface = state.surfaces.get_mut(&surface_handle).unwrap();
+    surface.compute_scratch_textures[idx] = Some(h);
+    Ok(h)
 }
 
 /// Get surface dimensions.
@@ -776,139 +982,4 @@ fn wait_for_gpu(device: &LogicalDevice) -> Result<()> {
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence")?;
     wait_for_fence(&device.fence, fence_value)
-}
-
-// ---------------------------------------------------------------------------
-// Transient surface texture registration
-// ---------------------------------------------------------------------------
-// These functions register/unregister back-buffer resources in the global
-// bindless descriptor heap so that compute shaders can write to them via
-// RWTexture2D. The ID3D12Resource is COM-cloned (refcount bump) on acquire
-// and released (refcount decrement) on present — the swapchain retains its
-// own reference throughout.
-
-/// Register a back-buffer resource as a transient storage texture.
-///
-/// Creates a UAV descriptor in the CBV/SRV/UAV heap and inserts a `TextureState`.
-/// Returns a `TextureHandle` that the caller stores in
-/// `SurfaceState::current_texture_handle`.
-#[allow(clippy::too_many_arguments)]
-fn register_surface_texture(
-    state: &mut Dx12State,
-    device_handle: DeviceHandle,
-    resource: ID3D12Resource,
-    dxgi_format: DXGI_FORMAT,
-    goldy_format: TextureFormat,
-    width: u32,
-    height: u32,
-) -> Result<TextureHandle> {
-    let handle = state.next_texture_handle;
-    state.next_texture_handle += 1;
-
-    let logical_device = state
-        .devices
-        .get_mut(&device_handle)
-        .context("Device no longer valid")?;
-
-    // Register a UAV descriptor so compute shaders can write to this texture.
-    // SRV is also registered so the texture can be read back if needed.
-    let srv_offset = logical_device.resource_registry.register_texture(handle);
-    let uav_offset = logical_device
-        .resource_registry
-        .register_texture_uav(handle);
-
-    // Create SRV descriptor
-    let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
-        Format: dxgi_format,
-        ViewDimension: D3D12_SRV_DIMENSION_TEXTURE2D,
-        Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-        Anonymous: D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
-            Texture2D: D3D12_TEX2D_SRV {
-                MostDetailedMip: 0,
-                MipLevels: 1,
-                PlaneSlice: 0,
-                ResourceMinLODClamp: 0.0,
-            },
-        },
-    };
-
-    let srv_cpu_handle = unsafe {
-        let mut h = logical_device
-            .cbv_srv_uav_heap
-            .GetCPUDescriptorHandleForHeapStart();
-        h.ptr += (srv_offset * logical_device.cbv_srv_uav_descriptor_size) as usize;
-        h
-    };
-    unsafe {
-        logical_device
-            .device
-            .CreateShaderResourceView(&resource, Some(&srv_desc), srv_cpu_handle);
-    }
-
-    // Create UAV descriptor for compute write access
-    let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
-        Format: dxgi_format,
-        ViewDimension: D3D12_UAV_DIMENSION_TEXTURE2D,
-        Anonymous: D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
-            Texture2D: D3D12_TEX2D_UAV {
-                MipSlice: 0,
-                PlaneSlice: 0,
-            },
-        },
-    };
-
-    let uav_cpu_handle = unsafe {
-        let mut h = logical_device
-            .cbv_srv_uav_heap
-            .GetCPUDescriptorHandleForHeapStart();
-        h.ptr += (uav_offset * logical_device.cbv_srv_uav_descriptor_size) as usize;
-        h
-    };
-    unsafe {
-        logical_device.device.CreateUnorderedAccessView(
-            Some(&resource),
-            None,
-            Some(&uav_desc),
-            uav_cpu_handle,
-        );
-    }
-
-    state.textures.insert(
-        handle,
-        TextureState {
-            device_handle,
-            width,
-            height,
-            format: goldy_format,
-            resource,
-            srv_offset,
-            bindless_offset: Some(uav_offset),
-            last_layout: D3D12_BARRIER_LAYOUT_PRESENT,
-        },
-    );
-
-    tracing::debug!(
-        "Registered surface texture {} ({}x{}, srv={}, uav={})",
-        handle,
-        width,
-        height,
-        srv_offset,
-        uav_offset,
-    );
-
-    Ok(handle)
-}
-
-/// Unregister a transient surface texture.
-///
-/// Removes the `TextureState` and unregisters from the resource registry.
-/// The `ID3D12Resource` COM refcount decrements when the `TextureState` is dropped,
-/// but the swapchain retains its own reference, so the back buffer stays alive.
-fn unregister_surface_texture(state: &mut Dx12State, tex_handle: TextureHandle) {
-    if let Some(tex_state) = state.textures.remove(&tex_handle) {
-        if let Some(dev) = state.devices.get_mut(&tex_state.device_handle) {
-            dev.resource_registry.unregister_texture(tex_handle);
-        }
-        tracing::debug!("Unregistered surface texture {}", tex_handle);
-    }
 }

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -335,6 +335,8 @@ pub(crate) struct FrameSync {
     pub command_list: Direct3D12::ID3D12GraphicsCommandList7,
     pub command_allocator: Direct3D12::ID3D12CommandAllocator,
     pub fence_value: u64,
+    /// Set after `surface::render` submits. When false, `present` copies the compute scratch texture.
+    pub render_pass_submitted: bool,
 }
 
 /// Surface (swapchain) state for window presentation.
@@ -361,6 +363,9 @@ pub(crate) struct SurfaceState {
     /// registered in the bindless descriptor heap as a UAV so compute shaders
     /// can write directly to the swapchain image.
     pub current_texture_handle: Option<super::TextureHandle>,
+    /// Per swapchain buffer index: persistent UAV texture for compute; results are
+    /// copied to the real back buffer in `present` (swapchain images cannot be UAVs).
+    pub compute_scratch_textures: Vec<Option<super::TextureHandle>>,
 }
 
 /// Consolidated DX12 backend state.

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -559,7 +559,7 @@ impl GpuBackend for VulkanBackend {
     ) -> Result<()> {
         surface::render(
             &self.state.devices,
-            &self.state.surfaces,
+            &mut self.state.surfaces,
             surface_handle,
             _image,
             commands,

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -215,6 +215,12 @@ pub(super) fn create(
                 .create_semaphore(&semaphore_info, None)
         }
         .context("Failed to create image available semaphore")?;
+        let image_ready_semaphore = unsafe {
+            logical_device
+                .device
+                .create_semaphore(&semaphore_info, None)
+        }
+        .context("Failed to create image ready semaphore")?;
         let render_finished_semaphore = unsafe {
             logical_device
                 .device
@@ -227,20 +233,25 @@ pub(super) fn create(
         let in_flight_fence = unsafe { logical_device.device.create_fence(&fence_info, None) }
             .context("Failed to create in-flight fence")?;
 
-        // Allocate command buffer
+        // Allocate two primary command buffers per frame: one for the acquire-time
+        // layout-prep submit and one for the render-path submit (graphics commands or
+        // the compute-only present barrier).
         let alloc_info = vk::CommandBufferAllocateInfo::default()
             .command_pool(logical_device.command_pool)
             .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1);
+            .command_buffer_count(2);
         let command_buffers =
             unsafe { logical_device.device.allocate_command_buffers(&alloc_info) }
                 .context("Failed to allocate command buffer")?;
 
         frame_sync.push(FrameSync {
             command_buffer: command_buffers[0],
+            prep_command_buffer: command_buffers[1],
             image_available_semaphore,
+            image_ready_semaphore,
             render_finished_semaphore,
             in_flight_fence,
+            render_pass_submitted: false,
         });
     }
 
@@ -372,6 +383,9 @@ pub(super) fn destroy(
                         .destroy_semaphore(frame.image_available_semaphore, None);
                     logical_device
                         .device
+                        .destroy_semaphore(frame.image_ready_semaphore, None);
+                    logical_device
+                        .device
                         .destroy_semaphore(frame.render_finished_semaphore, None);
                     logical_device
                         .device
@@ -451,6 +465,12 @@ pub(super) fn acquire(
     }
     .context("Failed to wait for frame fence")?;
 
+    {
+        let surface_state = surfaces.get_mut(&surface_handle).unwrap();
+        let cf = surface_state.current_frame;
+        surface_state.frame_sync[cf].render_pass_submitted = false;
+    }
+
     // Process deferred deletions - resources from frames that have now completed
     // Since we just waited for the fence, frame (current_deletion_frame - MAX_FRAMES_IN_FLIGHT) has completed
     {
@@ -491,17 +511,103 @@ pub(super) fn acquire(
             if suboptimal {
                 tracing::debug!("Swapchain suboptimal - consider resizing");
             }
-            // Update surface state
-            let surface_state = surfaces.get_mut(&surface_handle).unwrap();
-            surface_state.current_image_index = Some(image_index);
+            // Submit a "prep" barrier on the acquired image: `UNDEFINED → GENERAL`,
+            // waiting on `image_available_semaphore` and signaling `image_ready_semaphore`.
+            //
+            // After `vkAcquireNextImageKHR`, the swapchain image must not be accessed
+            // until `image_available_semaphore` has been waited on, and its layout is
+            // either `UNDEFINED` (first use) or `PRESENT_SRC_KHR` (recycled). Compute
+            // shaders writing via `RWTexture2D` require `GENERAL`. This prep submit
+            // consumes the acquire semaphore, performs the layout transition once, and
+            // signals `image_ready_semaphore` which both the graphics render path and
+            // the compute-only present path wait on — so downstream compute submits
+            // can safely write the image in any order on the same queue.
+            let (prep_cmd, image_ready_semaphore, image) = {
+                let surface_state = surfaces.get_mut(&surface_handle).unwrap();
+                surface_state.current_image_index = Some(image_index);
+                let frame = &surface_state.frame_sync[surface_state.current_frame];
+                (
+                    frame.prep_command_buffer,
+                    frame.image_ready_semaphore,
+                    surface_state.swapchain_images[image_index as usize],
+                )
+            };
+
+            unsafe {
+                logical_device
+                    .device
+                    .reset_command_buffer(prep_cmd, vk::CommandBufferResetFlags::empty())
+            }
+            .context("Failed to reset acquire prep command buffer")?;
+
+            let begin_info = vk::CommandBufferBeginInfo::default()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+            unsafe {
+                logical_device
+                    .device
+                    .begin_command_buffer(prep_cmd, &begin_info)
+            }
+            .context("Failed to begin acquire prep command buffer")?;
+
+            let prep_barrier = vk::ImageMemoryBarrier2::default()
+                .src_stage_mask(vk::PipelineStageFlags2::TOP_OF_PIPE)
+                .src_access_mask(vk::AccessFlags2::NONE)
+                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .dst_access_mask(
+                    vk::AccessFlags2::SHADER_WRITE
+                        | vk::AccessFlags2::SHADER_READ
+                        | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+                        | vk::AccessFlags2::TRANSFER_WRITE,
+                )
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::GENERAL)
+                .image(image)
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                });
+            let dep_info = vk::DependencyInfo::default()
+                .image_memory_barriers(std::slice::from_ref(&prep_barrier));
+            unsafe {
+                logical_device
+                    .device
+                    .cmd_pipeline_barrier2(prep_cmd, &dep_info)
+            };
+
+            unsafe { logical_device.device.end_command_buffer(prep_cmd) }
+                .context("Failed to end acquire prep command buffer")?;
+
+            let wait_semaphores = [image_available_semaphore];
+            let wait_stages = [vk::PipelineStageFlags::TOP_OF_PIPE];
+            let signal_semaphores = [image_ready_semaphore];
+            let prep_submit = vk::SubmitInfo::default()
+                .wait_semaphores(&wait_semaphores)
+                .wait_dst_stage_mask(&wait_stages)
+                .command_buffers(std::slice::from_ref(&prep_cmd))
+                .signal_semaphores(&signal_semaphores);
+            unsafe {
+                logical_device.device.queue_submit(
+                    logical_device.queue,
+                    std::slice::from_ref(&prep_submit),
+                    vk::Fence::null(),
+                )
+            }
+            .context("Failed to submit acquire prep barrier")?;
 
             // Register the swapchain image as a storage texture for compute access.
             // The image view is created for GENERAL layout so compute shaders can write
             // via RWTexture2D in bindless.
-            let image = surface_state.swapchain_images[image_index as usize];
-            let width = surface_state.width;
-            let height = surface_state.height;
-            let vk_format = surface_state.format;
+            let (width, height, vk_format) = {
+                let surface_state = surfaces.get(&surface_handle).unwrap();
+                (
+                    surface_state.width,
+                    surface_state.height,
+                    surface_state.format,
+                )
+            };
             let goldy_format =
                 super::utils::vk_to_format(vk_format).unwrap_or(TextureFormat::Bgra8UnormSrgb);
 
@@ -550,7 +656,7 @@ pub(super) fn frame_texture(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn render<F>(
     devices: &HashMap<DeviceHandle, LogicalDevice>,
-    surfaces: &HashMap<SurfaceHandle, SurfaceState>,
+    surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
     commands: &[RenderCommand],
@@ -607,7 +713,11 @@ where
     unsafe { logical_device.device.begin_command_buffer(cmd, &begin_info) }
         .context("Failed to begin command buffer")?;
 
-    // Transition image to color attachment
+    // Transition image to color attachment. The image is in `GENERAL` layout at this
+    // point (acquire submits a prep barrier `UNDEFINED → GENERAL`), but we pass
+    // `UNDEFINED` as old_layout to let the driver discard any prior contents — the
+    // render path is expected to fully overwrite the frame (clear + draw), so we
+    // don't need to preserve compute writes here.
     let color_barrier = vk::ImageMemoryBarrier2::default()
         .src_stage_mask(vk::PipelineStageFlags2::TOP_OF_PIPE)
         .src_access_mask(vk::AccessFlags2::NONE)
@@ -763,9 +873,11 @@ where
     unsafe { logical_device.device.end_command_buffer(cmd) }
         .context("Failed to end command buffer")?;
 
-    // Get per-frame sync primitives
+    // Get per-frame sync primitives. We wait on `image_ready_semaphore` (signaled by
+    // the acquire-time prep submit) rather than `image_available_semaphore` — the
+    // prep submit already consumed the latter to transition the image into `GENERAL`.
     let frame = &surface_state.frame_sync[current_frame];
-    let wait_semaphores = [frame.image_available_semaphore];
+    let wait_semaphores = [frame.image_ready_semaphore];
     let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
     let signal_semaphores = [frame.render_finished_semaphore];
 
@@ -784,6 +896,10 @@ where
         )
     }
     .context("Failed to submit command buffer")?;
+
+    if let Some(surface_state) = surfaces.get_mut(&surface_handle) {
+        surface_state.frame_sync[current_frame].render_pass_submitted = true;
+    }
 
     Ok(())
 }
@@ -819,11 +935,83 @@ pub(super) fn present(
         .context("No image to present - call surface_render first")?;
 
     let current_frame = surface_state.current_frame;
-    let frame = &surface_state.frame_sync[current_frame];
+    let image = surface_state.swapchain_images[image_index as usize];
+    let render_pass_submitted = surface_state.frame_sync[current_frame].render_pass_submitted;
+    let device_handle = surface_state.device_handle;
 
     let logical_device = devices
-        .get(&surface_state.device_handle)
+        .get(&device_handle)
         .context("Surface's device is invalid")?;
+
+    // Graphics path: `surface_render` waits `image_available`, writes the swapchain image,
+    // signals `render_finished`, and sets `render_pass_submitted`.
+    // Compute-only path: host waits on the compute fence, but nothing signals
+    // `render_finished` or `in_flight_fence` — `queue_present` would block forever.
+    // Submit a layout barrier (GENERAL → PRESENT_SRC) with the same semaphore/fence pattern.
+    if !render_pass_submitted {
+        let frame = &surface_state.frame_sync[current_frame];
+        let cmd = frame.command_buffer;
+
+        unsafe {
+            logical_device
+                .device
+                .reset_command_buffer(cmd, vk::CommandBufferResetFlags::empty())
+        }
+        .context("Failed to reset compute-present barrier command buffer")?;
+
+        let begin_info = vk::CommandBufferBeginInfo::default()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+        unsafe { logical_device.device.begin_command_buffer(cmd, &begin_info) }
+            .context("Failed to begin compute-present barrier command buffer")?;
+
+        let barrier = vk::ImageMemoryBarrier2::default()
+            .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .src_access_mask(vk::AccessFlags2::SHADER_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::BOTTOM_OF_PIPE)
+            .dst_access_mask(vk::AccessFlags2::NONE)
+            .old_layout(vk::ImageLayout::GENERAL)
+            .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+            .image(image)
+            .subresource_range(vk::ImageSubresourceRange {
+                aspect_mask: vk::ImageAspectFlags::COLOR,
+                base_mip_level: 0,
+                level_count: 1,
+                base_array_layer: 0,
+                layer_count: 1,
+            });
+
+        let dep_info =
+            vk::DependencyInfo::default().image_memory_barriers(std::slice::from_ref(&barrier));
+        unsafe { logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info) };
+
+        unsafe { logical_device.device.end_command_buffer(cmd) }
+            .context("Failed to end compute-present barrier command buffer")?;
+
+        // Wait on `image_ready_semaphore` (signaled by the acquire-time prep submit).
+        // The prep barrier already consumed `image_available_semaphore` and transitioned
+        // the image from `UNDEFINED` into `GENERAL`, so compute shaders have already
+        // written it at the correct layout by the time we reach this post-barrier.
+        let frame = &surface_state.frame_sync[current_frame];
+        let wait_semaphores = [frame.image_ready_semaphore];
+        let wait_stages = [vk::PipelineStageFlags::COMPUTE_SHADER];
+        let signal_semaphores = [frame.render_finished_semaphore];
+        let submit_info = vk::SubmitInfo::default()
+            .wait_semaphores(&wait_semaphores)
+            .wait_dst_stage_mask(&wait_stages)
+            .command_buffers(std::slice::from_ref(&cmd))
+            .signal_semaphores(&signal_semaphores);
+
+        unsafe {
+            logical_device.device.queue_submit(
+                logical_device.queue,
+                std::slice::from_ref(&submit_info),
+                frame.in_flight_fence,
+            )
+        }
+        .context("Failed to submit compute-present layout barrier")?;
+    }
+
+    let frame = &surface_state.frame_sync[current_frame];
 
     let swapchain_loader = khr::swapchain::Device::new(instance, &logical_device.device);
 
@@ -839,7 +1027,6 @@ pub(super) fn present(
     let result = unsafe { swapchain_loader.queue_present(logical_device.queue, &present_info) };
 
     // Clear the current image and advance frame counter
-    let device_handle = surface_state.device_handle;
     let surface_state = surfaces.get_mut(&surface_handle).unwrap();
     surface_state.current_image_index = None;
     surface_state.current_frame = (surface_state.current_frame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -347,9 +347,23 @@ pub const MAX_FRAMES_IN_FLIGHT: usize = 2;
 /// Per-frame synchronization resources for proper swapchain pipelining.
 pub(crate) struct FrameSync {
     pub command_buffer: vk::CommandBuffer,
+    /// Dedicated command buffer for the acquire-time "prep" submit that transitions
+    /// the newly-acquired swapchain image from `UNDEFINED` to `GENERAL` so that compute
+    /// shaders can write it via `RWTexture2D`. Consumes `image_available_semaphore`
+    /// and signals `image_ready_semaphore`; later render/present submits wait on the
+    /// latter.
+    pub prep_command_buffer: vk::CommandBuffer,
     pub image_available_semaphore: vk::Semaphore,
+    /// Signaled by the acquire-time prep submit once the swapchain image is in
+    /// `GENERAL` layout. Render and compute-only present paths wait on this instead
+    /// of `image_available_semaphore`, so the swapchain image is always in a
+    /// compute-writable layout by the time any downstream submit touches it.
+    pub image_ready_semaphore: vk::Semaphore,
     pub render_finished_semaphore: vk::Semaphore,
     pub in_flight_fence: vk::Fence,
+    /// Set after `surface_render` submits the graphics command buffer. Compute-only
+    /// presentation uses a barrier submit in `present` instead (see `surface::present`).
+    pub render_pass_submitted: bool,
 }
 
 /// Surface (swapchain) state for window presentation.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -168,12 +168,14 @@ impl Buffer {
     /// Get this buffer's typed bindless handle for read-only structured-buffer
     /// access (maps to `goldy_dyn_buf_ro` / `StructuredBuffer<T>`).
     ///
-    /// Uses the SRV index on DX12, which may differ from the UAV index.
-    /// Always returns a [`BindlessCategory::Scattered`] handle since
-    /// `goldy_dyn_buf_ro` reads from the storage-buffer pool on every backend.
+    /// Uses [`Self::bindless_srv_index`]: on Direct3D 12, scattered storage buffers have a
+    /// separate SRV heap slot from the UAV; on Vulkan and Metal the read index matches
+    /// [`Self::bindless_index`]. The handle's [`BindlessCategory`] follows
+    /// [`Self::access`], same as [`Self::bindless_handle`], so non-DX12 backends produce the
+    /// same handle as `bindless_handle()` when the indices coincide.
     pub fn bindless_srv_handle(&self) -> Option<BindlessHandle> {
         self.bindless_srv_index()
-            .map(|i| BindlessHandle::new(BindlessCategory::Scattered, i))
+            .map(|i| BindlessHandle::new(BindlessCategory::from(self.access), i))
     }
 
     /// Get the buffer's SRV (read-only) bindless index for `StructuredBuffer<T>` / `goldy_dyn_buf_ro` access.


### PR DESCRIPTION
- Updated the compute shader in `compute_to_surface.rs` to enhance the animated plasma effect and improve UV coordinate calculations.
- Modified the `Buffer` and `SurfaceState` structures to support typed bindless handles and manage compute scratch textures, ensuring proper resource handling during rendering.
- Adjusted DX12 and Vulkan backends to handle swapchain images correctly, preventing issues with UAV usage on swapchain buffers.
- Enhanced synchronization mechanisms in `FrameSync` to track render pass submissions, improving the reliability of the rendering pipeline.