### PR TITLE
Implement buffer stride validation for push constants

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -97,6 +97,20 @@ The **`gradient`** and **`checkerboard`** examples demonstrate this with `TimeUn
 
 Standalone reflection without shader creation remains available via **`Device::reflect_struct`** and **`SlangCompiler::reflect_struct_layout`**.
 
+## Buffer stride validation (push constants)
+
+A common footgun is uploading uniform or structured data with the wrong **element stride** (for example passing `bytemuck::bytes_of(&uniforms)` into `Buffer::with_data`, which infers `T = u8` and stride 1). That can work on Vulkan but yield silent wrong reads on Direct3D 12 structured-buffer views.
+
+`GOLDY_VALIDATE_LAYOUTS` covers this too. When enabled, Goldy validates at **dispatch / draw time** that each buffer bound via `set_push_constants_typed` has the same element stride the shader expects for `goldy_dyn_buf_ro<T>`, `goldy_dyn_scattered<T>`, `goldy_dyn_broadcast<T>`, and `goldy_dyn_byte_address` (byte stride 1).
+
+```bash
+GOLDY_VALIDATE_LAYOUTS=1 cargo run --example compute_to_surface
+```
+
+This is **off by default** (no per-dispatch cost). Turn it on when results look wrong after a binding or buffer upload change, or when debugging cross-backend differences.
+
+The check compares the buffer’s recorded stride (from `Buffer::with_data`, `with_bytes_stride`, `new_with_stride`, etc.) against Slang’s reflected size of `T` for each literal `goldy_dyn_*<T>(N)` slot. If reflection cannot resolve a type name, that slot is skipped with a warning in the `goldy::slang` tracing target.
+
 ## Inspecting Compiled Shader Assembly
 
 When a shader produces unexpected results, inspecting the compiled bytecode can reveal codegen issues that aren't visible in the source. This is useful when:

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -676,6 +676,34 @@ pub(super) fn bindless_srv_index(state: &Dx12State, buffer_handle: BufferHandle)
         .and_then(|b| b.bindless_srv_offset.or(b.bindless_offset))
 }
 
+/// Effective structured-buffer element stride for `GOLDY_VALIDATE_BUFFER_STRIDES` checks.
+pub(super) fn element_stride_for_bindless_handle(
+    state: &Dx12State,
+    handle: crate::types::BindlessHandle,
+) -> Option<u32> {
+    use crate::types::BindlessCategory;
+    let idx = handle.index();
+    for b in state.buffers.values() {
+        match handle.category() {
+            BindlessCategory::Scattered if !b.is_storage => continue,
+            BindlessCategory::Broadcast if b.is_storage => continue,
+            BindlessCategory::Scattered | BindlessCategory::Broadcast => {}
+            _ => continue,
+        }
+        let matches_idx = b.bindless_offset == Some(idx)
+            || (handle.category() == BindlessCategory::Scattered
+                && b.bindless_srv_offset == Some(idx));
+        if !matches_idx {
+            continue;
+        }
+        if b.is_storage {
+            return Some(b.element_stride.unwrap_or(4));
+        }
+        return b.element_stride;
+    }
+    None
+}
+
 /// Read buffer contents back to CPU memory.
 ///
 /// For DEFAULT heap buffers (storage), creates a readback buffer and copies.

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -1,6 +1,7 @@
 //! Compute pipeline and dispatch logic.
 
 use super::barriers;
+use super::buffer;
 use super::shader;
 use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, Dx12State};
 use super::{ComputePipelineHandle, DeviceHandle, ShaderHandle};
@@ -19,11 +20,16 @@ pub(super) fn create(
     let cs_bytecode =
         shader::ensure_stage_compiled(state, compute_shader, crate::slang::SlangStage::Compute)?;
 
-    let push_constant_categories = state
+    let (push_constant_categories, push_constant_buffer_strides) = state
         .shaders
         .get(&compute_shader)
         .and_then(|s| s.reflection.as_ref())
-        .map(|r| r.push_constant_categories.clone())
+        .map(|r| {
+            (
+                r.push_constant_categories.clone(),
+                r.push_constant_buffer_strides.clone(),
+            )
+        })
         .unwrap_or_default();
     let shader_debug_name = format!("compute_shader#{compute_shader}");
 
@@ -68,6 +74,7 @@ pub(super) fn create(
             root_signature,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );
@@ -234,6 +241,12 @@ pub(super) fn submit(
                         typed_handles,
                         &pipeline.push_constant_categories,
                         &pipeline.shader_debug_name,
+                    )?;
+                    crate::backend::validate_typed_push_constant_buffer_strides(
+                        typed_handles,
+                        &pipeline.push_constant_buffer_strides,
+                        &pipeline.shader_debug_name,
+                        |h| buffer::element_stride_for_bindless_handle(state, h),
                     )?;
                 }
                 let mut indices = types::BindlessIndices::default();

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -12,25 +12,38 @@ fn push_constant_expectations(
     state: &Dx12State,
     vertex_shader: ShaderHandle,
     fragment_shader: ShaderHandle,
-) -> (Vec<Option<crate::types::BindlessCategory>>, String) {
-    let fs_cats = state
+) -> (
+    Vec<Option<crate::types::BindlessCategory>>,
+    Vec<Option<u32>>,
+    String,
+) {
+    let fs = state
         .shaders
         .get(&fragment_shader)
-        .and_then(|s| s.reflection.as_ref())
+        .and_then(|s| s.reflection.as_ref());
+    let fs_cats = fs
         .map(|r| r.push_constant_categories.clone())
         .unwrap_or_default();
-    let cats = if !fs_cats.is_empty() {
-        fs_cats
+    let fs_strides = fs
+        .map(|r| r.push_constant_buffer_strides.clone())
+        .unwrap_or_default();
+    let (cats, strides) = if !fs_cats.is_empty() {
+        (fs_cats, fs_strides)
     } else {
-        state
+        let vs = state
             .shaders
             .get(&vertex_shader)
-            .and_then(|s| s.reflection.as_ref())
-            .map(|r| r.push_constant_categories.clone())
-            .unwrap_or_default()
+            .and_then(|s| s.reflection.as_ref());
+        (
+            vs.map(|r| r.push_constant_categories.clone())
+                .unwrap_or_default(),
+            vs.map(|r| r.push_constant_buffer_strides.clone())
+                .unwrap_or_default(),
+        )
     };
     (
         cats,
+        strides,
         format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})"),
     )
 }
@@ -52,7 +65,7 @@ pub(super) fn create(
     let fs_bytecode =
         shader::ensure_stage_compiled(state, fragment_shader, crate::slang::SlangStage::Fragment)?;
 
-    let (push_constant_categories, shader_debug_name) =
+    let (push_constant_categories, push_constant_buffer_strides, shader_debug_name) =
         push_constant_expectations(state, vertex_shader, fragment_shader);
 
     let logical_device = state
@@ -204,6 +217,7 @@ pub(super) fn create(
             topology,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );
@@ -229,7 +243,7 @@ pub(super) fn create_with_depth(
     let fs_bytecode =
         shader::ensure_stage_compiled(state, fragment_shader, crate::slang::SlangStage::Fragment)?;
 
-    let (push_constant_categories, shader_debug_name) =
+    let (push_constant_categories, push_constant_buffer_strides, shader_debug_name) =
         push_constant_expectations(state, vertex_shader, fragment_shader);
 
     let logical_device = state
@@ -393,6 +407,7 @@ pub(super) fn create_with_depth(
             topology,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );

--- a/src/backend/dx12/render_commands.rs
+++ b/src/backend/dx12/render_commands.rs
@@ -3,6 +3,7 @@
 //! This module contains `record` which is used by both
 //! `render_to_target` and `surface_render` to avoid code duplication.
 
+use super::buffer;
 use super::types::{self, Dx12State};
 use super::utils::{index_format_to_dxgi, topology_to_d3d12};
 use super::{DeviceHandle, RenderCommand};
@@ -119,6 +120,12 @@ pub(super) fn record(
                         typed_handles,
                         &pipeline.push_constant_categories,
                         &pipeline.shader_debug_name,
+                    )?;
+                    crate::backend::validate_typed_push_constant_buffer_strides(
+                        typed_handles,
+                        &pipeline.push_constant_buffer_strides,
+                        &pipeline.shader_debug_name,
+                        |h| buffer::element_stride_for_bindless_handle(state, h),
                     )?;
                 }
                 let mut indices = types::BindlessIndices::default();

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -257,6 +257,8 @@ pub(crate) struct PipelineState {
     /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
     /// calls in the bound shader(s). Empty disables validation.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     pub shader_debug_name: String,
 }
@@ -272,6 +274,8 @@ pub(crate) struct ComputePipelineState {
     /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
     /// calls in the bound compute shader. Empty disables validation.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     pub shader_debug_name: String,
 }

--- a/src/backend/metal/buffer.rs
+++ b/src/backend/metal/buffer.rs
@@ -6,6 +6,7 @@ use crate::backend::DataAccess;
 use ::metal as mtl;
 use anyhow::{Context, Result};
 use mtl::MTLResourceOptions;
+use std::collections::HashMap;
 
 /// Create a buffer with the given size and access pattern.
 pub(super) fn create(
@@ -13,7 +14,7 @@ pub(super) fn create(
     device_handle: DeviceHandle,
     size: u64,
     access: DataAccess,
-    _element_stride: Option<u32>,
+    element_stride: Option<u32>,
 ) -> Result<BufferHandle> {
     let logical_device = state
         .devices
@@ -75,6 +76,8 @@ pub(super) fn create(
             buffer,
             size,
             arg_buffer_index,
+            access,
+            element_stride,
         },
     );
 
@@ -90,6 +93,7 @@ pub(super) fn create_view(
     parent_handle: BufferHandle,
     offset: u64,
     size: u64,
+    element_stride: Option<u32>,
 ) -> Result<BufferHandle> {
     let parent = state
         .buffers
@@ -138,6 +142,8 @@ pub(super) fn create_view(
             buffer: parent_mtl_buffer,
             size,
             arg_buffer_index,
+            access: DataAccess::Scattered,
+            element_stride,
         },
     );
 
@@ -192,6 +198,38 @@ pub(super) fn bindless_index(state: &MetalState, buffer_handle: BufferHandle) ->
         .buffers
         .get(&buffer_handle)
         .map(|b| b.arg_buffer_index)
+}
+
+/// Effective structured-buffer element stride for `GOLDY_VALIDATE_BUFFER_STRIDES` checks.
+pub(super) fn element_stride_for_bindless_handle_map(
+    buffers: &HashMap<BufferHandle, BufferState>,
+    handle: crate::types::BindlessHandle,
+) -> Option<u32> {
+    use crate::types::{BindlessCategory, DataAccess};
+    let want_access = match handle.category() {
+        BindlessCategory::Scattered => DataAccess::Scattered,
+        BindlessCategory::Broadcast => DataAccess::Broadcast,
+        _ => return None,
+    };
+    let idx = handle.index();
+    for b in buffers.values() {
+        if b.access != want_access || b.arg_buffer_index != idx {
+            continue;
+        }
+        if b.access == DataAccess::Scattered {
+            return Some(b.element_stride.unwrap_or(4));
+        }
+        return b.element_stride;
+    }
+    None
+}
+
+/// See [`element_stride_for_bindless_handle_map`].
+pub(super) fn element_stride_for_bindless_handle(
+    state: &MetalState,
+    handle: crate::types::BindlessHandle,
+) -> Option<u32> {
+    element_stride_for_bindless_handle_map(&state.buffers, handle)
 }
 
 /// Read buffer contents back to CPU memory.

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -1,6 +1,7 @@
 //! Compute pipeline and dispatch logic.
 
 use super::super::{ComputeCommand, ComputePipelineHandle, DeviceHandle, FenceToken, ShaderHandle};
+use super::buffer;
 use super::shader::parse_numthreads;
 use super::types::PUSH_CONSTANTS_SLOT;
 use super::types::{BindlessIndices, ComputePipelineState, MetalState, MAX_PUSH_CONSTANT_INDICES};
@@ -48,10 +49,15 @@ pub(super) fn create(
         .new_compute_pipeline_state_with_function(&function)
         .map_err(|e| anyhow::anyhow!("Failed to create compute pipeline: {}", e))?;
 
-    let push_constant_categories = shader
+    let (push_constant_categories, push_constant_buffer_strides) = shader
         .reflection
         .as_ref()
-        .map(|r| r.push_constant_categories.clone())
+        .map(|r| {
+            (
+                r.push_constant_categories.clone(),
+                r.push_constant_buffer_strides.clone(),
+            )
+        })
         .unwrap_or_default();
 
     let handle = state.next_compute_pipeline_handle;
@@ -64,6 +70,7 @@ pub(super) fn create(
             pipeline,
             workgroup_size,
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name: "cs_main".to_string(),
         },
     );
@@ -223,6 +230,12 @@ fn record_commands_to_buffer(
                     handles,
                     &pipeline.push_constant_categories,
                     &pipeline.shader_debug_name,
+                )?;
+                super::super::validate_typed_push_constant_buffer_strides(
+                    handles,
+                    &pipeline.push_constant_buffer_strides,
+                    &pipeline.shader_debug_name,
+                    |h| buffer::element_stride_for_bindless_handle(state, h),
                 )?;
                 let mut indices = BindlessIndices::default();
                 for (i, handle) in handles.iter().enumerate() {

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -143,9 +143,9 @@ impl GpuBackend for MetalBackend {
         parent: BufferHandle,
         offset: u64,
         size: u64,
-        _element_stride: Option<u32>,
+        element_stride: Option<u32>,
     ) -> Result<BufferHandle> {
-        buffer::create_view(&mut self.state, parent, offset, size)
+        buffer::create_view(&mut self.state, parent, offset, size, element_stride)
     }
 
     fn read_buffer_to_cpu(

--- a/src/backend/metal/pipeline.rs
+++ b/src/backend/metal/pipeline.rs
@@ -129,6 +129,19 @@ pub(super) fn create_with_depth(
         })
         .unwrap_or_default();
 
+    let push_constant_buffer_strides = fs_shader
+        .reflection
+        .as_ref()
+        .map(|r| r.push_constant_buffer_strides.clone())
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            vs_shader
+                .reflection
+                .as_ref()
+                .map(|r| r.push_constant_buffer_strides.clone())
+        })
+        .unwrap_or_default();
+
     let handle = state.next_pipeline_handle;
     state.next_pipeline_handle += 1;
 
@@ -140,6 +153,7 @@ pub(super) fn create_with_depth(
             depth_stencil: depth_stencil_state,
             primitive_type: topology_to_mtl(topology),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name: "fs_main/vs_main".to_string(),
         },
     );

--- a/src/backend/metal/render_commands.rs
+++ b/src/backend/metal/render_commands.rs
@@ -3,6 +3,7 @@
 //! Used by both render_target and surface to avoid code duplication.
 
 use super::super::{BufferHandle, PipelineHandle, RenderCommand};
+use super::buffer;
 use super::types::{
     BindlessIndices, PipelineState, MAX_PUSH_CONSTANT_INDICES, PUSH_CONSTANTS_SLOT,
 };
@@ -113,15 +114,28 @@ pub(super) fn record(
             RenderCommand::SetPushConstantsTyped {
                 handles: typed_handles,
             } => {
-                let (expectations, debug_name): (&[Option<crate::types::BindlessCategory>], &str) =
-                    match current_pipeline {
-                        Some(p) => (&p.push_constant_categories, p.shader_debug_name.as_str()),
-                        None => (&[], "<no pipeline bound>"),
-                    };
+                let (expectations, stride_expectations, debug_name): (
+                    &[Option<crate::types::BindlessCategory>],
+                    &[Option<u32>],
+                    &str,
+                ) = match current_pipeline {
+                    Some(p) => (
+                        &p.push_constant_categories,
+                        &p.push_constant_buffer_strides,
+                        p.shader_debug_name.as_str(),
+                    ),
+                    None => (&[], &[], "<no pipeline bound>"),
+                };
                 super::super::validate_typed_push_constants(
                     typed_handles,
                     expectations,
                     debug_name,
+                )?;
+                super::super::validate_typed_push_constant_buffer_strides(
+                    typed_handles,
+                    stride_expectations,
+                    debug_name,
+                    |h| buffer::element_stride_for_bindless_handle_map(buffers, h),
                 )?;
                 let mut indices = BindlessIndices::default();
                 for (i, handle) in typed_handles.iter().enumerate() {

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -521,6 +521,9 @@ pub(crate) struct BufferState {
     pub size: u64,
     /// Index in the global argument buffer (always present — heap required).
     pub arg_buffer_index: u32,
+    pub access: crate::types::DataAccess,
+    /// Structured-buffer / uniform element stride from buffer creation.
+    pub element_stride: Option<u32>,
 }
 
 /// Shader module state with cached compiled stages.
@@ -554,6 +557,8 @@ pub(crate) struct PipelineState {
     /// Per-push-constant-slot category expected by the fragment/vertex shader,
     /// inferred from `goldy_dyn_*(N)` calls. Empty disables validation.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     pub shader_debug_name: String,
 }
@@ -569,6 +574,8 @@ pub(crate) struct ComputePipelineState {
     /// all-`None` disables validation. See
     /// [`crate::slang::ShaderReflection::push_constant_categories`].
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     /// Defaults to `"cs_main"` for compute pipelines.
     pub shader_debug_name: String,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -97,6 +97,63 @@ pub(crate) fn validate_typed_push_constants(
     }
 }
 
+/// Validate typed push-constant buffer element strides when
+/// `GOLDY_VALIDATE_BUFFER_STRIDES` is enabled (see repository `DEBUGGING.md`).
+///
+/// `expected_strides[i]` is the byte stride the shader expects at slot `i`
+/// (from Slang reflection). `None` skips that slot. `resolve_stride` must return
+/// the host buffer's effective stride, or `None` if it cannot be determined.
+#[cfg(any(
+    test,
+    feature = "vulkan",
+    all(feature = "dx12", target_os = "windows"),
+    all(feature = "metal", target_os = "macos"),
+))]
+pub(crate) fn validate_typed_push_constant_buffer_strides(
+    handles: &[BindlessHandle],
+    expected_strides: &[Option<u32>],
+    shader_name: &str,
+    mut resolve_stride: impl FnMut(BindlessHandle) -> Option<u32>,
+) -> Result<()> {
+    if !crate::slang::layout_validation_enabled() {
+        return Ok(());
+    }
+    let mut mismatches: Vec<String> = Vec::new();
+    for (slot, handle) in handles.iter().enumerate() {
+        let Some(expected) = expected_strides.get(slot).copied().flatten() else {
+            continue;
+        };
+        match handle.category() {
+            BindlessCategory::Scattered | BindlessCategory::Broadcast => {}
+            _ => continue,
+        }
+        let Some(actual) = resolve_stride(*handle) else {
+            mismatches.push(format!(
+                "slot {slot}: shader expects element stride {expected} bytes but no element stride could be resolved for bindless index {} ({})",
+                handle.index(),
+                handle.category().name()
+            ));
+            continue;
+        };
+        if actual != expected {
+            mismatches.push(format!(
+                "slot {slot}: shader expects element stride {expected} bytes but bound buffer has stride {actual} (bindless index {})",
+                handle.index()
+            ));
+        }
+    }
+    if mismatches.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "push-constant buffer stride mismatch in shader `{shader_name}`:\n  {}\n\
+             Hint: match `Buffer::with_data` / `with_bytes_stride` / `new_with_stride` to the `T` in `goldy_dyn_*<T>`. \
+             See DEBUGGING.md (`GOLDY_VALIDATE_LAYOUTS`).",
+            mismatches.join("\n  ")
+        );
+    }
+}
+
 // Re-export raw_window_handle for Surface API users
 pub use raw_window_handle;
 
@@ -733,5 +790,78 @@ mod typed_push_constant_validation_tests {
         assert!(err.contains("slot 1"), "slot 1 must appear: {err}");
         // Exactly one mismatch reported.
         assert_eq!(err.matches("slot ").count(), 1, "only one mismatch: {err}");
+    }
+}
+
+#[cfg(test)]
+mod typed_push_constant_stride_validation_tests {
+    use super::validate_typed_push_constant_buffer_strides;
+    use crate::types::{BindlessCategory, BindlessHandle};
+    use std::ffi::OsString;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn stride_skipped_when_env_off() {
+        let _g = EnvGuard::remove("GOLDY_VALIDATE_LAYOUTS");
+        let handles = [BindlessHandle::new(BindlessCategory::Scattered, 0)];
+        let expected = [Some(16u32)];
+        validate_typed_push_constant_buffer_strides(&handles, &expected, "s", |_| Some(4)).unwrap();
+    }
+
+    #[test]
+    fn stride_ok_when_env_on() {
+        let _g = EnvGuard::set("GOLDY_VALIDATE_LAYOUTS", "1");
+        let handles = [BindlessHandle::new(BindlessCategory::Scattered, 0)];
+        let expected = [Some(16u32)];
+        validate_typed_push_constant_buffer_strides(&handles, &expected, "s", |_| Some(16))
+            .unwrap();
+    }
+
+    #[test]
+    fn stride_err_on_mismatch() {
+        let _g = EnvGuard::set("GOLDY_VALIDATE_LAYOUTS", "1");
+        let handles = [BindlessHandle::new(BindlessCategory::Scattered, 0)];
+        let expected = [Some(16u32)];
+        let err =
+            validate_typed_push_constant_buffer_strides(&handles, &expected, "my_cs", |_| Some(1))
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("16"), "expected stride: {err}");
+        assert!(err.contains('1'), "actual stride: {err}");
+    }
+
+    #[test]
+    fn stride_skips_non_buffer_categories() {
+        let _g = EnvGuard::set("GOLDY_VALIDATE_LAYOUTS", "1");
+        let handles = [BindlessHandle::new(BindlessCategory::Texture, 0)];
+        let expected = [Some(4u32)];
+        validate_typed_push_constant_buffer_strides(&handles, &expected, "s", |_| None).unwrap();
     }
 }

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -4,6 +4,7 @@ use super::types::{self, BufferState};
 use super::utils::find_memory_type;
 use super::{BufferHandle, DeviceHandle};
 use crate::backend::DataAccess;
+use crate::types::{BindlessCategory, BindlessHandle};
 use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
@@ -75,7 +76,7 @@ pub(super) fn create(
     device_handle: DeviceHandle,
     size: u64,
     access: DataAccess,
-    _element_stride: Option<u32>,
+    element_stride: Option<u32>,
 ) -> Result<BufferHandle> {
     let logical_device = devices
         .get(&device_handle)
@@ -205,6 +206,7 @@ pub(super) fn create(
             size,
             bindless_index,
             is_storage,
+            element_stride,
             staging_buffer,
             staging_memory,
             is_view: false,
@@ -251,7 +253,7 @@ pub(super) fn create_view(
     parent_handle: BufferHandle,
     offset: u64,
     size: u64,
-    _element_stride: Option<u32>,
+    element_stride: Option<u32>,
 ) -> Result<BufferHandle> {
     let parent = buffers
         .get(&parent_handle)
@@ -330,6 +332,7 @@ pub(super) fn create_view(
             size,
             bindless_index,
             is_storage,
+            element_stride,
             staging_buffer: None,
             staging_memory: None,
             is_view: true,
@@ -474,6 +477,30 @@ pub(super) fn bindless_index(
     buffer_handle: BufferHandle,
 ) -> Option<u32> {
     buffers.get(&buffer_handle).and_then(|b| b.bindless_index)
+}
+
+/// Effective structured-buffer element stride for `GOLDY_VALIDATE_BUFFER_STRIDES` checks.
+pub(super) fn element_stride_for_bindless_handle(
+    buffers: &HashMap<BufferHandle, BufferState>,
+    handle: BindlessHandle,
+) -> Option<u32> {
+    let idx = handle.index();
+    for b in buffers.values() {
+        match handle.category() {
+            BindlessCategory::Scattered if !b.is_storage => continue,
+            BindlessCategory::Broadcast if b.is_storage => continue,
+            BindlessCategory::Scattered | BindlessCategory::Broadcast => {}
+            _ => continue,
+        }
+        if b.bindless_index != Some(idx) {
+            continue;
+        }
+        if b.is_storage {
+            return Some(b.element_stride.unwrap_or(4));
+        }
+        return b.element_stride;
+    }
+    None
 }
 
 /// Read buffer contents to CPU. Copies from offset 0 for length output.len().

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -1,5 +1,6 @@
 //! Compute pipeline and dispatch logic.
 
+use super::buffer;
 use super::types::{self, BindlessIndices, ComputePipelineState, LogicalDevice};
 use super::{ComputePipelineHandle, DeviceHandle};
 use crate::backend::{ComputeCommand, FenceToken};
@@ -16,6 +17,7 @@ pub(super) fn create(
     device_handle: DeviceHandle,
     cs_module: vk::ShaderModule,
     push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    push_constant_buffer_strides: Vec<Option<u32>>,
     shader_debug_name: String,
 ) -> Result<ComputePipelineHandle> {
     let logical_device = devices
@@ -66,6 +68,7 @@ pub(super) fn create(
             owns_layout,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );
@@ -239,6 +242,12 @@ pub(super) fn submit(
                         typed_handles,
                         &pipeline.push_constant_categories,
                         &pipeline.shader_debug_name,
+                    )?;
+                    crate::backend::validate_typed_push_constant_buffer_strides(
+                        typed_handles,
+                        &pipeline.push_constant_buffer_strides,
+                        &pipeline.shader_debug_name,
+                        |h| buffer::element_stride_for_bindless_handle(buffers, h),
                     )?;
                     let mut indices = BindlessIndices::default();
                     for (i, handle) in typed_handles.iter().enumerate() {

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -40,23 +40,36 @@ fn render_push_constant_expectations(
     shaders: &HashMap<ShaderHandle, ShaderState>,
     vertex_shader: ShaderHandle,
     fragment_shader: ShaderHandle,
-) -> (Vec<Option<crate::types::BindlessCategory>>, String) {
-    let fs_cats = shaders
+) -> (
+    Vec<Option<crate::types::BindlessCategory>>,
+    Vec<Option<u32>>,
+    String,
+) {
+    let fs = shaders
         .get(&fragment_shader)
-        .and_then(|s| s.reflection.as_ref())
+        .and_then(|s| s.reflection.as_ref());
+    let fs_cats = fs
         .map(|r| r.push_constant_categories.clone())
         .unwrap_or_default();
-    let cats = if !fs_cats.is_empty() {
-        fs_cats
+    let fs_strides = fs
+        .map(|r| r.push_constant_buffer_strides.clone())
+        .unwrap_or_default();
+    let (cats, strides) = if !fs_cats.is_empty() {
+        (fs_cats, fs_strides)
     } else {
-        shaders
+        let vs = shaders
             .get(&vertex_shader)
-            .and_then(|s| s.reflection.as_ref())
-            .map(|r| r.push_constant_categories.clone())
-            .unwrap_or_default()
+            .and_then(|s| s.reflection.as_ref());
+        (
+            vs.map(|r| r.push_constant_categories.clone())
+                .unwrap_or_default(),
+            vs.map(|r| r.push_constant_buffer_strides.clone())
+                .unwrap_or_default(),
+        )
     };
     (
         cats,
+        strides,
         format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})"),
     )
 }
@@ -421,7 +434,7 @@ impl GpuBackend for VulkanBackend {
         let fs_module =
             self.ensure_shader_stage_compiled(fragment_shader, crate::slang::SlangStage::Fragment)?;
 
-        let (push_constant_categories, shader_debug_name) =
+        let (push_constant_categories, push_constant_buffer_strides, shader_debug_name) =
             render_push_constant_expectations(&self.state.shaders, vertex_shader, fragment_shader);
 
         pipeline::create(
@@ -435,6 +448,7 @@ impl GpuBackend for VulkanBackend {
             topology,
             target_format,
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         )
     }
@@ -632,7 +646,7 @@ impl GpuBackend for VulkanBackend {
         let fs_module =
             self.ensure_shader_stage_compiled(fragment_shader, crate::slang::SlangStage::Fragment)?;
 
-        let (push_constant_categories, shader_debug_name) =
+        let (push_constant_categories, push_constant_buffer_strides, shader_debug_name) =
             render_push_constant_expectations(&self.state.shaders, vertex_shader, fragment_shader);
 
         pipeline::create_with_depth(
@@ -647,6 +661,7 @@ impl GpuBackend for VulkanBackend {
             target_format,
             depth_stencil,
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         )
     }
@@ -796,17 +811,19 @@ impl GpuBackend for VulkanBackend {
         let cs_module =
             self.ensure_shader_stage_compiled(compute_shader, crate::slang::SlangStage::Compute)?;
 
-        let (push_constant_categories, shader_debug_name) = self
+        let (push_constant_categories, push_constant_buffer_strides, shader_debug_name) = self
             .state
             .shaders
             .get(&compute_shader)
             .map(|s| {
-                let cats = s
-                    .reflection
-                    .as_ref()
+                let refl = s.reflection.as_ref();
+                let cats = refl
                     .map(|r| r.push_constant_categories.clone())
                     .unwrap_or_default();
-                (cats, format!("compute_shader#{compute_shader}"))
+                let strides = refl
+                    .map(|r| r.push_constant_buffer_strides.clone())
+                    .unwrap_or_default();
+                (cats, strides, format!("compute_shader#{compute_shader}"))
             })
             .unwrap_or_default();
 
@@ -817,6 +834,7 @@ impl GpuBackend for VulkanBackend {
             device_handle,
             cs_module,
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         )
     }

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -25,6 +25,7 @@ pub(super) fn create(
     topology: PrimitiveTopology,
     target_format: TextureFormat,
     push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    push_constant_buffer_strides: Vec<Option<u32>>,
     shader_debug_name: String,
 ) -> Result<PipelineHandle> {
     let logical_device = devices
@@ -156,6 +157,7 @@ pub(super) fn create(
             owns_layout,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );
@@ -178,6 +180,7 @@ pub(super) fn create_with_depth(
     target_format: TextureFormat,
     depth_stencil: Option<&DepthStencilState>,
     push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    push_constant_buffer_strides: Vec<Option<u32>>,
     shader_debug_name: String,
 ) -> Result<PipelineHandle> {
     let logical_device = devices
@@ -352,6 +355,7 @@ pub(super) fn create_with_depth(
             owns_layout,
             parameter_block_layouts: Vec::new(),
             push_constant_categories,
+            push_constant_buffer_strides,
             shader_debug_name,
         },
     );

--- a/src/backend/vulkan/render_commands.rs
+++ b/src/backend/vulkan/render_commands.rs
@@ -3,6 +3,7 @@
 //! This module contains `record_render_commands` which is used by both
 //! `render_to_target` and `surface_render` to avoid code duplication.
 
+use super::buffer;
 use super::types::{self, BindlessIndices, MAX_PUSH_CONSTANT_INDICES};
 use super::utils::index_format_to_vk;
 use super::{BufferHandle, PipelineHandle, RenderCommand};
@@ -123,6 +124,12 @@ pub(super) fn record(
                         typed_handles,
                         &pipeline.push_constant_categories,
                         &pipeline.shader_debug_name,
+                    )?;
+                    crate::backend::validate_typed_push_constant_buffer_strides(
+                        typed_handles,
+                        &pipeline.push_constant_buffer_strides,
+                        &pipeline.shader_debug_name,
+                        |h| buffer::element_stride_for_bindless_handle(buffers, h),
                     )?;
                     let mut indices = BindlessIndices::default();
                     for (i, handle) in typed_handles.iter().enumerate() {

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -227,6 +227,8 @@ pub(crate) struct BufferState {
     /// Whether this is a storage buffer (vs uniform buffer)
     #[allow(dead_code)]
     pub is_storage: bool,
+    /// Structured-buffer / uniform element stride from buffer creation (for optional validation).
+    pub element_stride: Option<u32>,
     /// HOST_VISIBLE staging buffer for DEVICE_LOCAL storage buffers (CPU upload/readback)
     pub staging_buffer: Option<vk::Buffer>,
     pub staging_memory: Option<vk::DeviceMemory>,
@@ -269,6 +271,8 @@ pub(crate) struct PipelineState {
     /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
     /// calls in the bound shader(s). Empty disables validation.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     pub shader_debug_name: String,
 }
@@ -286,6 +290,8 @@ pub(crate) struct ComputePipelineState {
     /// Per-push-constant-slot category inferred from `goldy_dyn_*(N)` literal
     /// calls in the bound compute shader. Empty disables validation.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per-slot structured element stride from shader reflection (bytes), when resolved.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
     /// Human-readable identifier used in category-mismatch error messages.
     pub shader_debug_name: String,
 }

--- a/src/slang/compiler.rs
+++ b/src/slang/compiler.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use super::ffi::*;
 use super::loader::SlangLibrary;
@@ -14,14 +14,14 @@ use crate::types::OptimizationLevel;
 use crate::{goldy_event, goldy_span};
 
 /// Returns `true` when `GOLDY_VALIDATE_LAYOUTS=1` (or any truthy value).
-/// Checked once per process and cached.
+///
+/// Controls both struct layout checks (at compile time) and buffer element-stride
+/// checks (at dispatch time). Reads the environment on every call so that tests
+/// can toggle the flag without restarting the process.
 pub fn layout_validation_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        std::env::var("GOLDY_VALIDATE_LAYOUTS")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
-            .unwrap_or(false)
-    })
+    std::env::var("GOLDY_VALIDATE_LAYOUTS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
 }
 
 // ============================================================================
@@ -228,6 +228,177 @@ pub fn analyze_push_constant_categories_from_source(
         .collect()
 }
 
+/// Parsed stride hint for a push-constant slot (before Slang resolution).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PushConstantStrideHint {
+    /// Reflect `T` from the same compile request to get the element byte stride.
+    Structured { type_name: String },
+    /// `goldy_dyn_byte_address` — host buffer should use byte stride 1.
+    ByteAddress,
+}
+
+/// Scan Slang source for `goldy_dyn_buf_ro<T>(N)`, `goldy_dyn_scattered<T>(N)`,
+/// `goldy_dyn_broadcast<T>(N)`, and `goldy_dyn_byte_address(N)` with literal
+/// slot indices. Returns a sparse vector aligned to slot indices (same trimming
+/// rules as [`analyze_push_constant_categories_from_source`]).
+///
+/// Conflicting hints for the same slot (e.g. different `T` or typed buffer vs
+/// byte-address) collapse to `None` so validation is skipped for that slot.
+pub fn analyze_push_constant_stride_hints_from_source(
+    source: &str,
+) -> Vec<Option<PushConstantStrideHint>> {
+    #[derive(Clone, PartialEq, Eq)]
+    enum Slot {
+        Unknown,
+        One(PushConstantStrideHint),
+        Conflict,
+    }
+    let mut slots = vec![Slot::Unknown; 16];
+
+    #[derive(Clone, Copy)]
+    struct DynStrideFunc {
+        name: &'static str,
+        /// `true` = requires a `<T>` generic before `(`.
+        needs_type_arg: bool,
+    }
+
+    const STRIDE_FUNCS: &[DynStrideFunc] = &[
+        DynStrideFunc {
+            name: "goldy_dyn_scattered",
+            needs_type_arg: true,
+        },
+        DynStrideFunc {
+            name: "goldy_dyn_buf_ro",
+            needs_type_arg: true,
+        },
+        DynStrideFunc {
+            name: "goldy_dyn_broadcast",
+            needs_type_arg: true,
+        },
+        DynStrideFunc {
+            name: "goldy_dyn_byte_address",
+            needs_type_arg: false,
+        },
+    ];
+
+    for spec in STRIDE_FUNCS {
+        let fn_name = spec.name;
+        let mut search_from = 0usize;
+        while let Some(rel) = source[search_from..].find(fn_name) {
+            let abs = search_from + rel;
+            search_from = abs + fn_name.len();
+
+            if abs > 0 {
+                let prev = source.as_bytes()[abs - 1];
+                if prev.is_ascii_alphanumeric() || prev == b'_' {
+                    continue;
+                }
+            }
+
+            let mut cursor = search_from;
+            let bytes = source.as_bytes();
+
+            let hint = if spec.needs_type_arg {
+                while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                    cursor += 1;
+                }
+                if cursor >= bytes.len() || bytes[cursor] != b'<' {
+                    continue;
+                }
+                let mut depth = 1i32;
+                let type_start = cursor + 1;
+                cursor += 1;
+                while cursor < bytes.len() && depth > 0 {
+                    match bytes[cursor] {
+                        b'<' => depth += 1,
+                        b'>' => depth -= 1,
+                        _ => {}
+                    }
+                    cursor += 1;
+                }
+                if depth != 0 {
+                    continue;
+                }
+                let type_end = cursor - 1;
+                let type_name = source[type_start..type_end].trim();
+                if type_name.is_empty() {
+                    continue;
+                }
+                PushConstantStrideHint::Structured {
+                    type_name: type_name.to_string(),
+                }
+            } else {
+                while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                    cursor += 1;
+                }
+                PushConstantStrideHint::ByteAddress
+            };
+
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+
+            if cursor >= bytes.len() || bytes[cursor] != b'(' {
+                continue;
+            }
+            cursor += 1;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            let num_start = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            if cursor == num_start {
+                continue;
+            }
+            let mut end = cursor;
+            while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                end += 1;
+            }
+            if end >= bytes.len() || (bytes[end] != b')' && bytes[end] != b'u') {
+                continue;
+            }
+            if bytes[end] == b'u' {
+                end += 1;
+                while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                    end += 1;
+                }
+                if end >= bytes.len() || bytes[end] != b')' {
+                    continue;
+                }
+            }
+
+            let Ok(n) = source[num_start..cursor].parse::<usize>() else {
+                continue;
+            };
+            if n >= slots.len() {
+                continue;
+            }
+
+            slots[n] = match (&slots[n], &hint) {
+                (Slot::Unknown, _) => Slot::One(hint.clone()),
+                (Slot::One(prev), next) if prev == next => Slot::One(prev.clone()),
+                _ => Slot::Conflict,
+            };
+        }
+    }
+
+    let mut last_known = 0usize;
+    for (i, s) in slots.iter().enumerate() {
+        if !matches!(s, Slot::Unknown) {
+            last_known = i + 1;
+        }
+    }
+    slots[..last_known]
+        .iter()
+        .map(|s| match s {
+            Slot::One(h) => Some(h.clone()),
+            Slot::Unknown | Slot::Conflict => None,
+        })
+        .collect()
+}
+
 /// Complete reflection information for a compiled shader
 #[derive(Debug, Clone, Default)]
 pub struct ShaderReflection {
@@ -242,6 +413,13 @@ pub struct ShaderReflection {
     /// [`crate::types::BindlessHandle`]-typed push-constant setters to catch
     /// category mismatches at dispatch time.
     pub push_constant_categories: Vec<Option<crate::types::BindlessCategory>>,
+    /// Per push-constant slot, the structured-buffer / uniform element size in
+    /// bytes the shader expects for `goldy_dyn_*<T>(slot)` (or `1` for
+    /// `goldy_dyn_byte_address`), or `None` when stride checking doesn't apply
+    /// or couldn't be resolved. Populated at shader compile time from source
+    /// analysis + Slang reflection. Used when `GOLDY_VALIDATE_BUFFER_STRIDES`
+    /// is enabled.
+    pub push_constant_buffer_strides: Vec<Option<u32>>,
 }
 
 /// Byte layout of a Slang `struct` under uniform / constant-buffer rules (`SlangLayoutRules::Default`).
@@ -766,6 +944,9 @@ impl SlangCompiler {
                 let mut reflection = slf.extract_reflection(request)?;
                 reflection.push_constant_categories =
                     analyze_push_constant_categories_from_source(source);
+                let stride_hints = analyze_push_constant_stride_hints_from_source(source);
+                reflection.push_constant_buffer_strides =
+                    slf.resolve_push_constant_buffer_strides(request, &stride_hints);
 
                 if !layout_checks.is_empty() {
                     slf.validate_owned_layout_checks(request, layout_checks)?;
@@ -845,6 +1026,75 @@ impl SlangCompiler {
         }
 
         self.extract_struct_layout_uniform(layout_ptr, type_name)
+    }
+
+    /// Byte size of `type_name` for buffer / structured-buffer layout, using the
+    /// first non-zero size among Slang categories (shader resource, uniform,
+    /// constant buffer).
+    fn reflect_type_byte_stride_for_buffer(
+        &self,
+        request: *mut SlangCompileRequest,
+        type_name: &str,
+    ) -> Result<u32> {
+        let reflection_ptr = unsafe { (self.library.get_reflection)(request) };
+        if reflection_ptr.is_null() {
+            anyhow::bail!("No Slang reflection available after compile");
+        }
+
+        let name_cstr = CString::new(type_name).context("type_name contains null bytes")?;
+        let ty = unsafe {
+            (self.library.reflection_find_type_by_name)(reflection_ptr, name_cstr.as_ptr())
+        };
+        if ty.is_null() {
+            anyhow::bail!("Slang reflection: type `{type_name}` not found");
+        }
+
+        let layout_ptr = unsafe {
+            (self.library.reflection_get_type_layout)(reflection_ptr, ty, SlangLayoutRules::Default)
+        };
+        if layout_ptr.is_null() {
+            anyhow::bail!("Slang reflection: failed to get layout for `{type_name}`");
+        }
+
+        for cat in [
+            SlangParameterCategory::ShaderResource,
+            SlangParameterCategory::Uniform,
+            SlangParameterCategory::ConstantBuffer,
+        ] {
+            let size =
+                unsafe { (self.library.reflection_type_layout_get_size)(layout_ptr, cat as i32) };
+            if size > 0 {
+                return Ok(size as u32);
+            }
+        }
+
+        anyhow::bail!("Slang reflection: zero byte size for `{type_name}` in buffer layouts")
+    }
+
+    fn resolve_push_constant_buffer_strides(
+        &self,
+        request: *mut SlangCompileRequest,
+        hints: &[Option<PushConstantStrideHint>],
+    ) -> Vec<Option<u32>> {
+        hints
+            .iter()
+            .map(|h| match h {
+                None => None,
+                Some(PushConstantStrideHint::ByteAddress) => Some(1),
+                Some(PushConstantStrideHint::Structured { type_name }) => {
+                    match self.reflect_type_byte_stride_for_buffer(request, type_name) {
+                        Ok(s) => Some(s),
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "goldy::slang",
+                                "could not resolve push-constant stride for Slang type `{type_name}`: {e}"
+                            );
+                            None
+                        }
+                    }
+                }
+            })
+            .collect()
     }
 
     fn extract_struct_layout_uniform(
@@ -995,6 +1245,7 @@ impl SlangCompiler {
         Ok(ShaderReflection {
             parameter_blocks,
             push_constant_categories: Vec::new(),
+            push_constant_buffer_strides: Vec::new(),
         })
     }
 
@@ -1457,6 +1708,65 @@ mod struct_layout_validate_tests {
         assert!(err.contains("offset"), "expected offset mismatch: {err}");
         assert!(err.contains("`y`"), "expected field y: {err}");
     }
+
+    /// Integration test: feeds a deliberate layout mismatch through the full
+    /// `compile_with_reflection` path and checks that the error message is
+    /// actionable (contains the struct name and "offset").
+    ///
+    /// This is the path an agent hits when `GOLDY_VALIDATE_LAYOUTS=1` is set
+    /// and a `#[derive(LayoutCheckable)]` struct drifts from its Slang counterpart.
+    #[test]
+    fn layout_validation_end_to_end_catches_mismatch() {
+        use super::{OwnedLayoutCheck, ShaderTarget, SlangCompiler, SlangStage};
+        use crate::types::OptimizationLevel;
+
+        let compiler = SlangCompiler::new().expect("Slang compiler unavailable; skipping");
+
+        // A minimal compute shader that declares MyUniforms.
+        let source = r#"
+            struct MyUniforms { float x; float y; };
+            [shader("compute")]
+            [numthreads(1, 1, 1)]
+            void cs_main() {}
+        "#;
+
+        // Correct Rust layout for { float x; float y; } — size=8, y at offset 4.
+        // We intentionally claim y is at offset 8, which Slang will disagree with.
+        let bad_check = OwnedLayoutCheck {
+            type_name: "MyUniforms".into(),
+            rust_size: 8,
+            rust_fields: vec![
+                ("x".into(), 0, 4),
+                ("y".into(), 8, 4), // wrong: Slang reflects offset 4
+            ],
+        };
+
+        let err = compiler
+            .compile_with_reflection(
+                source,
+                ShaderTarget::Spirv,
+                &[("cs_main", SlangStage::Compute)],
+                &[],
+                &[],
+                &[bad_check],
+                OptimizationLevel::None,
+            )
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("MyUniforms"),
+            "error should name the mismatched struct: {err}"
+        );
+        assert!(
+            err.contains("offset"),
+            "error should describe the offset mismatch: {err}"
+        );
+        assert!(
+            err.contains("`y`"),
+            "error should name the offending field: {err}"
+        );
+    }
 }
 
 impl Drop for SlangCompiler {
@@ -1573,5 +1883,38 @@ mod push_constant_source_analysis_tests {
         // 3 slots total: None, None, Some(Broadcast) — nothing after 2.
         assert_eq!(cats.len(), 3);
         assert_eq!(cats[2], Some(BindlessCategory::Broadcast));
+    }
+
+    #[test]
+    fn stride_hints_buf_ro() {
+        use super::{analyze_push_constant_stride_hints_from_source, PushConstantStrideHint};
+        let src = "ReadOnlyBuffer<Particle> p = goldy_dyn_buf_ro<Particle>(1);";
+        let h = analyze_push_constant_stride_hints_from_source(src);
+        assert_eq!(h.len(), 2);
+        assert_eq!(
+            h[1],
+            Some(PushConstantStrideHint::Structured {
+                type_name: "Particle".into()
+            })
+        );
+    }
+
+    #[test]
+    fn stride_hints_byte_address() {
+        use super::{analyze_push_constant_stride_hints_from_source, PushConstantStrideHint};
+        let src = "ByteAddressView v = goldy_dyn_byte_address(0);";
+        let h = analyze_push_constant_stride_hints_from_source(src);
+        assert_eq!(h, vec![Some(PushConstantStrideHint::ByteAddress)]);
+    }
+
+    #[test]
+    fn stride_hints_conflict_on_same_slot() {
+        use super::analyze_push_constant_stride_hints_from_source;
+        let src = r#"
+            ReadOnlyBuffer<A> a = goldy_dyn_buf_ro<A>(0);
+            ReadOnlyBuffer<B> b = goldy_dyn_buf_ro<B>(0);
+        "#;
+        let h = analyze_push_constant_stride_hints_from_source(src);
+        assert_eq!(h, vec![None]);
     }
 }

