### PR TITLE
Enhance Vulkan backend with improved resource management and diagnostics

### DIFF
--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -40,7 +40,7 @@ fn drain_info_queue(device: &ID3D12Device10) -> Option<String> {
             }
             let msg = &*msg_ptr;
             let desc = std::slice::from_raw_parts(
-                msg.pDescription as *const u8,
+                msg.pDescription,
                 msg.DescriptionByteLength.saturating_sub(1),
             );
             let text = std::str::from_utf8(desc).unwrap_or("<non-utf8 description>");

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -42,12 +42,24 @@ pub struct BindlessIndices {
 ///
 /// IMPORTANT: All CBV, SRV, and UAV descriptors share the same heap (cbv_srv_uav_heap),
 /// so we use a unified offset counter to avoid collisions.
+///
+/// Each `register_*` call pops a slot from the appropriate free list before minting a
+/// new one, preventing monotonic counter exhaustion when transient resources (e.g.
+/// per-frame pool views or swapchain-back-buffer UAVs) are created and destroyed every
+/// frame. Without this recycling the `next_cbv_srv_uav_offset` would hit
+/// `MAX_BINDLESS_CBV_SRV_UAV` (16 384) and subsequent descriptor writes would go
+/// out-of-bounds, corrupting the heap and causing GPU hangs / device loss.
 #[derive(Default)]
 pub(crate) struct ResourceRegistry {
-    /// Unified offset counter for CBV/SRV/UAV heap (they all share the same heap!)
+    /// Monotonic fallback counter: only advanced when the free list is empty.
     next_cbv_srv_uav_offset: u32,
     next_sampler_offset: u32,
-    /// Maps buffer handle to its primary descriptor offset
+    /// Recycled CBV/SRV/UAV heap slots returned by `unregister_buffer` /
+    /// `unregister_texture`. Popped first by every `register_*` call.
+    free_cbv_srv_uav_slots: Vec<u32>,
+    /// Recycled sampler heap slots returned by `unregister_sampler`.
+    free_sampler_slots: Vec<u32>,
+    /// Maps buffer handle to its primary descriptor offset (UAV for storage, CBV for uniform)
     pub buffer_offsets: HashMap<BufferHandle, u32>,
     /// Maps buffer handle to its secondary SRV offset (for storage buffers that need read access)
     pub buffer_srv_offsets: HashMap<BufferHandle, u32>,
@@ -61,10 +73,10 @@ pub(crate) struct ResourceRegistry {
 impl ResourceRegistry {
     pub fn new() -> Self {
         Self {
-            // All CBV/SRV/UAV descriptors use a single unified counter
-            // to avoid descriptor heap collisions
             next_cbv_srv_uav_offset: 0,
             next_sampler_offset: 0,
+            free_cbv_srv_uav_slots: Vec::new(),
+            free_sampler_slots: Vec::new(),
             buffer_offsets: HashMap::new(),
             buffer_srv_offsets: HashMap::new(),
             texture_offsets: HashMap::new(),
@@ -73,46 +85,58 @@ impl ResourceRegistry {
         }
     }
 
+    /// Pop a recycled CBV/SRV/UAV slot or mint a fresh one.
+    fn alloc_cbv_srv_uav(&mut self) -> u32 {
+        self.free_cbv_srv_uav_slots.pop().unwrap_or_else(|| {
+            let offset = self.next_cbv_srv_uav_offset;
+            self.next_cbv_srv_uav_offset += 1;
+            offset
+        })
+    }
+
+    /// Pop a recycled sampler slot or mint a fresh one.
+    fn alloc_sampler(&mut self) -> u32 {
+        self.free_sampler_slots.pop().unwrap_or_else(|| {
+            let offset = self.next_sampler_offset;
+            self.next_sampler_offset += 1;
+            offset
+        })
+    }
+
     pub fn register_buffer_cbv(&mut self, handle: BufferHandle) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
+        let offset = self.alloc_cbv_srv_uav();
         self.buffer_offsets.insert(handle, offset);
         offset
     }
 
     pub fn register_buffer_srv(&mut self, handle: BufferHandle) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
+        let offset = self.alloc_cbv_srv_uav();
         // Store in secondary map since buffer may already have a UAV offset
         self.buffer_srv_offsets.insert(handle, offset);
         offset
     }
 
     pub fn register_buffer_uav(&mut self, handle: BufferHandle) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
+        let offset = self.alloc_cbv_srv_uav();
         self.buffer_offsets.insert(handle, offset);
         offset
     }
 
     pub fn register_texture(&mut self, handle: TextureHandle) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
+        let offset = self.alloc_cbv_srv_uav();
         self.texture_offsets.insert(handle, offset);
         offset
     }
 
     /// Register a UAV descriptor for a texture (e.g. storage image / SpatialAccess::Direct).
     pub fn register_texture_uav(&mut self, handle: TextureHandle) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
+        let offset = self.alloc_cbv_srv_uav();
         self.texture_uav_offsets.insert(handle, offset);
         offset
     }
 
     pub fn register_sampler(&mut self, handle: SamplerHandle) -> u32 {
-        let offset = self.next_sampler_offset;
-        self.next_sampler_offset += 1;
+        let offset = self.alloc_sampler();
         self.sampler_offsets.insert(handle, offset);
         offset
     }
@@ -122,25 +146,156 @@ impl ResourceRegistry {
         self.buffer_srv_offsets.get(&handle).copied()
     }
 
