### PR TITLE
Enhance Metal backend with GPU idleness checks and error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ cocoa = { version = "0.26", optional = true }
 objc = { version = "0.2", optional = true }
 core-graphics-types = { version = "0.2", optional = true }
 foreign-types = { version = "0.5", optional = true }
+block = { version = "0.1", optional = true }
 
 [dev-dependencies]
 # PNG output for examples / integration tests that save images
@@ -91,7 +92,7 @@ winit = "0.30"
 default = ["vulkan", "metal", "dx12", "instrumentation"]
 vulkan = ["dep:ash"]
 dx12 = ["dep:windows", "dep:gpu-allocator", "dep:windows-core"]
-metal = ["dep:metal", "dep:cocoa", "dep:objc", "dep:core-graphics-types", "dep:foreign-types"]
+metal = ["dep:metal", "dep:cocoa", "dep:objc", "dep:core-graphics-types", "dep:foreign-types", "dep:block"]
 # Regenerate `tests/screenshots/*.png` via `cargo run --bin update-screenshots --features update-screenshots`
 update-screenshots = ["dep:image"]
 # Structured instrumentation with named observation points (zero-cost when disabled)

--- a/src/backend/metal/buffer.rs
+++ b/src/backend/metal/buffer.rs
@@ -151,15 +151,37 @@ pub(super) fn create_view(
 }
 
 /// Destroy a buffer, unregistering it from the bindless registry.
+///
+/// Slot recycling is gated on GPU idleness: if any previously-submitted
+/// compute command buffer is still running, the slot parks in the registry's
+/// pending list and only becomes reusable after the next `wait_fence()`
+/// succeeds. This prevents the CPU from overwriting an argument-buffer
+/// descriptor that an in-flight shader is about to dereference (descriptor
+/// aliasing = random wrong-buffer reads and MTLCommandBufferError::Internal).
 pub(super) fn destroy(state: &mut MetalState, buffer_handle: BufferHandle) {
+    let gpu_idle = super::gpu_is_idle(state);
     if let Some(buffer) = state.buffers.remove(&buffer_handle) {
         if let Some(device) = state.devices.get_mut(&buffer.device_handle) {
-            device.resource_registry.unregister_buffer(buffer_handle);
+            device
+                .resource_registry
+                .unregister_buffer(buffer_handle, !gpu_idle);
         }
     }
 }
 
 /// Write data to a buffer at the specified offset.
+///
+/// See [`clear`] for the full rationale. The short version: a CPU
+/// `copy_nonoverlapping` on `contents()` is **not** queue-ordered with
+/// subsequent compute dispatches, so we pair it with a queue-ordered blit
+/// copy (from a transient staging buffer) so the next command buffer
+/// submitted to this device queue is guaranteed to observe the written
+/// bytes. The observable symptom in ekrano/velato was the `config` uniform
+/// buffer returning stale `config.lines_size` to the binning shader, which
+/// then flagged `STAGE_FLATTEN` overflow even when the actual flatten
+/// output was tiny — only visible around scene transitions where the
+/// previous frame's config had happened to be re-uploaded into the same
+/// pool-recycled physical buffer.
 pub(super) fn write(
     state: &MetalState,
     buffer_handle: BufferHandle,
@@ -175,10 +197,39 @@ pub(super) fn write(
         anyhow::bail!("Write would exceed buffer bounds");
     }
 
+    if data.is_empty() {
+        return Ok(());
+    }
+
     unsafe {
         let ptr = buffer.buffer.contents().add(offset as usize);
         std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
     }
+
+    let device_handle = buffer.device_handle;
+    let logical_device = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?;
+
+    // Allocate a transient staging buffer (shared storage) populated with the
+    // same bytes and emit a blit `copy_from_buffer` into the destination on
+    // the device queue. Because this blit is committed to the same queue as
+    // all subsequent compute dispatches, Metal serializes it with them and
+    // the GPU is guaranteed to observe the new bytes. The staging buffer is
+    // retained only by the command buffer's autorelease pool, so it is
+    // dropped as soon as the blit completes.
+    let staging = logical_device.device.new_buffer_with_data(
+        data.as_ptr() as *const _,
+        data.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    );
+
+    let command_buffer = logical_device.command_queue.new_command_buffer();
+    let blit = command_buffer.new_blit_command_encoder();
+    blit.copy_from_buffer(&staging, 0, &buffer.buffer, offset, data.len() as u64);
+    blit.end_encoding();
+    command_buffer.commit();
 
     Ok(())
 }
@@ -259,10 +310,41 @@ pub(super) fn read_to_cpu(
 }
 
 /// Fill buffer region with zeros.