--- a/src/slang/mod.rs
+++ b/src/slang/mod.rs
@@ -45,8 +45,9 @@ pub mod ffi;
 pub mod loader;
 
 pub use compiler::{
-    analyze_push_constant_categories_from_source, layout_validation_enabled, CompiledShader,
-    CompiledShaderWithReflection, FieldLayout, LayoutCheck, OwnedLayoutCheck, ParameterBlockLayout,
-    ResourceKind, ShaderReflection, ShaderTarget, SlangCompiler, StructFieldLayout, StructLayout,
+    analyze_push_constant_categories_from_source, analyze_push_constant_stride_hints_from_source,
+    layout_validation_enabled, CompiledShader, CompiledShaderWithReflection, FieldLayout,
+    LayoutCheck, OwnedLayoutCheck, ParameterBlockLayout, PushConstantStrideHint, ResourceKind,
+    ShaderReflection, ShaderTarget, SlangCompiler, StructFieldLayout, StructLayout,
 };
 pub use ffi::SlangStage;


### PR DESCRIPTION
- Added `validate_typed_push_constant_buffer_strides` function to check element strides against shader expectations during dispatch.
- Introduced `GOLDY_VALIDATE_LAYOUTS` environment variable to enable stride validation, enhancing debugging capabilities for cross-backend differences.
- Updated backend implementations (DX12, Metal, Vulkan) to utilize the new stride validation, ensuring correct buffer handling and preventing silent errors.
- Enhanced shader reflection to include per-slot structured element strides, improving validation accuracy.
- Added tests to verify stride validation functionality and ensure correct behavior across different backends.

Item 3 from #94 