-    /// Allocate a raw descriptor slot (not tied to any resource).
+    /// Allocate a raw descriptor slot not tied to any resource handle.
+    /// Used for permanent device-lifetime slots (e.g. `scratch_clear_uav_offset`).
     pub fn alloc_cbv_srv_uav_slot(&mut self) -> u32 {
-        let offset = self.next_cbv_srv_uav_offset;
-        self.next_cbv_srv_uav_offset += 1;
-        offset
+        self.alloc_cbv_srv_uav()
     }
 
+    /// Unregister a buffer, returning all of its descriptor slots to the free list.
+    ///
+    /// Storage buffers may occupy two slots (UAV primary + SRV secondary); both are
+    /// recycled here. Without this, per-frame buffer churn exhausts the 16 384-slot
+    /// heap in seconds and subsequent descriptor writes corrupt adjacent entries.
     pub fn unregister_buffer(&mut self, handle: BufferHandle) {
-        self.buffer_offsets.remove(&handle);
-        self.buffer_srv_offsets.remove(&handle);
+        if let Some(offset) = self.buffer_offsets.remove(&handle) {
+            self.free_cbv_srv_uav_slots.push(offset);
+        }
+        if let Some(offset) = self.buffer_srv_offsets.remove(&handle) {
+            self.free_cbv_srv_uav_slots.push(offset);
+        }
     }
 
+    /// Unregister a texture, returning all of its descriptor slots to the free list.
+    ///
+    /// Storage textures may occupy two slots (SRV + UAV); both are recycled here.
     pub fn unregister_texture(&mut self, handle: TextureHandle) {
-        self.texture_offsets.remove(&handle);
-        self.texture_uav_offsets.remove(&handle);
+        if let Some(offset) = self.texture_offsets.remove(&handle) {
+            self.free_cbv_srv_uav_slots.push(offset);
+        }
+        if let Some(offset) = self.texture_uav_offsets.remove(&handle) {
+            self.free_cbv_srv_uav_slots.push(offset);
+        }
     }
 
     pub fn unregister_sampler(&mut self, handle: SamplerHandle) {
-        self.sampler_offsets.remove(&handle);
+        if let Some(offset) = self.sampler_offsets.remove(&handle) {
+            self.free_sampler_slots.push(offset);
+        }
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    /// Simulate the per-frame create/destroy churn that ekrano generates for transient
+    /// pool-view buffers. The counter must stay bounded — well below MAX_BINDLESS_CBV_SRV_UAV
+    /// — even after far more iterations than the heap limit.
+    #[test]
+    fn buffer_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..50_000u64 {
+            let handle = i as BufferHandle;
+            reg.register_buffer_uav(handle);
+            reg.unregister_buffer(handle);
+        }
+        // Only one slot should ever have been minted (slot 0), now sitting in the free list.
+        assert_eq!(
+            reg.next_cbv_srv_uav_offset, 1,
+            "UAV counter grew; slot recycling not working"
+        );
+        assert_eq!(reg.free_cbv_srv_uav_slots.len(), 1);
+    }
+
+    /// Storage buffers register two slots (UAV primary + SRV secondary).
+    /// Both must be returned to the free list on unregister.
+    #[test]
+    fn storage_buffer_dual_slot_recycled() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..1_000u64 {
+            let handle = i as BufferHandle;
+            reg.register_buffer_uav(handle);
+            reg.register_buffer_srv(handle);
+            reg.unregister_buffer(handle);
+        }
+        assert_eq!(
+            reg.next_cbv_srv_uav_offset, 2,
+            "counter should only have advanced twice (one UAV + one SRV slot ever minted)"
+        );
+        assert_eq!(
+            reg.free_cbv_srv_uav_slots.len(),
+            2,
+            "both slots must be in the free list"
+        );
+    }
+
+    /// Textures with both SRV and UAV views (storage textures) must recycle both slots.
+    #[test]
+    fn texture_dual_slot_recycled() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..1_000u64 {
+            let handle = i as TextureHandle;
+            reg.register_texture(handle);
+            reg.register_texture_uav(handle);
+            reg.unregister_texture(handle);
+        }
+        assert_eq!(reg.next_cbv_srv_uav_offset, 2);
+        assert_eq!(reg.free_cbv_srv_uav_slots.len(), 2);
+    }
+
+    /// Sampler slots are in a separate heap; verify they recycle independently.
+    #[test]
+    fn sampler_slots_recycled() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..5_000u64 {
+            let handle = i as SamplerHandle;
+            reg.register_sampler(handle);
+            reg.unregister_sampler(handle);
+        }
+        assert_eq!(reg.next_sampler_offset, 1);
+        assert_eq!(reg.free_sampler_slots.len(), 1);
+    }
+
+    /// Simultaneously-live resources must receive distinct slots.
+    #[test]
+    fn live_resources_get_distinct_slots() {
+        let mut reg = ResourceRegistry::new();
+        const N: u64 = 64;
+        let mut slots: Vec<u32> = (0..N)
+            .map(|i| reg.register_buffer_uav(i as BufferHandle))
+            .collect();
+        slots.sort_unstable();
+        slots.dedup();
+        assert_eq!(
+            slots.len(),
+            N as usize,
+            "duplicate slots assigned to live resources"
+        );
+    }
+
+    /// Slots freed by destroyed resources must be reused before the counter advances,
+    /// keeping the high-water mark at or below the number of concurrently-live resources.
+    #[test]
+    fn high_water_mark_bounded_by_live_count() {
+        let mut reg = ResourceRegistry::new();
+        const LIVE: u64 = 8;
+        const ROUNDS: u64 = 10_000;
+
+        // Prime with LIVE simultaneous resources.
+        for i in 0..LIVE {
+            reg.register_buffer_uav(i as BufferHandle);
+        }
+        // Repeatedly destroy the oldest and create a new one.
+        for i in LIVE..LIVE + ROUNDS {
+            reg.unregister_buffer((i - LIVE) as BufferHandle);
+            reg.register_buffer_uav(i as BufferHandle);
+        }
+        assert!(
+            reg.next_cbv_srv_uav_offset <= LIVE as u32,
+            "counter ({}) exceeded live count ({LIVE}); slot recycling broken",
+            reg.next_cbv_srv_uav_offset
+        );
     }
 }
 

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -8,6 +8,48 @@ use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
 