-/// Metal buffers use StorageModeShared so we can memset via contents().
+///
+/// # Why both a CPU memset and a queue-ordered blit
+///
+/// Metal buffers on Apple Silicon use `StorageModeShared`, so the CPU and
+/// GPU ultimately observe the same bytes of physical memory. But the two
+/// paths have asymmetric visibility:
+///
+/// * A `contents()` + `write_bytes()` is **immediately** visible to any
+///   subsequent CPU read of the same buffer (tests and readback paths rely
+///   on this).
+/// * That same CPU store is **not** automatically serialized with the next
+///   command buffer submitted to the GPU queue. Without an explicit
+///   queue-ordered operation on the buffer, a compute dispatch encoded into
+///   a separately-built command buffer can read the GPU L2 cache's
+///   pre-clear contents. Even if the caller has just waited on prior GPU
+///   work, that wait establishes GPU→CPU ordering, not the reverse.
+///
+/// The observable symptom we hit in ekrano/velato was a `bump_buf` that had
+/// just been memset to zero still appearing non-zero to the flatten shader,
+/// which then flagged `STAGE_FLATTEN` overflow (`bump.lines >
+/// config.lines_size`) and triggered an endless retry cascade.
+///
+/// We therefore do both:
+///
+/// 1. `write_bytes` so CPU-side readers observe the clear immediately.
+/// 2. A `fillBuffer` blit committed to the same command queue so the next
+///    compute dispatch on that queue is queue-ordered after the clear and
+///    observes zeros.
+///
+/// The blit is committed without waiting — Metal's queue guarantees
+/// ordering with subsequent command buffers, and whichever future waits on
+/// the final fence will also drain this one.
 pub(super) fn clear(
     state: &MetalState,
-    _device_handle: DeviceHandle,
+    device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
     offset: u64,
     size: u64,
@@ -290,6 +372,18 @@ pub(super) fn clear(
         let ptr = (buffer.buffer.contents() as *mut u8).add(offset as usize);
         std::ptr::write_bytes(ptr, 0, clear_size as usize);
     }
+
+    let logical_device = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?;
+
+    let command_buffer = logical_device.command_queue.new_command_buffer();
+    let blit = command_buffer.new_blit_command_encoder();
+    let range = mtl::NSRange::new(offset, clear_size);
+    blit.fill_buffer(&buffer.buffer, range, 0);
+    blit.end_encoding();
+    command_buffer.commit();
 
     Ok(())
 }

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -382,6 +382,10 @@ pub(super) fn submit(
     device_handle: DeviceHandle,
     commands: &[ComputeCommand],
 ) -> Result<FenceToken> {
+    if state.device_lost.load(Ordering::Relaxed) {
+        anyhow::bail!("GPU device is lost (earlier wait timed out); refusing to submit new work");
+    }
+
     let logical_device = state
         .devices
         .get(&device_handle)
@@ -400,6 +404,29 @@ pub(super) fn submit(
     let token = state
         .next_compute_fence_token
         .fetch_add(1, Ordering::SeqCst);
+
+    // Attach a completion handler that logs any Metal error the moment the
+    // GPU reports it. This fires even when no one is waiting (e.g. for work
+    // submitted by `submit_graph` whose `GpuFuture` has already been dropped
+    // because a later frame called `flush_graph`), giving us visibility into
+    // silent GPU faults that would otherwise only manifest as a hang on the
+    // *next* frame's `waitUntilCompleted`.
+    let handler_token = token;
+    let handler = block::ConcreteBlock::new(move |cb: &mtl::CommandBufferRef| {
+        let status = cb.status();
+        if status != MTLCommandBufferStatus::Completed {
+            let description = read_command_buffer_error_description(cb);
+            tracing::error!(
+                "GPU command buffer (fence={}) finished with status={:?}: {}",
+                handler_token,
+                status,
+                description
+            );
+        }
+    })
+    .copy();
+    command_buffer_ref.add_completed_handler(&handler);
+
     state
         .compute_fence_pool
         .lock()
@@ -417,6 +444,9 @@ pub(super) fn is_fence_complete(
     _device: DeviceHandle,
     token: FenceToken,
 ) -> bool {
+    if state.device_lost.load(Ordering::Relaxed) {
+        return true;
+    }
     let pool = state.compute_fence_pool.lock().unwrap();
     if let Some(buf) = pool.get(&token) {
         buf.status() == MTLCommandBufferStatus::Completed
@@ -425,17 +455,123 @@ pub(super) fn is_fence_complete(
     }
 }
 
-/// Block until the fence signals.
+/// Block until the fence signals — with a hard timeout — then check for GPU errors.
+///
+/// We deliberately do **not** call `MTLCommandBuffer::waitUntilCompleted` here:
+/// on Apple Silicon the GPU can wedge in a compute shader without the kernel
+/// watchdog firing (observed as a 20s+ "Unresponsive" hang with
+/// `GPU Restart Count` unchanged). In that state `waitUntilCompleted` blocks
+/// forever and the whole app has to be force-quit.
+///
+/// Instead we poll `status()` at 1ms intervals, bounded by
+/// `GOLDY_GPU_WAIT_TIMEOUT_MS` (default 5000). If the timeout expires we
+/// return an error so the caller can recover / report instead of silently
+/// hanging. On normal completion we still check `status`/`error` to surface
+/// any Metal-reported failure with its `localizedDescription`.
 pub(super) fn wait_fence(
     state: &MetalState,
     _device: DeviceHandle,
     token: FenceToken,
 ) -> Result<()> {
-    let mut pool = state.compute_fence_pool.lock().unwrap();
-    if let Some(buf) = pool.remove(&token) {
-        buf.wait_until_completed();
+    if state.device_lost.load(Ordering::Relaxed) {
+        anyhow::bail!("GPU device is lost (earlier wait timed out); refusing to wait on fence");
     }
-    Ok(())
+
+    let mut pool = state.compute_fence_pool.lock().unwrap();
+    let buf = match pool.remove(&token) {
+        Some(b) => b,
+        None => return Ok(()),
+    };
+    drop(pool);
+
+    let timeout = std::time::Duration::from_millis(gpu_wait_timeout_ms());
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(1);
+    let warn_threshold = std::time::Duration::from_millis(500);
+    let mut warned = false;
+
+    loop {
+        let status = buf.status();
+        match status {
+            MTLCommandBufferStatus::Completed => return Ok(()),
+            MTLCommandBufferStatus::Error => {
+                let description = read_command_buffer_error_description(&buf);
+                tracing::error!("Metal command buffer finished with error: {}", description);
+                anyhow::bail!("Metal compute command buffer error: {}", description);
+            }
+            _ => {}
+        }
+
+        let elapsed = start.elapsed();
+        if !warned && elapsed > warn_threshold {
+            warned = true;
+            tracing::warn!(
+                "GPU wait_fence exceeding {}ms (status={:?}); still polling up to {}ms",
+                warn_threshold.as_millis(),
+                status,
+                timeout.as_millis()
+            );
+        }
+        if elapsed >= timeout {
+            state.device_lost.store(true, Ordering::Relaxed);
+            tracing::error!(
+                "GPU wait_fence timed out after {}ms without the command buffer \
+                 reaching Completed/Error (status={:?}). The GPU is likely wedged \
+                 in a compute shader. Marking device as lost; all subsequent \
+                 fence waits will fail fast so the app can exit cleanly instead \
+                 of deadlocking.",
+                timeout.as_millis(),
+                status
+            );
+            // Intentionally drop `buf` without completion: letting it go out of
+            // scope calls `release`, but the Metal runtime retains it while the
+            // GPU is still "running" it. Attempting another `waitUntilCompleted`
+            // here would reproduce the hang, so we bail.
+            anyhow::bail!(
+                "GPU wait_fence timed out after {}ms (status={:?}); GPU appears wedged",
+                timeout.as_millis(),
+                status
+            );
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
+/// Read the timeout budget (in milliseconds) for a single `wait_fence` call.
+///
+/// Configurable via `GOLDY_GPU_WAIT_TIMEOUT_MS`. Defaults to 5000ms, which
+/// is generous for a single compute frame (Apple's own GPU hang watchdog
+/// fires around 2s) but short enough that a true wedge is recoverable.
+fn gpu_wait_timeout_ms() -> u64 {
+    std::env::var("GOLDY_GPU_WAIT_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5000)
+}
+
+/// Extract `localizedDescription` from an `MTLCommandBuffer`'s `error` property.
+/// Returns `"<none>"` when the buffer has no attached error, or a best-effort
+/// diagnostic string when it does.
+fn read_command_buffer_error_description(buf: &mtl::CommandBufferRef) -> String {
+    use objc::runtime::Object;
+    unsafe {
+        let err: *mut Object = msg_send![buf, error];
+        if err.is_null() {
+            return "<none>".into();
+        }
+        let nsstr: *mut Object = msg_send![err, localizedDescription];
+        if nsstr.is_null() {
+            return "<error with no description>".into();
+        }
+        let utf8: *const std::os::raw::c_char = msg_send![nsstr, UTF8String];
+        if utf8.is_null() {
+            return "<error with null UTF8>".into();
+        }
+        std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned()
+    }
 }
 
 /// Wait with timeout. Returns Ok(true) if signaled, Ok(false) if timeout elapsed.
@@ -445,6 +581,9 @@ pub(super) fn wait_fence_timeout(
     token: FenceToken,
     timeout_ms: u32,
 ) -> Result<bool> {
+    if state.device_lost.load(Ordering::Relaxed) {
+        anyhow::bail!("GPU device is lost (earlier wait timed out)");
+    }
     let start = std::time::Instant::now();
     let timeout = std::time::Duration::from_millis(timeout_ms as u64);
 

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -28,8 +28,50 @@ mod utils;
 
 use super::*;
 use crate::{goldy_event, goldy_span};
+use ::metal as mtl;
 use anyhow::{Context, Result};
 use types::MetalState;
+
+/// Returns `true` when every command buffer we've submitted has reached
+/// `MTLCommandBufferStatus::Completed`. Used by the destroy paths to decide
+/// whether a just-released bindless slot can be recycled immediately (GPU
+/// idle) or must park on the registry's pending list until the next
+/// `wait_fence()` confirms completion.
+///
+/// ## Why this exists
+///
+/// Metal argument buffers are CPU-writable GPU memory: each descriptor is a
+/// device pointer the shader dereferences at dispatch time. If the CPU
+/// overwrites slot N's descriptor while any in-flight command buffer still
+/// has a pending dispatch that will read slot N, the GPU reads the *new*
+/// descriptor and ends up pointing at the wrong buffer. Observationally this
+/// presents as:
+/// - Random glitches in parts of the scene that encode late (e.g. the
+///   stats/HUD overlay drawn after the main scene).
+/// - `MTLCommandBufferError::Internal` when the shader dereferences a pointer
+///   that isn't in the command buffer's residency set.
+///
+/// A conservative approximation — "if there's nothing in the fence pool, the
+/// GPU is idle" — isn't quite enough because `submit_graph` (non-blocking)
+/// leaves old fences in the pool until someone waits on them. Checking
+/// `status() == Completed` on each entry gives us an accurate snapshot.
+pub(in crate::backend::metal) fn gpu_is_idle(state: &MetalState) -> bool {
+    let pool = state.compute_fence_pool.lock().unwrap();
+    pool.values()
+        .all(|buf| buf.status() == mtl::MTLCommandBufferStatus::Completed)
+}
+
+/// Move every entry in each device's pending-slot list to its free list.
+///
+/// Called by the compute module after a successful `wait_fence()`: at that
+/// point we've established that all previously-submitted GPU work has
+/// completed, so any slot that was parked pending (because it was released
+/// while the GPU was still busy) is now safe to recycle.
+pub(in crate::backend::metal) fn drain_all_pending_slots(state: &mut MetalState) {
+    for device in state.devices.values_mut() {
+        device.resource_registry.drain_pending_slots();
+    }
+}
 
 /// Metal backend for macOS.
 pub struct MetalBackend {
@@ -51,6 +93,7 @@ impl MetalBackend {
             state: MetalState {
                 compute_fence_pool: std::sync::Mutex::new(std::collections::HashMap::new()),
                 next_compute_fence_token: std::sync::atomic::AtomicU64::new(1),
+                device_lost: std::sync::atomic::AtomicBool::new(false),
                 devices: std::collections::HashMap::new(),
                 next_device_handle: 1,
                 buffers: std::collections::HashMap::new(),
@@ -461,7 +504,12 @@ impl GpuBackend for MetalBackend {
     }
 
     fn wait_fence(&mut self, device: DeviceHandle, token: super::FenceToken) -> Result<()> {
-        compute::wait_fence(&self.state, device, token)
+        compute::wait_fence(&self.state, device, token)?;
+        // Successful wait establishes GPU idleness for everything submitted
+        // up to and including `token`. Any bindless slots parked pending while
+        // those command buffers were in-flight are now safe to recycle.
+        drain_all_pending_slots(&mut self.state);
+        Ok(())
     }
 
     fn wait_fence_timeout(
@@ -470,7 +518,11 @@ impl GpuBackend for MetalBackend {
         token: super::FenceToken,
         timeout_ms: u32,
     ) -> Result<bool> {
-        compute::wait_fence_timeout(&self.state, device, token, timeout_ms)
+        let signaled = compute::wait_fence_timeout(&self.state, device, token, timeout_ms)?;
+        if signaled {
+            drain_all_pending_slots(&mut self.state);
+        }
+        Ok(signaled)
     }
 
     fn reset_buffer_heaps(&mut self, device: DeviceHandle) {

--- a/src/backend/metal/surface.rs
+++ b/src/backend/metal/surface.rs
@@ -130,11 +130,17 @@ pub(super) fn destroy(state: &mut MetalState, surface: SurfaceHandle) {
 
     // Release the persistent bindless storage-image slot back to the device
     // registry's free list so another surface can claim it.
+    //
+    // Surface destruction is a teardown path that callers typically only
+    // invoke after stopping rendering, so GPU-in-flight aliasing is unlikely
+    // here — but we still go through the idle check for uniformity with
+    // texture/buffer destroy.
+    let gpu_idle = super::gpu_is_idle(state);
     if let (Some(dev), Some(local)) = (device_handle, slot) {
         if let Some(logical_device) = state.devices.get_mut(&dev) {
             logical_device
                 .resource_registry
-                .release_storage_image_slot(local);
+                .release_storage_image_slot(local, !gpu_idle);
         }
     }
 

--- a/src/backend/metal/texture.rs
+++ b/src/backend/metal/texture.rs
@@ -265,7 +265,14 @@ pub(super) fn read_to_cpu(
 /// If `slot_owned_externally` is set (e.g. a swapchain drawable whose slot is
 /// owned by `SurfaceState`), the slot is NOT released here — the owner manages
 /// it across frames.
+///
+/// As with buffer destroy, slot reuse is gated on GPU idleness: if any
+/// in-flight command buffer might still reference this descriptor, the slot
+/// parks on the pending list and is promoted by the next `wait_fence()`. This
+/// is what keeps the glyph atlas (and other sampled textures) from flickering
+/// when the renderer churns textures between frames.
 pub(super) fn destroy(state: &mut MetalState, texture_handle: TextureHandle) {
+    let gpu_idle = super::gpu_is_idle(state);
     if let Some(texture) = state.textures.remove(&texture_handle) {
         if let Some(device) = state.devices.get_mut(&texture.device_handle) {
             device.resource_registry.unregister_texture(texture_handle);
@@ -273,11 +280,11 @@ pub(super) fn destroy(state: &mut MetalState, texture_handle: TextureHandle) {
                 if texture.is_storage_image {
                     device
                         .resource_registry
-                        .release_storage_image_slot(texture.arg_buffer_index);
+                        .release_storage_image_slot(texture.arg_buffer_index, !gpu_idle);
                 } else {
                     device
                         .resource_registry
-                        .release_texture_slot(texture.arg_buffer_index);
+                        .release_texture_slot(texture.arg_buffer_index, !gpu_idle);
                 }
             }
         }

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -14,7 +14,7 @@ use super::super::{
     BufferHandle, ComputePipelineHandle, DeviceHandle, PipelineHandle, RenderTargetHandle,
     SamplerHandle, ShaderHandle, SurfaceHandle, TextureHandle,
 };
-use crate::backend::FenceToken;
+use crate::backend::{DataAccess, FenceToken};
 use crate::types::{DepthFormat, TextureFormat};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
@@ -60,6 +60,18 @@ const MIN_HEAP_SIZE: u64 = 64 * 1024 * 1024;
 /// Minimum overflow heap size (16 MB).
 const MIN_OVERFLOW_HEAP_SIZE: u64 = 16 * 1024 * 1024;
 
+/// Upper bound on any single heap allocation. Metal can nominally create
+/// heaps up to the device's `maxBufferLength` (tens of GB on Apple Silicon),
+/// but in practice a request that large always reflects an upstream bug:
+/// a stale bump counter fed into `RenderConfig::with_bump_estimates`, a
+/// `u32` wraparound, or similar. Creating the heap anyway does not usually
+/// succeed, and when it does it bakes a pathological memory footprint into
+/// a process that will then be OOM-killed. Failing fast here instead turns
+/// the symptom (hours-long hangs, crash spirals logging tens of thousands
+/// of 12 GB allocation attempts) into a single clean error the caller can
+/// handle. Raise this if a legitimate workload needs it.
+const MAX_HEAP_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
+
 /// Multi-heap allocator for Metal buffer allocations.
 ///
 /// Uses a long-lived primary heap that is right-sized between frames, plus
@@ -90,7 +102,19 @@ impl HeapAllocator {
     /// Allocate a buffer from the heap hierarchy.
     ///
     /// Tries primary, then the last overflow heap, then creates a new overflow.
+    /// Returns `None` if the requested size is larger than [`MAX_HEAP_SIZE`]
+    /// (see rationale there — we'd rather fail this one allocation than let
+    /// a corrupt size request wedge the whole process).
     pub fn allocate(&mut self, size: u64, options: MTLResourceOptions) -> Option<MTLBuffer> {
+        if size > MAX_HEAP_SIZE {
+            tracing::error!(
+                "Refusing buffer allocation of {}MB (cap={}MB); this usually indicates \
+                 a stale bump counter or similar upstream corruption",
+                size / 1024 / 1024,
+                MAX_HEAP_SIZE / 1024 / 1024,
+            );
+            return None;
+        }
         if let Some(buf) = self.primary.new_buffer(size, options) {
             self.buffer_count += 1;
             self.update_high_water_mark();
@@ -105,7 +129,9 @@ impl HeapAllocator {
             }
         }
 
-        let overflow_size = (size * 2).max(MIN_OVERFLOW_HEAP_SIZE);
+        // Clamp the overflow heap size too: `size * 2` on a ~1 GB request is
+        // already at the cap, and we do not want to chase the size in a loop.
+        let overflow_size = (size * 2).clamp(MIN_OVERFLOW_HEAP_SIZE, MAX_HEAP_SIZE);
         let new_heap = self.create_heap(overflow_size);
         tracing::info!(
             "Created overflow buffer heap (size={}MB, overflow_count={})",
@@ -356,7 +382,48 @@ pub(crate) struct ResourceRegistry {
     /// `next_texture_index`. Prevents slot exhaustion when textures are
     /// created and destroyed repeatedly at runtime.
     free_texture_slots: Vec<u32>,
-    pub buffer_indices: HashMap<BufferHandle, u32>,
+    /// Free list of previously-released storage-buffer LOCAL indices.
+    ///
+    /// Without this list, `register_storage_buffer()` monotonically bumps
+    /// `next_storage_buffer_index` forever. In workloads that allocate
+    /// transient pool views every frame (e.g. ekrano's per-frame
+    /// `BufferPool::alloc_bytes` calls, each of which creates a buffer view),
+    /// the counter grows past the 64-slot storage-buffer window within
+    /// seconds, then past 128 it writes descriptors into the uniform-buffer
+    /// region of the argument buffer, past 192 into the storage-image region
+    /// (corrupting the surface drawable!), and eventually past the whole
+    /// argument buffer — at which point `set_argument_buffer` silently skips
+    /// the encode (bounds check) and the shader reads a zero pointer,
+    /// producing empty frames or a wedged GPU.
+    free_storage_buffer_slots: Vec<u32>,
+    /// Free list of previously-released uniform-buffer LOCAL indices.
+    /// Same rationale as `free_storage_buffer_slots`.
+    free_uniform_buffer_slots: Vec<u32>,
+    /// Slots released while at least one GPU command buffer was in-flight.
+    ///
+    /// Metal's argument buffer is **just CPU-writable memory**: the descriptor
+    /// at slot N is a device pointer that the shader dereferences at dispatch
+    /// time. If we recycle slot N (overwrite its descriptor) while an in-flight
+    /// command buffer still has dispatches that will read slot N, the GPU
+    /// reads the *new* descriptor — pointing at a different buffer than the
+    /// shader was originally compiled to expect. The result is descriptor
+    /// aliasing: random garbage in some dispatches, and (eventually) an
+    /// `MTLCommandBufferError::Internal` when the shader dereferences a
+    /// pointer that happens to fall outside the resource's residency set.
+    ///
+    /// To prevent this, `destroy_*` checks whether the GPU is idle (all
+    /// entries in `compute_fence_pool` are `Completed`). If so, slots go
+    /// straight to the free list above. Otherwise they park here until
+    /// `wait_fence()` succeeds, at which point `drain_pending_slots()`
+    /// promotes them to the free list.
+    pending_free_storage_buffer_slots: Vec<u32>,
+    pending_free_uniform_buffer_slots: Vec<u32>,
+    pending_free_texture_slots: Vec<u32>,
+    pending_free_storage_image_slots: Vec<u32>,
+    /// (local_index, access) for each live buffer handle. The access is
+    /// needed at `unregister_buffer()` time to know which free list the slot
+    /// should be returned to.
+    pub buffer_indices: HashMap<BufferHandle, (u32, DataAccess)>,
     pub texture_indices: HashMap<TextureHandle, u32>,
     pub sampler_indices: HashMap<SamplerHandle, u32>,
 }
@@ -376,29 +443,96 @@ impl ResourceRegistry {
             next_sampler_index: 4 * MAX_RESOURCES_PER_CATEGORY,
             free_storage_image_slots: Vec::new(),
             free_texture_slots: Vec::new(),
+            free_storage_buffer_slots: Vec::new(),
+            free_uniform_buffer_slots: Vec::new(),
+            pending_free_storage_buffer_slots: Vec::new(),
+            pending_free_uniform_buffer_slots: Vec::new(),
+            pending_free_texture_slots: Vec::new(),
+            pending_free_storage_image_slots: Vec::new(),
             buffer_indices: HashMap::new(),
             texture_indices: HashMap::new(),
             sampler_indices: HashMap::new(),
         }
     }
 
-    /// Register a storage buffer (Scattered access) - indices 0-63
+    /// Register a storage buffer (Scattered access) - indices 0-63.
+    ///
+    /// Reuses a freed slot if available (see `unregister_buffer`). Without
+    /// this reuse, long-running apps that churn transient buffers every frame
+    /// (e.g. pool views) exhaust the argument-buffer encoder in seconds.
+    ///
+    /// # Panics on overflow
+    ///
+    /// If the local index would exceed [`MAX_RESOURCES_PER_CATEGORY`], the
+    /// returned slot would silently bleed into the next category's
+    /// argument-buffer region (uniform buffers at 64-127). The shader's
+    /// `goldy_dyn_buf_ro<T>(slot)` would then read undefined / zero bytes
+    /// from a wrong heap entry — observed in ekrano as binning's
+    /// `config.lines_size == 0` and a spurious `STAGE_FLATTEN` overflow.
+    /// Failing fast surfaces the leak instead of producing corrupt frames.
     pub fn register_storage_buffer(&mut self, handle: BufferHandle) -> u32 {
-        let index = self.next_storage_buffer_index;
-        self.next_storage_buffer_index += 1;
-        self.buffer_indices.insert(handle, index);
-        index
+        let local_index = if let Some(free) = self.free_storage_buffer_slots.pop() {
+            free
+        } else {
+            let index = self.next_storage_buffer_index;
+            assert!(
+                index < MAX_RESOURCES_PER_CATEGORY,
+                "storage-buffer bindless slots exhausted ({MAX_RESOURCES_PER_CATEGORY} max). \
+                 next_index={} free={} pending_free={} live_indices={} \
+                 (Scattered={}, Broadcast={}). \
+                 Likely a per-frame leak in bind_map; check that all transient buffers \
+                 (config_buf, scene_buf, indirect_buf, etc.) are explicitly freed via \
+                 `recording.free_buffer(...)` and that `run_recording` evicts them at \
+                 the end of the frame.",
+                self.next_storage_buffer_index,
+                self.free_storage_buffer_slots.len(),
+                self.pending_free_storage_buffer_slots.len(),
+                self.buffer_indices.len(),
+                self.buffer_indices
+                    .values()
+                    .filter(|(_, a)| *a == DataAccess::Scattered)
+                    .count(),
+                self.buffer_indices
+                    .values()
+                    .filter(|(_, a)| *a == DataAccess::Broadcast)
+                    .count(),
+            );
+            self.next_storage_buffer_index += 1;
+            index
+        };
+        self.buffer_indices
+            .insert(handle, (local_index, DataAccess::Scattered));
+        local_index
     }
 
     /// Register a uniform buffer (Broadcast access) - local indices 0-63 (shader slot),
     /// global indices 64-127 (argument buffer encoding offset).
     /// Returns the LOCAL index so push constants pass 0-63 to the shader
     /// (which indexes into uniformBuffers[0..63]).
+    ///
+    /// Reuses a freed slot if available (see `unregister_buffer`).
+    ///
+    /// # Panics on overflow
+    ///
+    /// See [`Self::register_storage_buffer`] for the analogous rationale —
+    /// a uniform-slot overflow would alias into the texture-index region
+    /// and cause silent shader-side garbage reads.
     pub fn register_uniform_buffer(&mut self, handle: BufferHandle) -> u32 {
-        let global_index = self.next_uniform_buffer_index;
-        let local_index = global_index - MAX_RESOURCES_PER_CATEGORY;
-        self.next_uniform_buffer_index += 1;
-        self.buffer_indices.insert(handle, local_index);
+        let local_index = if let Some(free) = self.free_uniform_buffer_slots.pop() {
+            free
+        } else {
+            let global_index = self.next_uniform_buffer_index;
+            let local = global_index - MAX_RESOURCES_PER_CATEGORY;
+            assert!(
+                local < MAX_RESOURCES_PER_CATEGORY,
+                "uniform-buffer bindless slots exhausted ({MAX_RESOURCES_PER_CATEGORY} max). \
+                 Likely a per-frame leak in bind_map for Broadcast buffers."
+            );
+            self.next_uniform_buffer_index += 1;
+            local
+        };
+        self.buffer_indices
+            .insert(handle, (local_index, DataAccess::Broadcast));
         local_index
     }
 
@@ -427,8 +561,17 @@ impl ResourceRegistry {
 
     /// Return a sampled-texture LOCAL index to the free list so it can be
     /// reused by a subsequent `register_texture`.
-    pub fn release_texture_slot(&mut self, local_index: u32) {
-        self.free_texture_slots.push(local_index);
+    ///
+    /// If `defer` is true, the slot is parked in the pending list until the
+    /// next successful `drain_pending_slots()`. Callers should pass `true`
+    /// whenever any GPU command buffer is still in-flight that might still
+    /// reference this slot's descriptor.
+    pub fn release_texture_slot(&mut self, local_index: u32, defer: bool) {
+        if defer {
+            self.pending_free_texture_slots.push(local_index);
+        } else {
+            self.free_texture_slots.push(local_index);
+        }
     }
 
     /// Returns the global argument buffer index for a sampled texture.
@@ -465,8 +608,14 @@ impl ResourceRegistry {
 
     /// Return a storage-image LOCAL index to the free list so it can be
     /// reused by a subsequent `register_storage_image` / `reserve_storage_image_slot`.
-    pub fn release_storage_image_slot(&mut self, local_index: u32) {
-        self.free_storage_image_slots.push(local_index);
+    ///
+    /// See [`Self::release_texture_slot`] for the `defer` semantics.
+    pub fn release_storage_image_slot(&mut self, local_index: u32, defer: bool) {
+        if defer {
+            self.pending_free_storage_image_slots.push(local_index);
+        } else {
+            self.free_storage_image_slots.push(local_index);
+        }
     }
 
     /// Pop a free slot if any, otherwise bump the monotonic counter.
@@ -501,8 +650,31 @@ impl ResourceRegistry {
         local_index + 4 * MAX_RESOURCES_PER_CATEGORY
     }
 
-    pub fn unregister_buffer(&mut self, handle: BufferHandle) {
-        self.buffer_indices.remove(&handle);
+    /// Remove a buffer handle from the registry and return its LOCAL slot
+    /// to the appropriate free list so subsequent `register_*_buffer` calls
+    /// reuse it. Without this, per-frame buffer churn exhausts the 64-slot
+    /// argument-buffer window in ~9 seconds and the shader starts reading
+    /// into corrupt / out-of-range descriptors.
+    ///
+    /// If `defer` is true, the slot is parked in the pending list rather
+    /// than the free list. See the `pending_free_*` fields for rationale.
+    pub fn unregister_buffer(&mut self, handle: BufferHandle, defer: bool) {
+        if let Some((local_index, access)) = self.buffer_indices.remove(&handle) {
+            match (access, defer) {
+                (DataAccess::Scattered, false) => {
+                    self.free_storage_buffer_slots.push(local_index);
+                }
+                (DataAccess::Scattered, true) => {
+                    self.pending_free_storage_buffer_slots.push(local_index);
+                }
+                (DataAccess::Broadcast, false) => {
+                    self.free_uniform_buffer_slots.push(local_index);
+                }
+                (DataAccess::Broadcast, true) => {
+                    self.pending_free_uniform_buffer_slots.push(local_index);
+                }
+            }
+        }
     }
 
     pub fn unregister_texture(&mut self, handle: TextureHandle) {
@@ -511,6 +683,32 @@ impl ResourceRegistry {
 
     pub fn unregister_sampler(&mut self, handle: SamplerHandle) {
         self.sampler_indices.remove(&handle);
+    }
+
+    /// Promote every pending slot to its corresponding free list.
+    ///
+    /// Called by the Metal backend after a successful `wait_fence()` (or any
+    /// other synchronization that establishes "all previously-submitted GPU
+    /// work has completed"). At that point the argument buffer descriptors
+    /// the pending slots used to hold are no longer reachable from any
+    /// in-flight command buffer, so the slots are safe to overwrite on the
+    /// next `register_*` call.
+    pub fn drain_pending_slots(&mut self) {
+        self.free_storage_buffer_slots
+            .append(&mut self.pending_free_storage_buffer_slots);
+        self.free_uniform_buffer_slots
+            .append(&mut self.pending_free_uniform_buffer_slots);
+        self.free_texture_slots
+            .append(&mut self.pending_free_texture_slots);
+        self.free_storage_image_slots
+            .append(&mut self.pending_free_storage_image_slots);
+    }
+
+    /// Number of buffer slots currently waiting for GPU idle before reuse.
+    /// Exposed for tests; not part of the public API.
+    #[cfg(test)]
+    pub fn pending_buffer_slot_count(&self) -> usize {
+        self.pending_free_storage_buffer_slots.len() + self.pending_free_uniform_buffer_slots.len()
     }
 }
 
@@ -668,6 +866,12 @@ pub(super) struct MetalState {
     /// Key: FenceToken. Removed when wait completes.
     pub compute_fence_pool: Mutex<HashMap<FenceToken, mtl::CommandBuffer>>,
     pub next_compute_fence_token: AtomicU64,
+    /// Set once any GPU wait has timed out (the GPU has wedged in a compute
+    /// shader without the driver watchdog noticing). Subsequent waits fail
+    /// fast instead of burning the full timeout budget per frame, letting
+    /// the app cascade errors quickly and exit cleanly rather than appearing
+    /// frozen for tens of seconds while each frame times out.
+    pub device_lost: std::sync::atomic::AtomicBool,
     pub devices: std::collections::HashMap<DeviceHandle, LogicalDevice>,
     pub next_device_handle: DeviceHandle,
     pub buffers: std::collections::HashMap<BufferHandle, BufferState>,
@@ -687,4 +891,205 @@ pub(super) struct MetalState {
     pub samplers: std::collections::HashMap<SamplerHandle, SamplerState_>,
     pub next_sampler_handle: SamplerHandle,
     pub slang_compiler: crate::slang::SlangCompiler,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the ekrano "black screen after ~540 frames" bug.
+    ///
+    /// Before the free-list fix, `register_storage_buffer` bumped a monotonic
+    /// counter with every call and `unregister_buffer` merely deleted the
+    /// HashMap entry — the LOCAL slot was leaked. Per-frame pool-view churn
+    /// blew through the 64-slot storage-buffer window in ~9 s and subsequent
+    /// slots bled into the uniform/texture/storage-image categories, which
+    /// corrupted the surface drawable and wedged the GPU.
+    ///
+    /// This test would have failed: after 64 register+unregister cycles, the
+    /// 65th registration would have returned slot 64 instead of recycling 0.
+    #[test]
+    fn storage_buffer_slots_are_reused_after_unregister() {
+        let mut reg = ResourceRegistry::new();
+        let mut all_indices = Vec::new();
+
+        // Churn 4x the per-category capacity; without slot reuse this would
+        // return 0, 1, 2, ..., 4*64 - 1 and blow through into the uniform
+        // region of the argument buffer.
+        for handle in 0..(MAX_RESOURCES_PER_CATEGORY as u64 * 4) {
+            let idx = reg.register_storage_buffer(handle);
+            all_indices.push(idx);
+            // defer=false: simulate the "GPU idle when destroy fires" case,
+            // e.g. ekrano's end-of-frame deferred_free_buffers after flush.
+            reg.unregister_buffer(handle, false);
+        }
+
+        assert!(
+            all_indices.iter().all(|&i| i < MAX_RESOURCES_PER_CATEGORY),
+            "storage buffer slots escaped the 0..{} window: {:?}",
+            MAX_RESOURCES_PER_CATEGORY,
+            all_indices
+                .iter()
+                .filter(|&&i| i >= MAX_RESOURCES_PER_CATEGORY)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn uniform_buffer_slots_are_reused_after_unregister() {
+        let mut reg = ResourceRegistry::new();
+        let mut all_indices = Vec::new();
+        for handle in 0..(MAX_RESOURCES_PER_CATEGORY as u64 * 4) {
+            let idx = reg.register_uniform_buffer(handle);
+            all_indices.push(idx);
+            reg.unregister_buffer(handle, false);
+        }
+        assert!(
+            all_indices.iter().all(|&i| i < MAX_RESOURCES_PER_CATEGORY),
+            "uniform buffer slots escaped the 0..{} window: {:?}",
+            MAX_RESOURCES_PER_CATEGORY,
+            all_indices
+                .iter()
+                .filter(|&&i| i >= MAX_RESOURCES_PER_CATEGORY)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Ensure a Broadcast handle freed via `unregister_buffer` goes to the
+    /// uniform free list (not the storage list), so a subsequent Scattered
+    /// registration can't accidentally re-hand out a uniform-local index
+    /// that isn't actually free in the storage category.
+    #[test]
+    fn unregister_routes_slot_to_correct_category() {
+        let mut reg = ResourceRegistry::new();
+        let h_uni: BufferHandle = 10;
+        let h_sto: BufferHandle = 20;
+
+        let _ = reg.register_uniform_buffer(h_uni);
+        let _ = reg.register_storage_buffer(h_sto);
+        reg.unregister_buffer(h_uni, false);
+        reg.unregister_buffer(h_sto, false);
+
+        assert_eq!(
+            reg.free_uniform_buffer_slots.len(),
+            1,
+            "uniform free list should have reclaimed the uniform slot"
+        );
+        assert_eq!(
+            reg.free_storage_buffer_slots.len(),
+            1,
+            "storage free list should have reclaimed the storage slot"
+        );
+    }
+
+    /// Slots recycled via the free list must hand back the most recently
+    /// freed index first (LIFO) — primarily to make behavior deterministic
+    /// for tests, and to keep hot slots warm.
+    #[test]
+    fn freed_storage_buffer_slot_is_reused_lifo() {
+        let mut reg = ResourceRegistry::new();
+        let h0: BufferHandle = 1;
+        let h1: BufferHandle = 2;
+
+        let i0 = reg.register_storage_buffer(h0);
+        let i1 = reg.register_storage_buffer(h1);
+        assert_eq!(i0, 0);
+        assert_eq!(i1, 1);
+
+        reg.unregister_buffer(h0, false);
+        reg.unregister_buffer(h1, false);
+
+        let h2: BufferHandle = 3;
+        let i2 = reg.register_storage_buffer(h2);
+        assert_eq!(i2, 1, "expected LIFO reuse of freed slot");
+    }
+
+    /// Deferred release: slots freed while `defer=true` must not be reused by
+    /// the next `register_*` call — they stay in the pending list until
+    /// `drain_pending_slots()` promotes them. This is the core mechanism
+    /// protecting against descriptor-aliasing with in-flight GPU work.
+    #[test]
+    fn deferred_buffer_slot_is_not_reused_until_drain() {
+        let mut reg = ResourceRegistry::new();
+        let h0: BufferHandle = 1;
+
+        let i0 = reg.register_storage_buffer(h0);
+        assert_eq!(i0, 0);
+
+        // GPU is "busy" → park on pending.
+        reg.unregister_buffer(h0, true);
+        assert_eq!(
+            reg.pending_buffer_slot_count(),
+            1,
+            "expected slot to land in pending"
+        );
+
+        // Until drain, register must NOT re-hand out slot 0.
+        let h1: BufferHandle = 2;
+        let i1 = reg.register_storage_buffer(h1);
+        assert_eq!(
+            i1, 1,
+            "register_storage_buffer must not recycle a still-pending slot"
+        );
+
+        // After drain, pending→free, and the next register picks it up.
+        reg.drain_pending_slots();
+        assert_eq!(reg.pending_buffer_slot_count(), 0);
+
+        reg.unregister_buffer(h1, false);
+        let h2: BufferHandle = 3;
+        let i2 = reg.register_storage_buffer(h2);
+        assert_eq!(i2, 1, "LIFO pick from free list after drain");
+    }
+
+    /// Drain must route pending slots back to the right category (storage vs
+    /// uniform). A bug here would let a pending uniform slot show up as a
+    /// "free" storage slot and vice versa.
+    #[test]
+    fn drain_pending_routes_to_correct_category() {
+        let mut reg = ResourceRegistry::new();
+        let h_sto: BufferHandle = 10;
+        let h_uni: BufferHandle = 20;
+        let _ = reg.register_storage_buffer(h_sto);
+        let _ = reg.register_uniform_buffer(h_uni);
+
+        reg.unregister_buffer(h_sto, true);
+        reg.unregister_buffer(h_uni, true);
+        reg.drain_pending_slots();
+
+        assert_eq!(reg.free_storage_buffer_slots.len(), 1);
+        assert_eq!(reg.free_uniform_buffer_slots.len(), 1);
+        assert_eq!(reg.pending_buffer_slot_count(), 0);
+    }
+
+    /// Texture slots must honor the same deferred-release pattern. In the
+    /// pre-fix behaviour, a font-atlas texture slot could be recycled while
+    /// the previous frame's compute shader was still reading it, producing
+    /// the "glitchy stats-overlay text" symptom.
+    #[test]
+    fn deferred_texture_slot_is_not_reused_until_drain() {
+        let mut reg = ResourceRegistry::new();
+        let h0: TextureHandle = 100;
+        let i0 = reg.register_texture(h0);
+        reg.release_texture_slot(i0, true);
+
+        let h1: TextureHandle = 101;
+        let i1 = reg.register_texture(h1);
+        assert_ne!(
+            i1, i0,
+            "texture slot must not be recycled while still pending"
+        );
+
+        reg.drain_pending_slots();
+        reg.release_texture_slot(i1, false);
+        let h2: TextureHandle = 102;
+        let i2 = reg.register_texture(h2);
+        // Either the just-released i1 or the drained i0 is acceptable; the
+        // guarantee we need is that it's one of the freed slots (not a fresh
+        // monotonic bump).
+        assert!(
+            i2 == i0 || i2 == i1,
+            "expected texture slot reuse after drain, got {i2}"
+        );
+    }
 }


### PR DESCRIPTION
- Added GPU idleness checks to buffer and texture destruction methods to prevent descriptor aliasing issues.
- Implemented a timeout mechanism for fence waits to avoid hangs caused by GPU wedging, with logging for error visibility.
- Introduced a completion handler for command buffers to log Metal errors immediately upon completion.
- Updated resource management to ensure proper recycling of slots based on GPU state, improving stability and performance.