### PR TITLE
Refactor Metal backend for improved GPU command buffer handling

### DIFF
--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -4,13 +4,17 @@ use super::super::{ComputeCommand, ComputePipelineHandle, DeviceHandle, FenceTok
 use super::buffer;
 use super::shader::parse_numthreads;
 use super::types::PUSH_CONSTANTS_SLOT;
-use super::types::{BindlessIndices, ComputePipelineState, MetalState, MAX_PUSH_CONSTANT_INDICES};
+use super::types::{
+    BindlessIndices, ComputePipelineState, FenceEntry, FenceSignal, MetalState,
+    MAX_PUSH_CONSTANT_INDICES,
+};
 use crate::slang::SlangStage;
 use ::metal as mtl;
 use anyhow::{Context, Result};
 use mtl::{MTLCommandBufferStatus, MTLSize};
 use objc::{msg_send, sel, sel_impl};
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 /// Create a compute pipeline.
 pub(super) fn create(
@@ -405,13 +409,20 @@ pub(super) fn submit(
         .next_compute_fence_token
         .fetch_add(1, Ordering::SeqCst);
 
-    // Attach a completion handler that logs any Metal error the moment the
-    // GPU reports it. This fires even when no one is waiting (e.g. for work
-    // submitted by `submit_graph` whose `GpuFuture` has already been dropped
-    // because a later frame called `flush_graph`), giving us visibility into
-    // silent GPU faults that would otherwise only manifest as a hang on the
-    // *next* frame's `waitUntilCompleted`.
+    // Completion handler responsibilities:
+    //  1. Publish the terminal status into the `FenceSignal` so any thread
+    //     waiting in `wait_fence` / `wait_fence_timeout` / `wait_all_in_flight`
+    //     wakes up immediately instead of ticking a 1 ms poll clock. This is
+    //     the pipeline win: a frame's GPU tail latency + 0 µs instead of
+    //     tail + avg(0.5 ms) polling jitter.
+    //  2. Log any non-`Completed` status so silent GPU faults on work that
+    //     nobody waits on (e.g. `submit_graph` whose `GpuFuture` was dropped
+    //     because a later `flush_graph` superseded it) still surface in the
+    //     tracing stream rather than only manifesting as a hang on the next
+    //     `wait_fence` call.
     let handler_token = token;
+    let signal = Arc::new(FenceSignal::new());
+    let signal_for_handler = signal.clone();
     let handler = block::ConcreteBlock::new(move |cb: &mtl::CommandBufferRef| {
         let status = cb.status();
         if status != MTLCommandBufferStatus::Completed {
@@ -423,15 +434,21 @@ pub(super) fn submit(
                 description
             );
         }
+        let mut done = signal_for_handler.done.lock().unwrap();
+        *done = Some(status);
+        drop(done);
+        signal_for_handler.cv.notify_all();
     })
     .copy();
     command_buffer_ref.add_completed_handler(&handler);
 
-    state
-        .compute_fence_pool
-        .lock()
-        .unwrap()
-        .insert(token, owned_buffer);
+    state.compute_fence_pool.lock().unwrap().insert(
+        token,
+        FenceEntry {
+            buffer: owned_buffer,
+            signal,
+        },
+    );
 
     command_buffer_ref.commit();
 
@@ -448,8 +465,15 @@ pub(super) fn is_fence_complete(
         return true;
     }
     let pool = state.compute_fence_pool.lock().unwrap();
-    if let Some(buf) = pool.get(&token) {
-        buf.status() == MTLCommandBufferStatus::Completed
+    if let Some(entry) = pool.get(&token) {
+        // Prefer the completion-handler-published status so callers don't
+        // need to reach into Metal. Fall back to the live `status()` read if
+        // the handler has not fired yet.
+        if let Some(status) = *entry.signal.done.lock().unwrap() {
+            status == MTLCommandBufferStatus::Completed
+        } else {
+            entry.buffer.status() == MTLCommandBufferStatus::Completed
+        }
     } else {
         true // Already removed (waited on), consider complete
     }
@@ -463,11 +487,12 @@ pub(super) fn is_fence_complete(
 /// `GPU Restart Count` unchanged). In that state `waitUntilCompleted` blocks
 /// forever and the whole app has to be force-quit.
 ///
-/// Instead we poll `status()` at 1ms intervals, bounded by
-/// `GOLDY_GPU_WAIT_TIMEOUT_MS` (default 5000). If the timeout expires we
-/// return an error so the caller can recover / report instead of silently
-/// hanging. On normal completion we still check `status`/`error` to surface
-/// any Metal-reported failure with its `localizedDescription`.
+/// Instead we block on a [`Condvar`] that the command buffer's completion
+/// handler signals from the Metal dispatch queue. A hard timeout of
+/// `GOLDY_GPU_WAIT_TIMEOUT_MS` (default 5000 ms) bounds the wait so a wedged
+/// GPU — where the completion handler never fires — is still recoverable.
+/// The 0.5 ms average jitter from the previous 1 ms poll loop is gone: wait
+/// completion is now granular to the handler dispatch (microseconds).
 pub(super) fn wait_fence(
     state: &MetalState,
     _device: DeviceHandle,
@@ -477,64 +502,111 @@ pub(super) fn wait_fence(
         anyhow::bail!("GPU device is lost (earlier wait timed out); refusing to wait on fence");
     }
 
-    let mut pool = state.compute_fence_pool.lock().unwrap();
-    let buf = match pool.remove(&token) {
-        Some(b) => b,
-        None => return Ok(()),
+    let entry = {
+        let mut pool = state.compute_fence_pool.lock().unwrap();
+        match pool.remove(&token) {
+            Some(e) => e,
+            None => return Ok(()),
+        }
     };
-    drop(pool);
 
     let timeout = std::time::Duration::from_millis(gpu_wait_timeout_ms());
-    let start = std::time::Instant::now();
-    let poll_interval = std::time::Duration::from_millis(1);
     let warn_threshold = std::time::Duration::from_millis(500);
-    let mut warned = false;
+    let status = wait_signal(&entry.signal, warn_threshold, timeout, |elapsed, status| {
+        tracing::warn!(
+            "GPU wait_fence exceeding {}ms (status={:?}); still waiting up to {}ms",
+            elapsed.as_millis(),
+            status,
+            timeout.as_millis()
+        );
+    });
 
-    loop {
-        let status = buf.status();
-        match status {
-            MTLCommandBufferStatus::Completed => return Ok(()),
-            MTLCommandBufferStatus::Error => {
-                let description = read_command_buffer_error_description(&buf);
-                tracing::error!("Metal command buffer finished with error: {}", description);
-                anyhow::bail!("Metal compute command buffer error: {}", description);
-            }
-            _ => {}
+    match status {
+        Some(MTLCommandBufferStatus::Completed) => Ok(()),
+        Some(MTLCommandBufferStatus::Error) => {
+            let description = read_command_buffer_error_description(&entry.buffer);
+            tracing::error!("Metal command buffer finished with error: {}", description);
+            anyhow::bail!("Metal compute command buffer error: {}", description);
         }
-
-        let elapsed = start.elapsed();
-        if !warned && elapsed > warn_threshold {
-            warned = true;
-            tracing::warn!(
-                "GPU wait_fence exceeding {}ms (status={:?}); still polling up to {}ms",
-                warn_threshold.as_millis(),
-                status,
-                timeout.as_millis()
+        Some(other) => {
+            // Completion handler fired with an unexpected non-terminal status.
+            // Treat as a wedge — the handler contract says it only fires on
+            // Completed or Error.
+            state.device_lost.store(true, Ordering::Relaxed);
+            anyhow::bail!(
+                "Metal completion handler reported non-terminal status={:?}",
+                other
             );
         }
-        if elapsed >= timeout {
+        None => {
+            // Timeout reached without the completion handler firing.
             state.device_lost.store(true, Ordering::Relaxed);
+            let status = entry.buffer.status();
             tracing::error!(
-                "GPU wait_fence timed out after {}ms without the command buffer \
-                 reaching Completed/Error (status={:?}). The GPU is likely wedged \
-                 in a compute shader. Marking device as lost; all subsequent \
-                 fence waits will fail fast so the app can exit cleanly instead \
-                 of deadlocking.",
+                "GPU wait_fence timed out after {}ms without the completion \
+                 handler firing (status={:?}). The GPU is likely wedged in a \
+                 compute shader. Marking device as lost; all subsequent fence \
+                 waits will fail fast so the app can exit cleanly instead of \
+                 deadlocking.",
                 timeout.as_millis(),
                 status
             );
-            // Intentionally drop `buf` without completion: letting it go out of
-            // scope calls `release`, but the Metal runtime retains it while the
-            // GPU is still "running" it. Attempting another `waitUntilCompleted`
-            // here would reproduce the hang, so we bail.
+            // Letting `entry` go out of scope calls `release`, but the Metal
+            // runtime retains the command buffer while the GPU is still
+            // "running" it. Attempting another wait here would reproduce the
+            // hang, so we bail.
             anyhow::bail!(
                 "GPU wait_fence timed out after {}ms (status={:?}); GPU appears wedged",
                 timeout.as_millis(),
                 status
             );
         }
+    }
+}
 
-        std::thread::sleep(poll_interval);
+/// Block on `signal.cv` until the completion handler publishes a terminal
+/// status or `hard_timeout` elapses. Returns the published status, or `None`
+/// on timeout.
+///
+/// If the wait exceeds `warn_after`, `on_warn` is invoked exactly once and
+/// the wait continues with the remaining budget. This preserves the legacy
+/// "GPU wait_fence exceeding 500ms" heartbeat without burning CPU on it.
+fn wait_signal(
+    signal: &FenceSignal,
+    warn_after: std::time::Duration,
+    hard_timeout: std::time::Duration,
+    mut on_warn: impl FnMut(std::time::Duration, Option<MTLCommandBufferStatus>),
+) -> Option<MTLCommandBufferStatus> {
+    let start = std::time::Instant::now();
+    let mut warned = false;
+    let mut guard = signal.done.lock().unwrap();
+    loop {
+        if let Some(status) = *guard {
+            return Some(status);
+        }
+        let elapsed = start.elapsed();
+        let remaining = hard_timeout.saturating_sub(elapsed);
+        if remaining.is_zero() {
+            return None;
+        }
+        let wait_slice = if !warned {
+            warn_after.saturating_sub(elapsed).min(remaining)
+        } else {
+            remaining
+        };
+        // `wait_slice` of zero means the warn threshold is reached and we've
+        // already fallen through once — loop again to log and continue.
+        if wait_slice.is_zero() && !warned {
+            warned = true;
+            on_warn(elapsed, *guard);
+            continue;
+        }
+        let (g, result) = signal.cv.wait_timeout(guard, wait_slice).unwrap();
+        guard = g;
+        if !warned && result.timed_out() && start.elapsed() >= warn_after {
+            warned = true;
+            on_warn(start.elapsed(), *guard);
+        }
     }
 }
 
@@ -584,26 +656,24 @@ pub(super) fn wait_fence_timeout(
     if state.device_lost.load(Ordering::Relaxed) {
         anyhow::bail!("GPU device is lost (earlier wait timed out)");
     }
-    let start = std::time::Instant::now();
     let timeout = std::time::Duration::from_millis(timeout_ms as u64);
-
-    loop {
-        {
-            let pool = state.compute_fence_pool.lock().unwrap();
-            if let Some(buf) = pool.get(&token) {
-                if buf.status() == MTLCommandBufferStatus::Completed {
-                    drop(pool);
-                    let mut p = state.compute_fence_pool.lock().unwrap();
-                    p.remove(&token);
-                    return Ok(true);
-                }
-            } else {
-                return Ok(true); // Already removed
-            }
+    // Snapshot the signal without removing the entry so a subsequent
+    // wait_fence call can still observe the command buffer when the timeout
+    // path returns `Ok(false)`.
+    let signal = {
+        let pool = state.compute_fence_pool.lock().unwrap();
+        match pool.get(&token) {
+            Some(entry) => entry.signal.clone(),
+            None => return Ok(true), // Already waited on / removed.
         }
-        if start.elapsed() >= timeout {
-            return Ok(false);
+    };
+    let status = wait_signal(&signal, timeout, timeout, |_, _| {});
+    match status {
+        Some(MTLCommandBufferStatus::Completed) | Some(MTLCommandBufferStatus::Error) => {
+            state.compute_fence_pool.lock().unwrap().remove(&token);
+            Ok(true)
         }
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        Some(_) => Ok(true), // Non-terminal but handler fired; treat as signaled.
+        None => Ok(false),
     }
 }

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -57,8 +57,16 @@ use types::MetalState;
 /// `status() == Completed` on each entry gives us an accurate snapshot.
 pub(in crate::backend::metal) fn gpu_is_idle(state: &MetalState) -> bool {
     let pool = state.compute_fence_pool.lock().unwrap();
-    pool.values()
-        .all(|buf| buf.status() == mtl::MTLCommandBufferStatus::Completed)
+    pool.values().all(|entry| {
+        // Prefer the handler-published status to avoid a Metal call on the
+        // fast (already-done) path; fall back to the live `status()` read if
+        // the handler has not yet been dispatched.
+        if let Some(status) = *entry.signal.done.lock().unwrap() {
+            status == mtl::MTLCommandBufferStatus::Completed
+        } else {
+            entry.buffer.status() == mtl::MTLCommandBufferStatus::Completed
+        }
+    })
 }
 
 /// Move every entry in each device's pending-slot list to its free list.
@@ -87,39 +95,53 @@ pub(in crate::backend::metal) fn wait_all_in_flight(state: &MetalState) -> Resul
     if state.device_lost.load(Ordering::Relaxed) {
         anyhow::bail!("GPU device is lost; refusing to wait for in-flight work");
     }
-    let tokens: Vec<_> = {
+    // Snapshot (token, signal) pairs without holding the pool lock across a
+    // blocking wait — the completion handler also locks the pool briefly
+    // to drop itself, and we must not deadlock against it.
+    let entries: Vec<(super::FenceToken, std::sync::Arc<types::FenceSignal>)> = {
         let pool = state.compute_fence_pool.lock().unwrap();
-        pool.keys().copied().collect()
+        pool.iter().map(|(t, e)| (*t, e.signal.clone())).collect()
     };
-    if tokens.is_empty() {
+    if entries.is_empty() {
         return Ok(());
     }
     let timeout = std::time::Duration::from_millis(5000);
-    let poll_interval = std::time::Duration::from_millis(1);
     let start = std::time::Instant::now();
-    for token in tokens {
-        loop {
-            let status = {
-                let pool = state.compute_fence_pool.lock().unwrap();
-                match pool.get(&token) {
-                    Some(buf) => buf.status(),
-                    None => break,
+    for (token, signal) in entries {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            state.device_lost.store(true, Ordering::Relaxed);
+            anyhow::bail!(
+                "GPU wait_all_in_flight timed out after {}ms",
+                timeout.as_millis()
+            );
+        }
+        let status = {
+            let mut guard = signal.done.lock().unwrap();
+            loop {
+                if let Some(status) = *guard {
+                    break status;
                 }
-            };
-            match status {
-                mtl::MTLCommandBufferStatus::Completed => {
-                    let mut pool = state.compute_fence_pool.lock().unwrap();
-                    pool.remove(&token);
-                    break;
+                let now_remaining = timeout.saturating_sub(start.elapsed());
+                if now_remaining.is_zero() {
+                    break mtl::MTLCommandBufferStatus::NotEnqueued;
                 }
-                mtl::MTLCommandBufferStatus::Error => {
-                    let mut pool = state.compute_fence_pool.lock().unwrap();
-                    pool.remove(&token);
-                    anyhow::bail!("Metal command buffer errored while waiting for idle");
+                let (g, result) = signal.cv.wait_timeout(guard, now_remaining).unwrap();
+                guard = g;
+                if result.timed_out() && guard.is_none() {
+                    break mtl::MTLCommandBufferStatus::NotEnqueued;
                 }
-                _ => {}
             }
-            if start.elapsed() >= timeout {
+        };
+        match status {
+            mtl::MTLCommandBufferStatus::Completed => {
+                state.compute_fence_pool.lock().unwrap().remove(&token);
+            }
+            mtl::MTLCommandBufferStatus::Error => {
+                state.compute_fence_pool.lock().unwrap().remove(&token);
+                anyhow::bail!("Metal command buffer errored while waiting for idle");
+            }
+            _ => {
                 state.device_lost.store(true, Ordering::Relaxed);
                 anyhow::bail!(
                     "GPU wait_all_in_flight timed out after {}ms (status={:?})",
@@ -127,7 +149,6 @@ pub(in crate::backend::metal) fn wait_all_in_flight(state: &MetalState) -> Resul
                     status
                 );
             }
-            std::thread::sleep(poll_interval);
         }
     }
     Ok(())

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -18,7 +18,7 @@ use crate::backend::{DataAccess, FenceToken};
 use crate::types::{DepthFormat, TextureFormat};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
-use std::sync::Mutex;
+use std::sync::{Arc, Condvar, Mutex};
 // Use explicit crate path to avoid collision with our module name
 use ::metal as mtl;
 use mtl::{
@@ -859,12 +859,44 @@ pub(crate) struct SurfaceState {
 unsafe impl Send for SurfaceState {}
 unsafe impl Sync for SurfaceState {}
 
+/// Terminal status of a submitted command buffer, published by its Metal
+/// completion handler. `None` means the command buffer is still in flight.
+///
+/// Paired with [`FenceSignal::cv`] so waiters can block on a condvar instead
+/// of polling `MTLCommandBuffer::status()` at a fixed 1 ms cadence. On a
+/// GPU frame that finishes in e.g. 2.3 ms the poll loop wasted an average
+/// of ~0.5 ms of wall time per frame simply waiting for the next tick; the
+/// condvar wakes within microseconds of Metal's completion-handler callback
+/// firing. The polling path remains available as a bounded-timeout safety
+/// net (see [`super::compute::wait_fence`]) for a truly wedged GPU where
+/// the completion handler never fires.
+pub(super) struct FenceSignal {
+    pub done: Mutex<Option<mtl::MTLCommandBufferStatus>>,
+    pub cv: Condvar,
+}
+
+impl FenceSignal {
+    pub fn new() -> Self {
+        Self {
+            done: Mutex::new(None),
+            cv: Condvar::new(),
+        }
+    }
+}
+
+/// An in-flight command buffer tracked by the fence pool, bundled with the
+/// completion-signal primitive its handler writes to.
+pub(super) struct FenceEntry {
+    pub buffer: mtl::CommandBuffer,
+    pub signal: Arc<FenceSignal>,
+}
+
 /// Consolidated Metal backend state.
 /// Holds all resources and state for the Metal backend.
 pub(super) struct MetalState {
     /// Pool of in-flight compute command buffers for non-blocking submit.
     /// Key: FenceToken. Removed when wait completes.
-    pub compute_fence_pool: Mutex<HashMap<FenceToken, mtl::CommandBuffer>>,
+    pub compute_fence_pool: Mutex<HashMap<FenceToken, FenceEntry>>,
     pub next_compute_fence_token: AtomicU64,
     /// Set once any GPU wait has timed out (the GPU has wedged in a compute
     /// shader without the driver watchdog noticing). Subsequent waits fail


### PR DESCRIPTION
- Introduced `FenceSignal` and `FenceEntry` structures to manage command buffer completion more efficiently, reducing polling overhead.
- Updated `submit` and `wait_fence` functions to utilize the new signal mechanism, enhancing responsiveness to GPU completion events.
- Improved `gpu_is_idle` and `wait_all_in_flight` functions to leverage handler-published statuses, minimizing unnecessary Metal status calls.
- Enhanced documentation to clarify the new synchronization approach and its benefits for performance and error handling.