+/// Reap fences that have already signaled from the compute fence pool.
+///
+/// Without this, every `submit_graph` that doesn't have a paired `wait_fence`
+/// (the common ekrano pattern: only the *last* `GpuFuture` in a recording is
+/// waited on; the intermediate ones are silently dropped) leaks a `VkFence` +
+/// `VkCommandBuffer` into the pool. Over a few thousand frames the pool grows
+/// large enough that the driver's command-pool / fence-pool internal arenas
+/// fall over, the device is lost (`ERROR_DEVICE_LOST` on the next
+/// `queue_submit`), and the unbounded HashMap teardown corrupts the heap on
+/// shutdown.
+fn reap_signaled_fences(state: &mut super::types::VulkanState) {
+    let signaled: Vec<u64> = state
+        .compute_fence_pool
+        .iter()
+        .filter_map(|(token, (device_handle, fence, _))| {
+            let logical_device = state.devices.get(device_handle)?;
+            let signaled =
+                unsafe { logical_device.device.get_fence_status(*fence) }.unwrap_or(false);
+            if signaled {
+                Some(*token)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for token in signaled {
+        if let Some((device_handle, fence, cmd_buf)) = state.compute_fence_pool.remove(&token) {
+            if let Some(logical_device) = state.devices.get(&device_handle) {
+                unsafe {
+                    if let Some(cb) = cmd_buf {
+                        logical_device
+                            .device
+                            .free_command_buffers(logical_device.command_pool, &[cb]);
+                    }
+                    logical_device.device.destroy_fence(fence, None);
+                }
+            }
+        }
+    }
+}
+
 /// Create a compute pipeline.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create(
@@ -107,6 +149,10 @@ pub(super) fn submit(
     device_handle: DeviceHandle,
     commands: &[ComputeCommand],
 ) -> Result<FenceToken> {
+    // Reap any previously-submitted fences that have already signaled. Keeps
+    // the pool bounded when callers (ekrano) don't wait on every GpuFuture.
+    reap_signaled_fences(state);
+
     let devices = &state.devices;
     let compute_pipelines = &state.compute_pipelines;
     let buffers = &state.buffers;
@@ -424,16 +470,27 @@ pub(super) fn wait_fence(
             .wait_for_fences(&[fence], true, u64::MAX)
     };
 
-    // Fence done (or failed) — safe to free command buffer and fence now.
-    if let Some(cb) = cmd_buf {
-        unsafe {
-            logical_device
-                .device
-                .free_command_buffers(logical_device.command_pool, &[cb]);
+    // On ERROR_DEVICE_LOST the driver's internal bookkeeping is corrupt;
+    // calling free_command_buffers / destroy_fence on a lost device is a
+    // known Windows heap-corruption trigger. vkDestroyDevice (called later
+    // from device::destroy) implicitly reclaims these objects.
+    let device_lost = matches!(wait_result, Err(vk::Result::ERROR_DEVICE_LOST));
+    if !device_lost {
+        if let Some(cb) = cmd_buf {
+            unsafe {
+                logical_device
+                    .device
+                    .free_command_buffers(logical_device.command_pool, &[cb]);
+            }
         }
-    }
-    unsafe {
-        logical_device.device.destroy_fence(fence, None);
+        unsafe {
+            logical_device.device.destroy_fence(fence, None);
+        }
+    } else {
+        tracing::warn!(
+            %token,
+            "skipping free_command_buffers/destroy_fence on lost device (avoids driver heap corruption on some Windows drivers)"
+        );
     }
 
     if let Err(e) = wait_result {
@@ -488,14 +545,25 @@ pub(super) fn wait_fence_timeout(
         }
         Err(vk::Result::TIMEOUT) => Ok(false),
         Err(e) => {
+            // Same device-lost cleanup hazard as wait_fence: skip Vulkan
+            // destroy calls if the device is lost (vkDestroyDevice will
+            // implicitly reclaim them).
+            let device_lost = matches!(e, vk::Result::ERROR_DEVICE_LOST);
             if let Some((_, f, cb)) = state.compute_fence_pool.remove(&token) {
-                unsafe {
-                    if let Some(c) = cb {
-                        logical_device
-                            .device
-                            .free_command_buffers(logical_device.command_pool, &[c]);
+                if !device_lost {
+                    unsafe {
+                        if let Some(c) = cb {
+                            logical_device
+                                .device
+                                .free_command_buffers(logical_device.command_pool, &[c]);
+                        }
+                        logical_device.device.destroy_fence(f, None);
                     }
-                    logical_device.device.destroy_fence(f, None);
+                } else {
+                    tracing::warn!(
+                        %token,
+                        "skipping free_command_buffers/destroy_fence on lost device in wait_fence_timeout (avoids driver heap corruption on some Windows drivers)"
+                    );
                 }
             }
             Err(anyhow::anyhow!(

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -322,9 +322,58 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
 /// Destroy a logical device and all resources associated with it.
 #[allow(clippy::too_many_lines)]
 pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
+    tracing::info!(
+        %device_handle,
+        global_devices = state.devices.len(),
+        buffers = state.buffers.len(),
+        shaders = state.shaders.len(),
+        graphics_pipelines = state.pipelines.len(),
+        compute_pipelines = state.compute_pipelines.len(),
+        render_targets = state.render_targets.len(),
+        textures = state.textures.len(),
+        samplers = state.samplers.len(),
+        "destroying Vulkan device"
+    );
     if let Some(mut logical_device) = state.devices.remove(&device_handle) {
         unsafe {
-            logical_device.device.device_wait_idle().ok();
+            let wait_result = logical_device.device.device_wait_idle();
+
+            // When the device is lost, individual Vulkan destroy calls are unsafe
+            // (driver bookkeeping is already corrupt). Per spec, vkDestroyDevice is
+            // always valid and implicitly reclaims all child objects, so skip
+            // individual cleanup and jump straight to it.
+            if matches!(wait_result, Err(vk::Result::ERROR_DEVICE_LOST)) {
+                let pending = logical_device.deletion_queue.pending.len();
+                tracing::warn!(
+                    %device_handle,
+                    pending_deferred = pending,
+                    "lost Vulkan device — skipping per-object destroy, calling vkDestroyDevice only (driver may be in an invalid state)"
+                );
+                // Drop map entries without calling Vulkan (handles become invalid).
+                state
+                    .buffers
+                    .retain(|_, b| b.device_handle != device_handle);
+                state
+                    .shaders
+                    .retain(|_, s| s.device_handle != device_handle);
+                state
+                    .pipelines
+                    .retain(|_, p| p.device_handle != device_handle);
+                state
+                    .compute_pipelines
+                    .retain(|_, p| p.device_handle != device_handle);
+                state
+                    .render_targets
+                    .retain(|_, t| t.device_handle != device_handle);
+                state
+                    .textures
+                    .retain(|_, t| t.device_handle != device_handle);
+                state
+                    .samplers
+                    .retain(|_, s| s.device_handle != device_handle);
+                logical_device.device.destroy_device(None);
+                return;
+            }
 
             // Flush any pending deferred deletions
             logical_device
@@ -508,7 +557,7 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 .destroy_command_pool(logical_device.command_pool, None);
             logical_device.device.destroy_device(None);
         }
-        tracing::info!("Destroyed Vulkan device {}", device_handle);
+        tracing::info!(%device_handle, "destroyed Vulkan device");
     }
 }
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -79,6 +79,37 @@ pub struct VulkanBackend {
     state: VulkanState,
 }
 
+impl Drop for VulkanBackend {
+    fn drop(&mut self) {
+        tracing::info!(
+            devices = self.state.devices.len(),
+            surfaces = self.state.surfaces.len(),
+            compute_fences = self.state.compute_fence_pool.len(),
+            "VulkanBackend drop"
+        );
+
+        // Explicitly destroy the Vulkan instance before ash::Entry drops and unloads
+        // the DLL. On device-lost, vkDestroyDevice may leave driver-internal background
+        // state (TDR recovery threads) alive; vkDestroyInstance signals them to stop
+        // before the DLL code is unmapped. Without this call the loader entry drop
+        // (FreeLibrary) races with those threads and causes STATUS_HEAP_CORRUPTION.
+        //
+        // Only safe when all child objects (devices, surfaces) have been destroyed first.
+        if self.state.devices.is_empty() && self.state.surfaces.is_empty() {
+            unsafe {
+                self.state.instance.destroy_instance(None);
+            }
+            tracing::info!("vkDestroyInstance complete");
+        } else {
+            tracing::warn!(
+                devices = self.state.devices.len(),
+                surfaces = self.state.surfaces.len(),
+                "skipped vkDestroyInstance with child devices/surfaces still live (cleanup order bug?)"
+            );
+        }
+    }
+}
+
 impl VulkanBackend {
     /// Create a new Vulkan backend.
     pub fn new() -> Result<Self> {
@@ -628,6 +659,25 @@ impl GpuBackend for VulkanBackend {
 
     fn surface_format(&self, surface_handle: SurfaceHandle) -> TextureFormat {
         surface::format(&self.state.surfaces, surface_handle)
+    }
+
+    fn surface_set_present_mode(
+        &mut self,
+        surface_handle: SurfaceHandle,
+        mode: crate::types::PresentMode,
+    ) -> Result<()> {
+        surface::set_present_mode(
+            &self.state.entry,
+            &self.state.instance,
+            &self.state.devices,
+            &mut self.state.surfaces,
+            surface_handle,
+            mode,
+        )
+    }
+
+    fn surface_present_mode(&self, surface_handle: SurfaceHandle) -> crate::types::PresentMode {
+        surface::get_present_mode(&self.state.surfaces, surface_handle)
     }
 
     fn create_pipeline_with_depth(

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -154,12 +154,16 @@ pub(super) fn create(
         }
     };
 
-    // Create swapchain
-    let image_count = (capabilities.min_image_count + 1).min(if capabilities.max_image_count > 0 {
-        capabilities.max_image_count
-    } else {
-        u32::MAX
-    });
+    // Create swapchain: need at least `MAX_FRAMES_IN_FLIGHT` images so
+    // `acquire_next_image` does not stall on availability independently of
+    // the in-flight fence.
+    let image_count = (capabilities.min_image_count + 1)
+        .max(MAX_FRAMES_IN_FLIGHT as u32)
+        .min(if capabilities.max_image_count > 0 {
+            capabilities.max_image_count
+        } else {
+            u32::MAX
+        });
 
     let swapchain_info = vk::SwapchainCreateInfoKHR::default()
         .surface(surface)
@@ -334,6 +338,7 @@ pub(super) fn create(
             width: extent.width,
             height: extent.height,
             format: format.format,
+            present_mode,
             current_frame: 0,
             current_image_index: None,
             frame_sync,
@@ -439,7 +444,7 @@ pub(super) fn acquire(
     }
 
     // Get surface state and current frame index
-    let (device_handle, _current_frame, swapchain, in_flight_fence, image_available_semaphore) = {
+    let (device_handle, current_frame, swapchain, in_flight_fence, image_available_semaphore) = {
         let surface_state = surfaces
             .get(&surface_handle)
             .context("Invalid surface handle")?;
@@ -458,12 +463,22 @@ pub(super) fn acquire(
         .context("Surface's device is invalid")?;
 
     // Wait for the previous frame using this slot to finish
-    unsafe {
+    let wait_result = unsafe {
         logical_device
             .device
             .wait_for_fences(&[in_flight_fence], true, u64::MAX)
+    };
+    if let Err(e) = &wait_result {
+        tracing::warn!(
+            surface_handle,
+            %device_handle,
+            current_frame,
+            pending_deferred = logical_device.deletion_queue.pending.len(),
+            result = ?e,
+            "surface acquire: wait_for_fences (frame fence) failed"
+        );
     }
-    .context("Failed to wait for frame fence")?;
+    wait_result.context("Failed to wait for frame fence")?;
 
     {
         let surface_state = surfaces.get_mut(&surface_handle).unwrap();
@@ -491,8 +506,17 @@ pub(super) fn acquire(
         .context("Surface's device is invalid")?;
 
     // Reset fence for this frame
-    unsafe { logical_device.device.reset_fences(&[in_flight_fence]) }
-        .context("Failed to reset frame fence")?;
+    let reset_result = unsafe { logical_device.device.reset_fences(&[in_flight_fence]) };
+    if let Err(e) = &reset_result {
+        tracing::warn!(
+            surface_handle,
+            %device_handle,
+            current_frame,
+            result = ?e,
+            "surface acquire: reset_fences (frame fence) failed"
+        );
+    }
+    reset_result.context("Failed to reset frame fence")?;
 
     // Acquire next swapchain image
     let swapchain_loader = khr::swapchain::Device::new(instance, &logical_device.device);
@@ -588,14 +612,24 @@ pub(super) fn acquire(
                 .wait_dst_stage_mask(&wait_stages)
                 .command_buffers(std::slice::from_ref(&prep_cmd))
                 .signal_semaphores(&signal_semaphores);
-            unsafe {
+            let prep_submit_result = unsafe {
                 logical_device.device.queue_submit(
                     logical_device.queue,
                     std::slice::from_ref(&prep_submit),
                     vk::Fence::null(),
                 )
+            };
+            if let Err(e) = &prep_submit_result {
+                tracing::warn!(
+                    surface_handle,
+                    %device_handle,
+                    current_frame,
+                    image_index,
+                    result = ?e,
+                    "surface acquire: prep barrier queue_submit failed"
+                );
             }
-            .context("Failed to submit acquire prep barrier")?;
+            prep_submit_result.context("Failed to submit acquire prep barrier")?;
 
             // Register the swapchain image as a storage texture for compute access.
             // The image view is created for GENERAL layout so compute shaders can write
@@ -637,6 +671,13 @@ pub(super) fn acquire(
             anyhow::bail!("Surface lost - recreate surface")
         }
         Err(e) => {
+            tracing::warn!(
+                surface_handle,
+                %device_handle,
+                current_frame,
+                result = ?e,
+                "acquire_next_image failed"
+            );
             anyhow::bail!("Failed to acquire swapchain image: {:?}", e)
         }
     }
@@ -1001,14 +1042,24 @@ pub(super) fn present(
             .command_buffers(std::slice::from_ref(&cmd))
             .signal_semaphores(&signal_semaphores);
 
-        unsafe {
+        let submit_result = unsafe {
             logical_device.device.queue_submit(
                 logical_device.queue,
                 std::slice::from_ref(&submit_info),
                 frame.in_flight_fence,
             )
+        };
+        if let Err(e) = &submit_result {
+            tracing::warn!(
+                surface_handle,
+                %device_handle,
+                current_frame,
+                image_index,
+                result = ?e,
+                "compute-present layout barrier queue_submit failed"
+            );
         }
-        .context("Failed to submit compute-present layout barrier")?;
+        submit_result.context("Failed to submit compute-present layout barrier")?;
     }
 
     let frame = &surface_state.frame_sync[current_frame];
@@ -1025,6 +1076,16 @@ pub(super) fn present(
         .image_indices(&image_indices);
 
     let result = unsafe { swapchain_loader.queue_present(logical_device.queue, &present_info) };
+    if let Err(e) = &result {
+        tracing::warn!(
+            surface_handle,
+            %device_handle,
+            current_frame,
+            image_index,
+            result = ?e,
+            "queue_present failed"
+        );
+    }
 
     // Clear the current image and advance frame counter
     let surface_state = surfaces.get_mut(&surface_handle).unwrap();
@@ -1056,7 +1117,7 @@ pub(super) fn resize(
     height: u32,
 ) -> Result<()> {
     // Get surface info we need
-    let (device_handle, surface, old_swapchain, format, depth_fmt) = {
+    let (device_handle, surface, old_swapchain, format, depth_fmt, stored_present_mode) = {
         let surface_state = surfaces
             .get(&surface_handle)
             .context("Invalid surface handle")?;
@@ -1066,6 +1127,7 @@ pub(super) fn resize(
             surface_state.swapchain,
             surface_state.format,
             surface_state.depth_format,
+            surface_state.present_mode,
         )
     };
 
@@ -1115,11 +1177,13 @@ pub(super) fn resize(
         ),
     };
 
-    let image_count = (capabilities.min_image_count + 1).min(if capabilities.max_image_count > 0 {
-        capabilities.max_image_count
-    } else {
-        u32::MAX
-    });
+    let image_count = (capabilities.min_image_count + 1)
+        .max(MAX_FRAMES_IN_FLIGHT as u32)
+        .min(if capabilities.max_image_count > 0 {
+            capabilities.max_image_count
+        } else {
+            u32::MAX
+        });
 
     // Create new swapchain (reusing old one for efficiency)
     let swapchain_info = vk::SwapchainCreateInfoKHR::default()
@@ -1133,7 +1197,7 @@ pub(super) fn resize(
         .image_sharing_mode(vk::SharingMode::EXCLUSIVE)
         .pre_transform(capabilities.current_transform)
         .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
-        .present_mode(vk::PresentModeKHR::FIFO)
+        .present_mode(stored_present_mode)
         .clipped(true)
         .old_swapchain(old_swapchain);
 
@@ -1245,10 +1309,107 @@ pub(super) fn resize(
         surface_state.depth_image = new_depth_image;
         surface_state.depth_memory = new_depth_memory;
         surface_state.depth_view = new_depth_view;
+        surface_state.present_mode = stored_present_mode;
     }
 
     tracing::debug!("Resized surface to {}x{}", extent.width, extent.height);
+
     Ok(())
+}
+
+/// Set swapchain present mode (vsync). Recreates the swapchain when the mode changes.
+pub(super) fn set_present_mode(
+    entry: &Entry,
+    instance: &Instance,
+    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
+    surface_handle: SurfaceHandle,
+    mode: crate::types::PresentMode,
+) -> Result<()> {
+    let (w, h, current_vk) = {
+        let s = surfaces
+            .get(&surface_handle)
+            .context("Invalid surface handle")?;
+        (s.width, s.height, s.present_mode)
+    };
+
+    let (physical_device, vk_surface) = {
+        let surface_state = surfaces
+            .get(&surface_handle)
+            .context("Invalid surface handle")?;
+        let pd = devices
+            .get(&surface_state.device_handle)
+            .context("Surface's device is invalid")?
+            .physical_device;
+        (pd, surface_state.surface)
+    };
+
+    let surface_loader = khr::surface::Instance::new(entry, instance);
+    let present_modes = unsafe {
+        surface_loader.get_physical_device_surface_present_modes(physical_device, vk_surface)
+    }
+    .context("Failed to get present modes")?;
+
+    let vk_mode = pick_vk_present_mode(mode, &present_modes)?;
+    if vk_mode == current_vk {
+        return Ok(());
+    }
+
+    {
+        let surface_state = surfaces
+            .get_mut(&surface_handle)
+            .context("Invalid surface handle")?;
+        surface_state.present_mode = vk_mode;
+    }
+
+    resize(entry, instance, devices, surfaces, surface_handle, w, h)
+}
+
+fn pick_vk_present_mode(
+    requested: crate::types::PresentMode,
+    present_modes: &[vk::PresentModeKHR],
+) -> Result<vk::PresentModeKHR> {
+    use crate::types::PresentMode;
+    let vk_target = match requested {
+        PresentMode::Fifo => vk::PresentModeKHR::FIFO,
+        PresentMode::Mailbox => vk::PresentModeKHR::MAILBOX,
+        PresentMode::Immediate => vk::PresentModeKHR::IMMEDIATE,
+        PresentMode::Auto => {
+            if present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
+                vk::PresentModeKHR::MAILBOX
+            } else {
+                vk::PresentModeKHR::FIFO
+            }
+        }
+    };
+    if !present_modes.contains(&vk_target) {
+        anyhow::bail!(
+            "Requested present mode {:?} is not supported by this surface",
+            requested
+        );
+    }
+    Ok(vk_target)
+}
+
+/// Active swapchain present mode as a Goldy enum.
+pub(super) fn get_present_mode(
+    surfaces: &HashMap<SurfaceHandle, SurfaceState>,
+    surface_handle: SurfaceHandle,
+) -> crate::types::PresentMode {
+    surfaces
+        .get(&surface_handle)
+        .map(|s| vk_to_goldy_present_mode(s.present_mode))
+        .unwrap_or_default()
+}
+
+fn vk_to_goldy_present_mode(mode: vk::PresentModeKHR) -> crate::types::PresentMode {
+    use crate::types::PresentMode;
+    match mode {
+        vk::PresentModeKHR::FIFO | vk::PresentModeKHR::FIFO_RELAXED => PresentMode::Fifo,
+        vk::PresentModeKHR::MAILBOX => PresentMode::Mailbox,
+        vk::PresentModeKHR::IMMEDIATE => PresentMode::Immediate,
+        _ => PresentMode::Fifo,
+    }
 }
 
 /// Get the current size of the surface.

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -81,7 +81,12 @@ pub struct BindlessIndices {
 unsafe impl bytemuck::Pod for BindlessIndices {}
 unsafe impl bytemuck::Zeroable for BindlessIndices {}
 
-/// Registry for tracking bindless resource indices
+/// Registry for tracking bindless resource indices.
+///
+/// Each resource type has a monotonically-allocated counter plus a free list of
+/// slots reclaimed by `unregister_*`. Registration prefers a recycled slot so the
+/// total live + free count stays bounded by `MAX_BINDLESS_RESOURCES` rather than
+/// growing unbounded with creation churn.
 #[derive(Default)]
 pub(crate) struct ResourceRegistry {
     next_storage_buffer_index: u32,
@@ -89,8 +94,15 @@ pub(crate) struct ResourceRegistry {
     next_sampled_texture_index: u32,
     next_storage_image_index: u32,
     next_sampler_index: u32,
-    pub buffer_indices: HashMap<BufferHandle, u32>,
-    pub texture_indices: HashMap<TextureHandle, u32>,
+    free_storage_buffer_indices: Vec<u32>,
+    free_uniform_buffer_indices: Vec<u32>,
+    free_sampled_texture_indices: Vec<u32>,
+    free_storage_image_indices: Vec<u32>,
+    free_sampler_indices: Vec<u32>,
+    /// Map BufferHandle -> (bindless_index, is_storage)
+    pub buffer_indices: HashMap<BufferHandle, (u32, bool)>,
+    /// Map TextureHandle -> (bindless_index, is_storage_image)
+    pub texture_indices: HashMap<TextureHandle, (u32, bool)>,
     pub sampler_indices: HashMap<SamplerHandle, u32>,
 }
 
@@ -102,6 +114,11 @@ impl ResourceRegistry {
             next_sampled_texture_index: 0,
             next_storage_image_index: 0,
             next_sampler_index: 0,
+            free_storage_buffer_indices: Vec::new(),
+            free_uniform_buffer_indices: Vec::new(),
+            free_sampled_texture_indices: Vec::new(),
+            free_storage_image_indices: Vec::new(),
+            free_sampler_indices: Vec::new(),
             buffer_indices: HashMap::new(),
             texture_indices: HashMap::new(),
             sampler_indices: HashMap::new(),
@@ -110,49 +127,191 @@ impl ResourceRegistry {
 
     pub fn register_buffer(&mut self, handle: BufferHandle, is_storage: bool) -> u32 {
         let index = if is_storage {
-            let idx = self.next_storage_buffer_index;
-            self.next_storage_buffer_index += 1;
-            idx
+            self.free_storage_buffer_indices.pop().unwrap_or_else(|| {
+                let idx = self.next_storage_buffer_index;
+                self.next_storage_buffer_index += 1;
+                idx
+            })
         } else {
-            let idx = self.next_uniform_buffer_index;
-            self.next_uniform_buffer_index += 1;
-            idx
+            self.free_uniform_buffer_indices.pop().unwrap_or_else(|| {
+                let idx = self.next_uniform_buffer_index;
+                self.next_uniform_buffer_index += 1;
+                idx
+            })
         };
-        self.buffer_indices.insert(handle, index);
+        self.buffer_indices.insert(handle, (index, is_storage));
         index
     }
 
     pub fn register_texture(&mut self, handle: TextureHandle, is_storage_image: bool) -> u32 {
         let index = if is_storage_image {
-            let idx = self.next_storage_image_index;
-            self.next_storage_image_index += 1;
-            idx
+            self.free_storage_image_indices.pop().unwrap_or_else(|| {
+                let idx = self.next_storage_image_index;
+                self.next_storage_image_index += 1;
+                idx
+            })
         } else {
-            let idx = self.next_sampled_texture_index;
-            self.next_sampled_texture_index += 1;
-            idx
+            self.free_sampled_texture_indices.pop().unwrap_or_else(|| {
+                let idx = self.next_sampled_texture_index;
+                self.next_sampled_texture_index += 1;
+                idx
+            })
         };
-        self.texture_indices.insert(handle, index);
+        self.texture_indices
+            .insert(handle, (index, is_storage_image));
         index
     }
 
     pub fn register_sampler(&mut self, handle: SamplerHandle) -> u32 {
-        let index = self.next_sampler_index;
-        self.next_sampler_index += 1;
+        let index = self.free_sampler_indices.pop().unwrap_or_else(|| {
+            let idx = self.next_sampler_index;
+            self.next_sampler_index += 1;
+            idx
+        });
         self.sampler_indices.insert(handle, index);
         index
     }
 
     pub fn unregister_buffer(&mut self, handle: BufferHandle) {
-        self.buffer_indices.remove(&handle);
+        if let Some((index, is_storage)) = self.buffer_indices.remove(&handle) {
+            if is_storage {
+                self.free_storage_buffer_indices.push(index);
+            } else {
+                self.free_uniform_buffer_indices.push(index);
+            }
+        }
     }
 
     pub fn unregister_texture(&mut self, handle: TextureHandle) {
-        self.texture_indices.remove(&handle);
+        if let Some((index, is_storage_image)) = self.texture_indices.remove(&handle) {
+            if is_storage_image {
+                self.free_storage_image_indices.push(index);
+            } else {
+                self.free_sampled_texture_indices.push(index);
+            }
+        }
     }
 
     pub fn unregister_sampler(&mut self, handle: SamplerHandle) {
-        self.sampler_indices.remove(&handle);
+        if let Some(index) = self.sampler_indices.remove(&handle) {
+            self.free_sampler_indices.push(index);
+        }
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    /// Simulate the per-frame create/destroy churn that ekrano generates for transient
+    /// pool-view storage buffers. The counter must stay bounded — well below
+    /// MAX_BINDLESS_RESOURCES — even after far more iterations than the heap limit.
+    #[test]
+    fn storage_buffer_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..50_000u64 {
+            let handle = i as BufferHandle;
+            reg.register_buffer(handle, true);
+            reg.unregister_buffer(handle);
+        }
+        assert_eq!(
+            reg.next_storage_buffer_index, 1,
+            "storage buffer counter grew; slot recycling not working"
+        );
+        assert_eq!(reg.free_storage_buffer_indices.len(), 1);
+    }
+
+    /// Uniform buffer (non-storage) slots must recycle independently.
+    #[test]
+    fn uniform_buffer_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..50_000u64 {
+            let handle = i as BufferHandle;
+            reg.register_buffer(handle, false);
+            reg.unregister_buffer(handle);
+        }
+        assert_eq!(
+            reg.next_uniform_buffer_index, 1,
+            "uniform buffer counter grew; slot recycling not working"
+        );
+    }
+
+    /// Sampled textures (non-storage) must recycle their indices.
+    #[test]
+    fn sampled_texture_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..50_000u64 {
+            let handle = i as TextureHandle;
+            reg.register_texture(handle, false);
+            reg.unregister_texture(handle);
+        }
+        assert_eq!(reg.next_sampled_texture_index, 1);
+        assert_eq!(reg.free_sampled_texture_indices.len(), 1);
+    }
+
+    /// Storage images (RWTexture2D) must recycle their indices.
+    #[test]
+    fn storage_image_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..50_000u64 {
+            let handle = i as TextureHandle;
+            reg.register_texture(handle, true);
+            reg.unregister_texture(handle);
+        }
+        assert_eq!(reg.next_storage_image_index, 1);
+        assert_eq!(reg.free_storage_image_indices.len(), 1);
+    }
+
+    /// Sampler slots must recycle independently.
+    #[test]
+    fn sampler_slots_recycled_under_churn() {
+        let mut reg = ResourceRegistry::new();
+        for i in 0..5_000u64 {
+            let handle = i as SamplerHandle;
+            reg.register_sampler(handle);
+            reg.unregister_sampler(handle);
+        }
+        assert_eq!(reg.next_sampler_index, 1);
+        assert_eq!(reg.free_sampler_indices.len(), 1);
+    }
+
+    /// Simultaneously-live resources must receive distinct indices.
+    #[test]
+    fn live_resources_get_distinct_indices() {
+        let mut reg = ResourceRegistry::new();
+        const N: u64 = 64;
+        let mut indices: Vec<u32> = (0..N)
+            .map(|i| reg.register_buffer(i as BufferHandle, true))
+            .collect();
+        indices.sort_unstable();
+        indices.dedup();
+        assert_eq!(
+            indices.len(),
+            N as usize,
+            "duplicate indices assigned to live resources"
+        );
+    }
+
+    /// The high-water mark of the monotonic counter must never exceed the number of
+    /// concurrently-live resources, i.e. freed slots are reused before fresh ones are minted.
+    #[test]
+    fn high_water_mark_bounded_by_live_count() {
+        let mut reg = ResourceRegistry::new();
+        const LIVE: u64 = 8;
+        const ROUNDS: u64 = 10_000;
+
+        for i in 0..LIVE {
+            reg.register_buffer(i as BufferHandle, true);
+        }
+        for i in LIVE..LIVE + ROUNDS {
+            reg.unregister_buffer((i - LIVE) as BufferHandle);
+            reg.register_buffer(i as BufferHandle, true);
+        }
+        assert!(
+            reg.next_storage_buffer_index <= LIVE as u32,
+            "counter ({}) exceeded live count ({LIVE}); slot recycling broken",
+            reg.next_storage_buffer_index
+        );
     }
 }
 
@@ -348,7 +507,7 @@ pub(crate) struct SamplerState {
 }
 
 /// Maximum number of frames that can be in-flight at once.
-pub const MAX_FRAMES_IN_FLIGHT: usize = 2;
+pub const MAX_FRAMES_IN_FLIGHT: usize = 3;
 
 /// Per-frame synchronization resources for proper swapchain pipelining.
 pub(crate) struct FrameSync {
@@ -382,6 +541,8 @@ pub(crate) struct SurfaceState {
     pub width: u32,
     pub height: u32,
     pub format: vk::Format,
+    /// Current swapchain present mode (vsync strategy).
+    pub present_mode: vk::PresentModeKHR,
     /// Depth buffer (when depth_format is Some)
     pub depth_format: Option<DepthFormat>,
     pub depth_image: Option<vk::Image>,

--- a/src/device.rs
+++ b/src/device.rs
@@ -552,7 +552,12 @@ impl Device {
 
 impl Drop for Device {
     fn drop(&mut self) {
-        tracing::debug!(adapter_id = self.adapter_id, "Destroying GPU device");
+        tracing::debug!(
+            %self.handle,
+            adapter_id = self.adapter_id,
+            device_type = ?self.device_type,
+            "Destroying GPU device"
+        );
         let mut backend = self.backend.lock().unwrap();
         backend.destroy_device(self.handle);
     }


### PR DESCRIPTION
- Updated the `ResourceRegistry` to implement recycling of buffer and texture indices, preventing unbounded growth during resource churn.
- Added detailed logging in the Vulkan device destruction process to capture the state of resources being released.
- Implemented fence management in the Vulkan compute backend to prevent leaks and ensure proper cleanup of command buffers and fences.
- Enhanced error handling in surface acquisition and command submission, providing clearer diagnostics for potential failures.