### PR TITLE
Add StructuredBufferElement derive macro and implement for various types

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,6 +2,42 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
+/// Marker trait for types safe to pass to [`goldy::Buffer::with_data`].
+///
+/// Add this alongside `bytemuck::Pod` on `#[repr(C)]` structs used as GPU buffer elements.
+#[proc_macro_derive(StructuredBufferElement)]
+pub fn derive_structured_buffer_element(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    if !input.generics.params.is_empty() {
+        return syn::Error::new_spanned(
+            name,
+            "StructuredBufferElement cannot be derived for generic structs; implement manually if needed",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    match &input.data {
+        Data::Struct(_) => {}
+        _ => {
+            return syn::Error::new_spanned(
+                name,
+                "StructuredBufferElement can only be derived for structs",
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    let expanded = quote! {
+        impl ::goldy::StructuredBufferElement for #name {}
+    };
+
+    expanded.into()
+}
+
 /// Derive a `LAYOUT_CHECK` constant for `#[repr(C)]` structs.
 ///
 /// Generates a `const LAYOUT_CHECK: goldy::LayoutCheck<'static>` that captures

--- a/examples/bouncing_lines.rs
+++ b/examples/bouncing_lines.rs
@@ -35,6 +35,7 @@ struct Line {
     _pad2: u32,
     _pad3: u32,
 }
+impl goldy::StructuredBufferElement for Line {}
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();

--- a/examples/compute_particles.rs
+++ b/examples/compute_particles.rs
@@ -30,6 +30,7 @@ struct Particle {
     position: [f32; 2],
     velocity: [f32; 2],
 }
+impl goldy::StructuredBufferElement for Particle {}
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt::init();

--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -28,6 +28,7 @@ struct Uniforms {
     time: f32,
     _padding: f32,
 }
+impl goldy::StructuredBufferElement for Uniforms {}
 
 const COMPUTE_SHADER: &str = r#"
 import goldy_exp;

--- a/examples/depth_quads.rs
+++ b/examples/depth_quads.rs
@@ -34,6 +34,7 @@ struct DepthVertex {
     position: [f32; 3],
     color: [f32; 4],
 }
+impl goldy::StructuredBufferElement for DepthVertex {}
 
 impl DepthVertex {
     const fn new(x: f32, y: f32, z: f32, r: f32, g: f32, b: f32) -> Self {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -36,6 +36,7 @@ struct AnimParams {
     total_instances: u32,
     _pad: u32,
 }
+impl goldy::StructuredBufferElement for AnimParams {}
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt::init();

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -150,6 +150,7 @@ struct QuadVertex {
     uv: [f32; 2],
     time: f32,
 }
+impl goldy::StructuredBufferElement for QuadVertex {}
 
 impl QuadVertex {
     fn layout() -> VertexBufferLayout {

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -43,6 +43,8 @@ struct ParticleParams {
     _pad1: f32,
     _pad2: f32,
 }
+impl goldy::StructuredBufferElement for Particle {}
+impl goldy::StructuredBufferElement for ParticleParams {}
 
 // Simple pseudo-random for initialization
 static mut SEED: u32 = 42;

--- a/examples/starfield.rs
+++ b/examples/starfield.rs
@@ -47,6 +47,8 @@ struct StarfieldParams {
     _pad1: f32,
     _pad2: f32,
 }
+impl goldy::StructuredBufferElement for Star {}
+impl goldy::StructuredBufferElement for StarfieldParams {}
 
 // Simple pseudo-random for initialization
 static mut SEED: u32 = 12345;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -6,6 +6,45 @@ use crate::types::{BindlessCategory, BindlessHandle, DataAccess};
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
+/// Types allowed as elements in [`Buffer::with_data`] and [`BufferPool::alloc_with_data`].
+///
+/// This is implemented for common multi-byte primitives, arrays of those types, and
+/// `#[repr(C)]` structs via `#[derive(goldy_derive::StructuredBufferElement)]`.
+///
+/// **Not** implemented for `u8` / `i8`: passing `&[u8]` (e.g. from `bytemuck::bytes_of`) would
+/// set element stride to 1 while shaders usually expect a larger struct stride. Use
+/// [`Buffer::with_bytes_stride`] or a typed slice instead.
+///
+/// Unit type `()` is included so empty slices type-check.
+pub trait StructuredBufferElement: bytemuck::Pod {}
+
+macro_rules! impl_structured_buffer_element_for_primitives {
+    ($($t:ty),+ $(,)?) => {
+        $(impl StructuredBufferElement for $t {})+
+    };
+}
+
+impl_structured_buffer_element_for_primitives!(
+    (),
+    i16,
+    u16,
+    i32,
+    u32,
+    i64,
+    u64,
+    i128,
+    u128,
+    isize,
+    usize,
+    f32,
+    f64,
+);
+
+impl<T: StructuredBufferElement, const N: usize> StructuredBufferElement for [T; N] where
+    [T; N]: bytemuck::Pod
+{
+}
+
 /// A GPU buffer.
 pub struct Buffer {
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
@@ -48,8 +87,17 @@ impl Buffer {
 
     /// Create a buffer initialized with data.
     ///
-    /// See [`Buffer::new`] for access pattern documentation.
-    pub fn with_data<T: bytemuck::Pod>(
+    /// Element stride for structured-buffer views is `size_of::<T>()`. The type parameter is
+    /// load-bearing: passing a **`&[u8]`** (for example from `bytemuck::bytes_of(&uniforms)`)
+    /// fixes stride at **1 byte** while shaders usually expect `size_of::<YourStruct>()`.
+    /// On some backends that mismatch reads as zeros or garbage with no error. Prefer a
+    /// typed slice such as `&[YourStruct]` or [`Buffer::with_bytes_stride`] /
+    /// [`Buffer::with_bytes`] with an explicit stride.
+    ///
+    /// See [`StructuredBufferElement`] for which `T` are allowed (`u8` / `i8` are not).
+    ///
+    /// See [`Buffer::new`] and [`DataAccess::Scattered`] for access-pattern details.
+    pub fn with_data<T: StructuredBufferElement>(
         device: &Device,
         data: &[T],
         access: DataAccess,
@@ -75,7 +123,10 @@ impl Buffer {
         Ok(buffer)
     }
 
-    /// Create a buffer initialized with raw bytes.
+    /// Create a buffer initialized with raw bytes (element stride **1**).
+    ///
+    /// Use this or [`Buffer::with_bytes_stride`] when data is naturally `&[u8]`. For typed
+    /// structs, prefer [`Buffer::with_data`] with `&[T]` so stride matches the shader type.
     ///
     /// See [`Buffer::new`] for access pattern documentation.
     pub fn with_bytes(device: &Device, data: &[u8], access: DataAccess) -> Result<Self> {
@@ -464,7 +515,7 @@ impl BufferPool {
     ///
     /// Returns a `BufferView` spanning `count` elements of type `T`, with the offset
     /// aligned to the pool's alignment requirement.
-    pub fn alloc<T: bytemuck::Pod>(&mut self, count: u64) -> Result<BufferView> {
+    pub fn alloc<T: StructuredBufferElement>(&mut self, count: u64) -> Result<BufferView> {
         let stride = std::mem::size_of::<T>() as u64;
         let size = count * stride;
         self.alloc_bytes(size, Some(stride as u32))
@@ -473,8 +524,11 @@ impl BufferPool {
     /// Allocate and fill a typed region in one call.
     ///
     /// Equivalent to `alloc::<T>(data.len())` followed by `write_data(data)`.
-    /// Matches the ergonomics of [`Buffer::with_data`].
-    pub fn alloc_with_data<T: bytemuck::Pod>(&mut self, data: &[T]) -> Result<BufferView> {
+    /// Same element-stride rules as [`Buffer::with_data`].
+    pub fn alloc_with_data<T: StructuredBufferElement>(
+        &mut self,
+        data: &[T],
+    ) -> Result<BufferView> {
         let view = self.alloc::<T>(data.len() as u64)?;
         view.write_data(data)?;
         Ok(view)

--- a/src/common_types.rs
+++ b/src/common_types.rs
@@ -18,6 +18,7 @@
 //! let buffer = Buffer::with_data(&device, &particles, DataAccess::Scattered)?;
 //! ```
 
+use crate::buffer::StructuredBufferElement;
 use bytemuck::{Pod, Zeroable};
 
 // ============================================================================
@@ -184,6 +185,12 @@ impl Instance2D {
         }
     }
 }
+
+impl StructuredBufferElement for Particle2D {}
+impl StructuredBufferElement for Particle3D {}
+impl StructuredBufferElement for FrameUniforms {}
+impl StructuredBufferElement for Transform2D {}
+impl StructuredBufferElement for Instance2D {}
 
 #[cfg(test)]
 mod tests {

--- a/src/examples/common.rs
+++ b/src/examples/common.rs
@@ -3,6 +3,7 @@
 //! This module provides shared types and utilities that work across
 //! both native (Vulkan) and web (WebGPU) platforms.
 
+use crate::buffer::StructuredBufferElement;
 use crate::types::{VertexBufferLayout, VertexFormat};
 use bytemuck::{Pod, Zeroable};
 
@@ -60,6 +61,9 @@ impl VertexUvTime {
         ])
     }
 }
+
+impl StructuredBufferElement for VertexUv {}
+impl StructuredBufferElement for VertexUvTime {}
 
 /// Create a fullscreen quad with time baked into vertices.
 pub fn create_fullscreen_quad_with_time(time: f32) -> [VertexUvTime; 6] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,14 @@ pub mod slang;
 pub mod instrumentation;
 
 // Re-export main types
-pub use buffer::{Buffer, BufferPool, BufferSource, BufferView};
+pub use buffer::{Buffer, BufferPool, BufferSource, BufferView, StructuredBufferElement};
 pub use common_types::{FrameUniforms, Instance2D, Particle2D, Particle3D, Transform2D};
 pub use compute::{ComputeEncoder, ComputePass, ComputePipeline};
 pub use compute_graph::{ComputeGraph, ComputeProgram, DimSlotId, NodeAccess, NodeBuilder, SlotId};
 pub use device::{Adapter, Device, DeviceCapabilities, Instance};
 pub use encoder::{CommandEncoder, RenderPass};
 pub use goldy_derive::LayoutCheckable;
+pub use goldy_derive::StructuredBufferElement;
 pub use gpu_future::GpuFuture;
 pub use pipeline::{RenderPipeline, RenderPipelineDesc};
 pub use render_target::RenderTarget;

--- a/src/types.rs
+++ b/src/types.rs
@@ -132,9 +132,20 @@ impl TextureFormat {
 /// - `Scattered`: Any thread can access any address. No coherence assumptions.
 /// - `Broadcast`: All threads read the same address. Hardware can broadcast
 ///   a single fetch to the entire wave (32-64 threads).
+///
+/// When creating buffers with [`crate::Buffer::with_data`], the inferred element stride
+/// must match what the shader expects. Passing `&[u8]` (e.g. from `bytemuck::bytes_of`)
+/// sets stride to 1 byte; for structured data use a typed slice or
+/// [`crate::Buffer::with_bytes_stride`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum DataAccess {
     /// Any thread, any address, read/write. No coherence assumptions.
+    ///
+    /// Structured-buffer views use the buffer's recorded **element stride** (from
+    /// [`crate::Buffer::with_data`], [`crate::Buffer::with_bytes_stride`], etc.). A stride
+    /// that does not match the shader's `T` in `goldy_dyn_*<T>` can read incorrectly on
+    /// some backends without error.
+    ///
     /// Maps to storage buffers (StructuredBuffer, RWStructuredBuffer in shaders).
     #[default]
     Scattered,
@@ -539,6 +550,11 @@ impl Vertex2DUv {
         ])
     }
 }
+
+// StructuredBufferElement impls for public vertex types
+use crate::buffer::StructuredBufferElement;
+impl StructuredBufferElement for Vertex2D {}
+impl StructuredBufferElement for Vertex2DUv {}
 
 // ============================================================================
 // Depth Buffer Types

--- a/tests/common/render_fixtures.rs
+++ b/tests/common/render_fixtures.rs
@@ -258,6 +258,7 @@ pub struct Depth3DVertex {
     pub position: [f32; 3],
     pub color: [f32; 4],
 }
+impl goldy::StructuredBufferElement for Depth3DVertex {}
 
 pub fn depth_vertex_layout() -> VertexBufferLayout {
     VertexBufferLayout {

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -611,6 +611,7 @@ void cs_main(uint3 id : SV_DispatchThreadID) {
         position: [f32; 2],
         velocity: [f32; 2],
     }
+    impl goldy::StructuredBufferElement for Particle {}
 
     let particles = vec![
         Particle {
@@ -1053,6 +1054,7 @@ void cs_main(uint3 id : SV_DispatchThreadID) {
         a: u32,
         b: u32,
     }
+    impl goldy::StructuredBufferElement for Pair {}
 
     let input_data: Vec<Pair> = (0..8)
         .map(|i| Pair {

--- a/tests/render_target_integration.rs
+++ b/tests/render_target_integration.rs
@@ -400,6 +400,7 @@ struct Depth3DVertex {
     position: [f32; 3],
     color: [f32; 4],
 }
+impl goldy::StructuredBufferElement for Depth3DVertex {}
 
 fn depth_vertex_layout() -> VertexBufferLayout {
     VertexBufferLayout {


### PR DESCRIPTION
- Introduced a new `StructuredBufferElement` derive macro to facilitate the implementation of the trait for `#[repr(C)]` structs.
- Updated multiple examples and types to derive `StructuredBufferElement`, ensuring compatibility with GPU buffer operations.
- Enhanced documentation for `StructuredBufferElement` to clarify usage and constraints, particularly regarding element stride expectations in shaders.

Closes #94 