### PR TITLE
Implement CPU_COHERENT buffer support across backends

### DIFF
--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -4,6 +4,7 @@ use super::barriers;
 use super::types::{BufferState, Dx12State};
 use super::{BufferHandle, DeviceHandle};
 use crate::backend::DataAccess;
+use crate::types::BufferFlags;
 use anyhow::{Context, Result};
 use windows::core::Interface;
 use windows::Win32::Graphics::{Direct3D12::*, Dxgi::Common::*};
@@ -16,9 +17,11 @@ pub(super) fn create(
     size: u64,
     access: DataAccess,
     element_stride: Option<u32>,
+    flags: BufferFlags,
 ) -> Result<BufferHandle> {
+    let cpu_coherent = flags.contains(BufferFlags::CPU_COHERENT);
     // First pass: create the resource (immutable borrow of device)
-    let (resource, upload_buffer, is_storage) = {
+    let (resource, upload_buffer, is_storage, coherent_readback, coherent_readback_mapped) = {
         let logical_device = state
             .devices
             .get(&device_handle)
@@ -26,6 +29,10 @@ pub(super) fn create(
 
         // Scattered access -> storage buffer (UAV), Broadcast access -> uniform buffer (CBV)
         let is_storage = access == DataAccess::Scattered;
+
+        if cpu_coherent && !is_storage {
+            anyhow::bail!("BufferFlags::CPU_COHERENT is only valid for DataAccess::Scattered (storage) buffers");
+        }
 
         // Storage buffers need DEFAULT heap for UAV support (bindless)
         // Non-storage buffers can use UPLOAD heap for simpler CPU access
@@ -88,7 +95,63 @@ pub(super) fn create(
         // for buffers that are only GPU-written (intermediate compute buffers, pool backing).
         let upload_buffer = None;
 
-        (resource, upload_buffer, is_storage)
+        // CPU_COHERENT storage: pair DEFAULT UAV with a READBACK heap for `read_coherent` / `copy_to_coherent_readback`.
+        let (coherent_readback, coherent_readback_mapped) = if cpu_coherent && is_storage {
+            let readback_heap = D3D12_HEAP_PROPERTIES {
+                Type: D3D12_HEAP_TYPE_READBACK,
+                CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+                MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
+                CreationNodeMask: 0,
+                VisibleNodeMask: 0,
+            };
+            let readback_desc = D3D12_RESOURCE_DESC {
+                Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+                Alignment: 0,
+                Width: size,
+                Height: 1,
+                DepthOrArraySize: 1,
+                MipLevels: 1,
+                Format: DXGI_FORMAT_UNKNOWN,
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
+                Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                Flags: D3D12_RESOURCE_FLAG_NONE,
+            };
+            let mut rb: Option<ID3D12Resource> = None;
+            unsafe {
+                logical_device.device.CreateCommittedResource(
+                    &readback_heap,
+                    D3D12_HEAP_FLAG_NONE,
+                    &readback_desc,
+                    D3D12_RESOURCE_STATE_COPY_DEST,
+                    None,
+                    &mut rb,
+                )
+            }
+            .context("Failed to create CPU_COHERENT readback buffer")?;
+            let rb = rb.context("CreateCommittedResource readback returned null")?;
+            let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
+            let no_read = D3D12_RANGE { Begin: 0, End: 0 };
+            unsafe { rb.Map(0, Some(&no_read), Some(&mut mapped)) }
+                .context("Failed to map CPU_COHERENT readback buffer")?;
+            let p = mapped as *mut u8;
+            if p.is_null() {
+                anyhow::bail!("Map returned null for CPU_COHERENT readback");
+            }
+            (Some(rb), Some(p as usize))
+        } else {
+            (None, None)
+        };
+
+        (
+            resource,
+            upload_buffer,
+            is_storage,
+            coherent_readback,
+            coherent_readback_mapped,
+        )
     };
 
     let handle = state.next_buffer_handle;
@@ -242,6 +305,9 @@ pub(super) fn create(
             upload_buffer,
             element_stride,
             is_view: false,
+            coherent_readback,
+            coherent_readback_mapped,
+            flags,
         },
     );
 
@@ -255,6 +321,12 @@ pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
     if let Some(buffer) = state.buffers.remove(&buffer_handle) {
         if let Some(device) = state.devices.get_mut(&buffer.device_handle) {
             device.resource_registry.unregister_buffer(buffer_handle);
+        }
+        if buffer.coherent_readback_mapped.is_some() {
+            if let Some(ref rb) = buffer.coherent_readback {
+                let no_write = D3D12_RANGE { Begin: 0, End: 0 };
+                unsafe { rb.Unmap(0, Some(&no_write)) };
+            }
         }
         // Views don't own the resource — the parent does.
         // When `is_view` is false the ID3D12Resource drops naturally via its Drop impl.
@@ -305,6 +377,7 @@ pub(super) fn create_view(
 
     let device_handle = parent.device_handle;
     let resource = parent.resource.clone();
+    let parent_flags = parent.flags;
     let first_element = (offset / stride as u64) as u32;
     let num_elements = (size as u32) / stride;
 
@@ -413,6 +486,9 @@ pub(super) fn create_view(
             upload_buffer: None,
             element_stride,
             is_view: true,
+            coherent_readback: None,
+            coherent_readback_mapped: None,
+            flags: parent_flags,
         },
     );
 
@@ -704,6 +780,120 @@ pub(super) fn element_stride_for_bindless_handle(
     None
 }
 
+/// GPU copy DEFAULT UAV → paired READBACK for `CPU_COHERENT` storage buffers. Wait until complete.
+pub(super) fn copy_to_coherent_readback(
+    state: &mut Dx12State,
+    device_handle: DeviceHandle,
+    buffer_handle: BufferHandle,
+) -> Result<()> {
+    use super::utils::wait_for_fence;
+    use windows::Win32::Graphics::Direct3D12::*;
+
+    let (main_resource, readback, len) = {
+        let buffer = state
+            .buffers
+            .get(&buffer_handle)
+            .context("Invalid buffer handle")?;
+        if !buffer.flags.contains(BufferFlags::CPU_COHERENT) || !buffer.is_storage {
+            return Ok(());
+        }
+        let readback = buffer
+            .coherent_readback
+            .as_ref()
+            .context("CPU_COHERENT buffer missing readback resource")?;
+        (buffer.resource.clone(), readback.clone(), buffer.size)
+    };
+
+    let device = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?;
+
+    let copy_allocator: ID3D12CommandAllocator = unsafe {
+        device
+            .device
+            .CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
+    }
+    .context("Failed to create copy command allocator (coherent readback)")?;
+
+    let copy_list: ID3D12GraphicsCommandList = unsafe {
+        device
+            .device
+            .CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, &copy_allocator, None)
+    }
+    .context("Failed to create copy command list (coherent readback)")?;
+    let copy_list7: ID3D12GraphicsCommandList7 = copy_list.cast()?;
+
+    let pre_copy = D3D12_GLOBAL_BARRIER {
+        SyncBefore: D3D12_BARRIER_SYNC_ALL,
+        SyncAfter: D3D12_BARRIER_SYNC_COPY,
+        AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+        AccessAfter: D3D12_BARRIER_ACCESS_COPY_SOURCE,
+    };
+    let post_copy = D3D12_GLOBAL_BARRIER {
+        SyncBefore: D3D12_BARRIER_SYNC_COPY,
+        SyncAfter: D3D12_BARRIER_SYNC_ALL,
+        AccessBefore: D3D12_BARRIER_ACCESS_COPY_SOURCE,
+        AccessAfter: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+    };
+    unsafe {
+        barriers::barrier_globals(&copy_list7, &[pre_copy]);
+    }
+    unsafe {
+        copy_list.CopyBufferRegion(&readback, 0, &main_resource, 0, len);
+    }
+    unsafe {
+        barriers::barrier_globals(&copy_list7, &[post_copy]);
+    }
+    unsafe { copy_list.Close() }
+        .context("Failed to close copy command list (coherent readback)")?;
+
+    let lists: [Option<ID3D12CommandList>; 1] = [Some(
+        copy_list.cast().context("Failed to cast command list")?,
+    )];
+    unsafe { device.command_queue.ExecuteCommandLists(&lists) };
+
+    let fence_value = device.fence_value + 1;
+    unsafe { device.command_queue.Signal(&device.fence, fence_value) }
+        .context("Failed to signal fence (coherent readback)")?;
+    wait_for_fence(&device.fence, fence_value)?;
+
+    if let Some(dev) = state.devices.get_mut(&device_handle) {
+        dev.fence_value = fence_value + 1;
+    }
+    Ok(())
+}
+
+/// Read from the persistent READBACK map after `copy_to_coherent_readback`.
+pub(super) fn read_coherent(
+    buffers: &std::collections::HashMap<BufferHandle, BufferState>,
+    buffer_handle: BufferHandle,
+    offset: u64,
+    output: &mut [u8],
+) -> Result<()> {
+    let buffer = buffers
+        .get(&buffer_handle)
+        .context("Invalid buffer handle")?;
+    if !buffer.flags.contains(BufferFlags::CPU_COHERENT) {
+        anyhow::bail!("read_buffer_coherent requires BufferFlags::CPU_COHERENT");
+    }
+    let base = buffer
+        .coherent_readback_mapped
+        .context("CPU_COHERENT buffer not mapped for readback")?;
+    if offset + output.len() as u64 > buffer.size {
+        anyhow::bail!("read_coherent would exceed buffer bounds");
+    }
+    let p = base as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            p.add(offset as usize) as *const u8,
+            output.as_mut_ptr(),
+            output.len(),
+        );
+    }
+    Ok(())
+}
+
 /// Read buffer contents back to CPU memory.
 ///
 /// For DEFAULT heap buffers (storage), creates a readback buffer and copies.
@@ -724,6 +914,14 @@ pub(super) fn read_to_cpu(
     let len = output.len() as u64;
     if len > buffer.size {
         anyhow::bail!("Read would exceed buffer bounds");
+    }
+
+    if buffer.is_storage
+        && buffer.flags.contains(BufferFlags::CPU_COHERENT)
+        && buffer.coherent_readback.is_some()
+    {
+        copy_to_coherent_readback(state, device_handle, buffer_handle)?;
+        return read_coherent(&state.buffers, buffer_handle, 0, output);
     }
 
     if buffer.is_storage {

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -383,8 +383,16 @@ impl GpuBackend for Dx12Backend {
         size: u64,
         access: DataAccess,
         element_stride: Option<u32>,
+        flags: crate::types::BufferFlags,
     ) -> Result<BufferHandle> {
-        buffer::create(&mut self.state, device_handle, size, access, element_stride)
+        buffer::create(
+            &mut self.state,
+            device_handle,
+            size,
+            access,
+            element_stride,
+            flags,
+        )
     }
 
     fn destroy_buffer(&mut self, buffer_handle: BufferHandle) {
@@ -429,6 +437,23 @@ impl GpuBackend for Dx12Backend {
         output: &mut [u8],
     ) -> Result<()> {
         buffer::read_to_cpu(&mut self.state, device, buffer, output)
+    }
+
+    fn read_buffer_coherent(
+        &self,
+        buffer: BufferHandle,
+        offset: u64,
+        output: &mut [u8],
+    ) -> Result<()> {
+        buffer::read_coherent(&self.state.buffers, buffer, offset, output)
+    }
+
+    fn copy_to_coherent_readback(
+        &mut self,
+        device: DeviceHandle,
+        buffer: BufferHandle,
+    ) -> Result<()> {
+        buffer::copy_to_coherent_readback(&mut self.state, device, buffer)
     }
 
     fn clear_buffer(

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -373,6 +373,14 @@ pub(crate) struct BufferState {
     pub element_stride: Option<u32>,
     /// If true, this is a view into another buffer — don't free the resource on destroy.
     pub is_view: bool,
+    /// Direct3D 12: paired READBACK resource for [`crate::types::BufferFlags::CPU_COHERENT`]
+    /// storage buffers; CPU reads copy from this after [`super::buffer::copy_to_coherent_readback`].
+    pub coherent_readback: Option<Direct3D12::ID3D12Resource>,
+    /// Persistent map of `coherent_readback` (see above).
+    /// Persistent `Map` result address for the readback resource (`usize` for `Send`/`Sync`).
+    pub coherent_readback_mapped: Option<usize>,
+    /// Creation-time flags.
+    pub flags: crate::types::BufferFlags,
 }
 
 /// Shader module state with cached compiled bytecode.

--- a/src/backend/metal/buffer.rs
+++ b/src/backend/metal/buffer.rs
@@ -3,6 +3,7 @@
 use super::super::{BufferHandle, DeviceHandle};
 use super::types::{BufferState, MetalState, ResourceRegistry, ARGUMENT_BUFFER_SIZE};
 use crate::backend::DataAccess;
+use crate::types::BufferFlags;
 use ::metal as mtl;
 use anyhow::{Context, Result};
 use mtl::MTLResourceOptions;
@@ -15,7 +16,15 @@ pub(super) fn create(
     size: u64,
     access: DataAccess,
     element_stride: Option<u32>,
+    flags: BufferFlags,
 ) -> Result<BufferHandle> {
+    let cpu_coherent = flags.contains(BufferFlags::CPU_COHERENT);
+    let is_storage = access == DataAccess::Scattered;
+    if cpu_coherent && !is_storage {
+        anyhow::bail!(
+            "BufferFlags::CPU_COHERENT is only valid for DataAccess::Scattered (storage) buffers"
+        );
+    }
     let logical_device = state
         .devices
         .get_mut(&device_handle)
@@ -69,6 +78,16 @@ pub(super) fn create(
         );
     }
 
+    let host_mapped = if cpu_coherent && is_storage {
+        let ptr = buffer.contents() as *mut u8;
+        if ptr.is_null() {
+            anyhow::bail!("Metal buffer contents() returned null for CPU_COHERENT");
+        }
+        Some(ptr as usize)
+    } else {
+        None
+    };
+
     state.buffers.insert(
         handle,
         BufferState {
@@ -78,6 +97,8 @@ pub(super) fn create(
             arg_buffer_index,
             access,
             element_stride,
+            host_mapped,
+            flags,
         },
     );
 
@@ -111,6 +132,7 @@ pub(super) fn create_view(
 
     let device_handle = parent.device_handle;
     let parent_mtl_buffer = parent.buffer.clone();
+    let parent_flags = parent.flags;
 
     let handle = state.next_buffer_handle;
     state.next_buffer_handle += 1;
@@ -144,10 +166,42 @@ pub(super) fn create_view(
             arg_buffer_index,
             access: DataAccess::Scattered,
             element_stride,
+            host_mapped: None,
+            flags: parent_flags,
         },
     );
 
     Ok(handle)
+}
+
+/// Read from a `CPU_COHERENT` host mapping (same physical memory as the GPU on shared storage).
+pub(super) fn read_coherent(
+    buffers: &HashMap<BufferHandle, BufferState>,
+    buffer_handle: BufferHandle,
+    offset: u64,
+    output: &mut [u8],
+) -> Result<()> {
+    let buffer = buffers
+        .get(&buffer_handle)
+        .context("Invalid buffer handle")?;
+    if !buffer.flags.contains(BufferFlags::CPU_COHERENT) {
+        anyhow::bail!("read_buffer_coherent requires BufferFlags::CPU_COHERENT");
+    }
+    let base = buffer
+        .host_mapped
+        .context("CPU_COHERENT buffer has no host mapping")?;
+    if offset + output.len() as u64 > buffer.size {
+        anyhow::bail!("read_coherent would exceed buffer bounds");
+    }
+    let p = base as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            p.add(offset as usize) as *const u8,
+            output.as_mut_ptr(),
+            output.len(),
+        );
+    }
+    Ok(())
 }
 
 /// Destroy a buffer, unregistering it from the bindless registry.

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -237,8 +237,9 @@ impl GpuBackend for MetalBackend {
         size: u64,
         access: DataAccess,
         element_stride: Option<u32>,
+        flags: crate::types::BufferFlags,
     ) -> Result<BufferHandle> {
-        buffer::create(&mut self.state, device, size, access, element_stride)
+        buffer::create(&mut self.state, device, size, access, element_stride, flags)
     }
 
     fn destroy_buffer(&mut self, buffer: BufferHandle) {
@@ -279,6 +280,15 @@ impl GpuBackend for MetalBackend {
         output: &mut [u8],
     ) -> Result<()> {
         buffer::read_to_cpu(&self.state, device, buffer, output)
+    }
+
+    fn read_buffer_coherent(
+        &self,
+        buffer: BufferHandle,
+        offset: u64,
+        output: &mut [u8],
+    ) -> Result<()> {
+        buffer::read_coherent(&self.state.buffers, buffer, offset, output)
     }
 
     fn clear_buffer(
@@ -672,7 +682,13 @@ mod tests {
         let device = backend.create_device(0).unwrap();
 
         let buffer = backend
-            .create_buffer(device, 256, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                256,
+                DataAccess::Scattered,
+                None,
+                crate::types::BufferFlags::empty(),
+            )
             .unwrap();
 
         assert_eq!(backend.buffer_size(buffer), 256);

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -722,6 +722,11 @@ pub(crate) struct BufferState {
     pub access: crate::types::DataAccess,
     /// Structured-buffer / uniform element stride from buffer creation.
     pub element_stride: Option<u32>,
+    /// Persistent `contents()` pointer when created with [`crate::types::BufferFlags::CPU_COHERENT`]
+    /// (shared storage: same as a normal read for other buffers).
+    /// `buffer.contents() as usize` when `CPU_COHERENT` (for `Send`/`Sync`).
+    pub host_mapped: Option<usize>,
+    pub flags: crate::types::BufferFlags,
 }
 
 /// Shader module state with cached compiled stages.

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -67,6 +67,7 @@ struct MockBuffer {
     size: u64,
     data: Vec<u8>,
     bindless_index: u32,
+    flags: BufferFlags,
 }
 
 #[allow(dead_code)]
@@ -241,6 +242,7 @@ impl GpuBackend for MockBackend {
         size: u64,
         _access: DataAccess,
         _element_stride: Option<u32>,
+        flags: BufferFlags,
     ) -> Result<BufferHandle> {
         if !self.devices.contains_key(&device) {
             anyhow::bail!("Invalid device handle");
@@ -259,6 +261,7 @@ impl GpuBackend for MockBackend {
                 size,
                 data: vec![0u8; size as usize],
                 bindless_index,
+                flags,
             },
         );
 
@@ -326,6 +329,7 @@ impl GpuBackend for MockBackend {
                 size,
                 data: vec![0; size as usize],
                 bindless_index: index,
+                flags: BufferFlags::empty(),
             },
         );
 
@@ -345,6 +349,28 @@ impl GpuBackend for MockBackend {
 
         let len = output.len().min(buf.data.len());
         output[..len].copy_from_slice(&buf.data[..len]);
+        Ok(())
+    }
+
+    fn read_buffer_coherent(
+        &self,
+        buffer: BufferHandle,
+        offset: u64,
+        output: &mut [u8],
+    ) -> Result<()> {
+        let buf = self
+            .buffers
+            .get(&buffer)
+            .ok_or_else(|| anyhow::anyhow!("Invalid buffer handle"))?;
+        if !buf.flags.contains(BufferFlags::CPU_COHERENT) {
+            anyhow::bail!("read_buffer_coherent requires BufferFlags::CPU_COHERENT");
+        }
+        let start = offset as usize;
+        let end = start.saturating_add(output.len());
+        if end > buf.data.len() {
+            anyhow::bail!("read_coherent would exceed buffer bounds");
+        }
+        output.copy_from_slice(&buf.data[start..end]);
         Ok(())
     }
 
@@ -1088,7 +1114,13 @@ mod tests {
 
         // Create an index buffer
         let index_buffer = backend
-            .create_buffer(device, 12, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                12,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         // Write some indices (6 u16 indices for 2 triangles)
@@ -1163,7 +1195,13 @@ mod tests {
             .create_render_target(device, 100, 100, TextureFormat::Rgba8Unorm)
             .unwrap();
         let index_buffer = backend
-            .create_buffer(device, 24, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                24,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         // Test with offset and base_vertex
@@ -1374,13 +1412,31 @@ mod tests {
 
         // Create multiple buffers and verify they get sequential bindless indices
         let buffer1 = backend
-            .create_buffer(device, 64, DataAccess::Broadcast, None)
+            .create_buffer(
+                device,
+                64,
+                DataAccess::Broadcast,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
         let buffer2 = backend
-            .create_buffer(device, 128, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                128,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
         let buffer3 = backend
-            .create_buffer(device, 256, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                256,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         assert_eq!(backend.buffer_bindless_index(buffer1), Some(0));
@@ -1395,7 +1451,13 @@ mod tests {
 
         // Create a buffer first to verify textures share the same index namespace
         let _buffer = backend
-            .create_buffer(device, 64, DataAccess::Broadcast, None)
+            .create_buffer(
+                device,
+                64,
+                DataAccess::Broadcast,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         let texture1 = backend
@@ -1447,7 +1509,13 @@ mod tests {
 
         // Create resources in interleaved order to verify shared namespace
         let buffer1 = backend
-            .create_buffer(device, 64, DataAccess::Broadcast, None)
+            .create_buffer(
+                device,
+                64,
+                DataAccess::Broadcast,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
         let texture1 = backend
             .create_texture(
@@ -1463,7 +1531,13 @@ mod tests {
             .create_sampler(device, &SamplerDesc::default())
             .unwrap();
         let buffer2 = backend
-            .create_buffer(device, 128, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                128,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         // All resources share a single incrementing index
@@ -1492,10 +1566,22 @@ mod tests {
             .unwrap();
 
         let buffer1 = backend
-            .create_buffer(device, 64, DataAccess::Broadcast, None)
+            .create_buffer(
+                device,
+                64,
+                DataAccess::Broadcast,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
         let buffer2 = backend
-            .create_buffer(device, 128, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                128,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         // Record render commands with push constants (bindless path)
@@ -1558,10 +1644,22 @@ mod tests {
         let device = backend.create_device(0).unwrap();
 
         let buffer1 = backend
-            .create_buffer(device, 64, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                64,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
         let buffer2 = backend
-            .create_buffer(device, 128, DataAccess::Scattered, None)
+            .create_buffer(
+                device,
+                128,
+                DataAccess::Scattered,
+                None,
+                BufferFlags::empty(),
+            )
             .unwrap();
 
         // Record compute commands with push constants (bindless path)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -34,9 +34,9 @@ pub mod mock;
 pub mod metal;
 
 use crate::types::{
-    BackendType, BindlessHandle, Color, DataAccess, DepthFormat, DepthStencilState, DeviceType,
-    IndexFormat, PresentMode, PrimitiveTopology, SamplerDesc, SpatialAccess, TextureFlags,
-    TextureFormat, VertexBufferLayout,
+    BackendType, BindlessHandle, BufferFlags, Color, DataAccess, DepthFormat, DepthStencilState,
+    DeviceType, IndexFormat, PresentMode, PrimitiveTopology, SamplerDesc, SpatialAccess,
+    TextureFlags, TextureFormat, VertexBufferLayout,
 };
 use anyhow::Result;
 
@@ -317,6 +317,7 @@ pub trait GpuBackend: Send + Sync {
         size: u64,
         access: DataAccess,
         element_stride: Option<u32>,
+        flags: BufferFlags,
     ) -> Result<BufferHandle>;
     fn destroy_buffer(&mut self, buffer: BufferHandle);
     fn write_buffer(&mut self, buffer: BufferHandle, offset: u64, data: &[u8]) -> Result<()>;
@@ -327,6 +328,27 @@ pub trait GpuBackend: Send + Sync {
         buffer: BufferHandle,
         output: &mut [u8],
     ) -> Result<()>;
+    /// Copy bytes from a buffer created with [`BufferFlags::CPU_COHERENT`] into `output`
+    /// without a staging readback. Caller must have completed GPU work that wrote the buffer;
+    /// on Direct3D 12, call [`Self::copy_to_coherent_readback`] first after that work.
+    fn read_buffer_coherent(
+        &self,
+        buffer: BufferHandle,
+        offset: u64,
+        output: &mut [u8],
+    ) -> Result<()> {
+        let _ = (buffer, offset, output);
+        anyhow::bail!("read_buffer_coherent: buffer is not CPU_COHERENT or not supported")
+    }
+    /// Direct3D 12 only: copy GPU-visible storage (UAV) contents into the persistently mapped
+    /// readback buffer. No-op on other backends. Call after the submit that produced the data.
+    fn copy_to_coherent_readback(
+        &mut self,
+        _device: DeviceHandle,
+        _buffer: BufferHandle,
+    ) -> Result<()> {
+        Ok(())
+    }
     /// Fill buffer region with zeros. If size is 0, clears from offset to end of buffer.
     fn clear_buffer(
         &mut self,

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -4,7 +4,7 @@ use super::types::{self, BufferState};
 use super::utils::find_memory_type;
 use super::{BufferHandle, DeviceHandle};
 use crate::backend::DataAccess;
-use crate::types::{BindlessCategory, BindlessHandle};
+use crate::types::{BindlessCategory, BindlessHandle, BufferFlags};
 use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
@@ -77,6 +77,7 @@ pub(super) fn create(
     size: u64,
     access: DataAccess,
     element_stride: Option<u32>,
+    flags: BufferFlags,
 ) -> Result<BufferHandle> {
     let logical_device = devices
         .get(&device_handle)
@@ -101,6 +102,13 @@ pub(super) fn create(
         }
     };
 
+    let cpu_coherent = flags.contains(BufferFlags::CPU_COHERENT);
+    if cpu_coherent && !is_storage {
+        anyhow::bail!(
+            "BufferFlags::CPU_COHERENT is only valid for DataAccess::Scattered (storage) buffers"
+        );
+    }
+
     let bindless_descriptor_set = logical_device.bindless_descriptor_set;
 
     let buffer_info = vk::BufferCreateInfo::default()
@@ -113,10 +121,15 @@ pub(super) fn create(
 
     let mem_requirements = unsafe { logical_device.device.get_buffer_memory_requirements(buffer) };
 
-    // Storage buffers → DEVICE_LOCAL for GPU compute performance.
+    // Storage buffers → DEVICE_LOCAL for GPU compute performance, unless CPU_COHERENT
+    // (host-visible storage for persistent map + stable UAV bindless use).
     // Uniform buffers → HOST_VISIBLE|HOST_COHERENT for frequent CPU writes.
     let desired_flags = if is_storage {
-        vk::MemoryPropertyFlags::DEVICE_LOCAL
+        if cpu_coherent {
+            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT
+        } else {
+            vk::MemoryPropertyFlags::DEVICE_LOCAL
+        }
     } else {
         vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT
     };
@@ -143,6 +156,21 @@ pub(super) fn create(
     // for buffers that are only GPU-written (intermediate compute buffers, pool backing).
     // Clear uses vkCmdFillBuffer (GPU-side) so staging isn't needed for that.
     let (staging_buffer, staging_memory) = (None, None);
+
+    let host_mapped: Option<usize> = if cpu_coherent && is_storage {
+        let device = devices
+            .get(&device_handle)
+            .context("Buffer's device is invalid for host map")?;
+        let ptr = unsafe { device.map_memory2(memory, 0, size) }
+            .context("Failed to map CPU_COHERENT buffer memory")?;
+        let p = ptr as *mut u8;
+        if p.is_null() {
+            anyhow::bail!("map_memory2 returned null for CPU_COHERENT buffer");
+        }
+        Some(p as usize)
+    } else {
+        None
+    };
 
     let handle = *next_buffer_handle;
     *next_buffer_handle += 1;
@@ -210,6 +238,8 @@ pub(super) fn create(
             staging_buffer,
             staging_memory,
             is_view: false,
+            host_mapped,
+            flags,
         },
     );
 
@@ -230,6 +260,14 @@ pub(super) fn destroy(
             device.resource_registry.unregister_buffer(buffer_handle);
 
             if !buffer.is_view {
+                if buffer.host_mapped.is_some() {
+                    if let Err(e) = unsafe { device.unmap_memory2(buffer.memory) } {
+                        tracing::warn!(
+                            ?e,
+                            "unmap_memory2 failed for CPU_COHERENT buffer on destroy"
+                        );
+                    }
+                }
                 // Queue for deferred deletion - the buffer may still be in use by in-flight commands
                 device.deletion_queue.queue(types::PendingDeletion::Buffer {
                     buffer: buffer.buffer,
@@ -275,6 +313,7 @@ pub(super) fn create_view(
     let device_handle = parent.device_handle;
     let vk_buffer = parent.buffer;
     let is_storage = parent.is_storage;
+    let parent_flags = parent.flags;
 
     let logical_device = devices
         .get_mut(&device_handle)
@@ -336,6 +375,8 @@ pub(super) fn create_view(
             staging_buffer: None,
             staging_memory: None,
             is_view: true,
+            host_mapped: None,
+            flags: parent_flags,
         },
     );
 
@@ -352,7 +393,10 @@ pub(super) fn ensure_staging(
     let buffer = buffers
         .get(&buffer_handle)
         .context("Invalid buffer handle")?;
-    if !buffer.is_storage || buffer.staging_buffer.is_some() {
+    if !buffer.is_storage
+        || buffer.staging_buffer.is_some()
+        || buffer.flags.contains(BufferFlags::CPU_COHERENT)
+    {
         return Ok(());
     }
     let size = buffer.size;
@@ -416,6 +460,19 @@ pub(super) fn write(
         }
     }
 
+    {
+        let buffer = buffers
+            .get(&buffer_handle)
+            .context("Invalid buffer handle")?;
+        if let Some(base) = buffer.host_mapped {
+            let p = base as *mut u8;
+            unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), p.add(offset as usize), data.len());
+            }
+            return Ok(());
+        }
+    }
+
     // Lazily create staging buffer for storage buffers
     ensure_staging(instance, devices, buffers, buffer_handle)?;
 
@@ -460,6 +517,36 @@ pub(super) fn write(
         }
     }
 
+    Ok(())
+}
+
+/// Copy from a `CPU_COHERENT` host mapping (no staging, no map/unmap per call).
+pub(super) fn read_coherent(
+    buffers: &HashMap<BufferHandle, BufferState>,
+    buffer_handle: BufferHandle,
+    offset: u64,
+    output: &mut [u8],
+) -> Result<()> {
+    let buffer = buffers
+        .get(&buffer_handle)
+        .context("Invalid buffer handle")?;
+    if !buffer.flags.contains(BufferFlags::CPU_COHERENT) {
+        anyhow::bail!("read_buffer_coherent requires BufferFlags::CPU_COHERENT");
+    }
+    let Some(base) = buffer.host_mapped else {
+        anyhow::bail!("CPU_COHERENT buffer has no host mapping");
+    };
+    if offset + output.len() as u64 > buffer.size {
+        anyhow::bail!("read_coherent would exceed buffer bounds");
+    }
+    let p = base as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            p.add(offset as usize) as *const u8,
+            output.as_mut_ptr(),
+            output.len(),
+        );
+    }
     Ok(())
 }
 
@@ -515,6 +602,26 @@ pub(super) fn read_to_cpu(
     buffer_handle: BufferHandle,
     output: &mut [u8],
 ) -> Result<()> {
+    {
+        let buffer = buffers
+            .get(&buffer_handle)
+            .context("Invalid buffer handle")?;
+        if buffer.device_handle != device_handle {
+            anyhow::bail!("Buffer belongs to different device");
+        }
+        let len = output.len() as u64;
+        if len > buffer.size {
+            anyhow::bail!("Read would exceed buffer bounds");
+        }
+        if let Some(base) = buffer.host_mapped {
+            let p = base as *const u8;
+            unsafe {
+                std::ptr::copy_nonoverlapping(p, output.as_mut_ptr(), output.len());
+            }
+            return Ok(());
+        }
+    }
+
     // Lazily create staging buffer for storage buffers
     ensure_staging(instance, devices, buffers, buffer_handle)?;
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -305,6 +305,7 @@ impl GpuBackend for VulkanBackend {
         size: u64,
         access: DataAccess,
         element_stride: Option<u32>,
+        flags: crate::types::BufferFlags,
     ) -> Result<BufferHandle> {
         buffer::create(
             &mut self.state.devices,
@@ -315,6 +316,7 @@ impl GpuBackend for VulkanBackend {
             size,
             access,
             element_stride,
+            flags,
         )
     }
 
@@ -387,6 +389,15 @@ impl GpuBackend for VulkanBackend {
             buffer_handle,
             output,
         )
+    }
+
+    fn read_buffer_coherent(
+        &self,
+        buffer_handle: BufferHandle,
+        offset: u64,
+        output: &mut [u8],
+    ) -> Result<()> {
+        buffer::read_coherent(&self.state.buffers, buffer_handle, offset, output)
     }
 
     fn clear_buffer(

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -393,6 +393,14 @@ pub(crate) struct BufferState {
     pub staging_memory: Option<vk::DeviceMemory>,
     /// If true, this is a view into another buffer — don't free the VkBuffer/memory on destroy.
     pub is_view: bool,
+    /// Set when the buffer was created with [`crate::types::BufferFlags::CPU_COHERENT`]:
+    /// persistent host mapping of the entire buffer for CPU read/write.
+    /// Opaque address of the persistent `map_memory2` region for `CPU_COHERENT` storage.
+    /// Stored as [`usize`] so `BufferState` is `Send`/`Sync` for `GpuBackend` (raw pointers and
+    /// `NonNull` are not in this environment).
+    pub host_mapped: Option<usize>,
+    /// Mirror of create-time flags.
+    pub flags: crate::types::BufferFlags,
 }
 
 /// Shader module state with cached compiled stages.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,7 +2,7 @@
 
 use crate::backend::{BufferHandle, GpuBackend};
 use crate::device::Device;
-use crate::types::{BindlessCategory, BindlessHandle, DataAccess};
+use crate::types::{BindlessCategory, BindlessHandle, BufferFlags, DataAccess};
 use anyhow::Result;
 use std::sync::{Arc, Mutex};
 
@@ -51,6 +51,7 @@ pub struct Buffer {
     pub(crate) handle: BufferHandle,
     size: u64,
     access: DataAccess,
+    flags: BufferFlags,
 }
 
 impl Buffer {
@@ -64,7 +65,7 @@ impl Buffer {
     /// - `DataAccess::Broadcast`: All threads read the same address.
     ///   Hardware optimizes for wave-wide broadcast (ConstantBuffer).
     pub fn new(device: &Device, size: u64, access: DataAccess) -> Result<Self> {
-        Self::new_with_stride(device, size, access, None)
+        Self::new_with_stride_and_flags(device, size, access, None, BufferFlags::empty())
     }
 
     pub fn new_with_stride(
@@ -73,15 +74,27 @@ impl Buffer {
         access: DataAccess,
         element_stride: Option<u32>,
     ) -> Result<Self> {
-        tracing::debug!(size, ?access, element_stride, "Creating buffer");
+        Self::new_with_stride_and_flags(device, size, access, element_stride, BufferFlags::empty())
+    }
+
+    /// Create a buffer with optional element stride and [`BufferFlags`].
+    pub fn new_with_stride_and_flags(
+        device: &Device,
+        size: u64,
+        access: DataAccess,
+        element_stride: Option<u32>,
+        flags: BufferFlags,
+    ) -> Result<Self> {
+        tracing::debug!(size, ?access, element_stride, ?flags, "Creating buffer");
         let mut backend = device.backend.lock().unwrap();
-        let handle = backend.create_buffer(device.handle, size, access, element_stride)?;
+        let handle = backend.create_buffer(device.handle, size, access, element_stride, flags)?;
 
         Ok(Self {
             backend: Arc::clone(&device.backend),
             handle,
             size,
             access,
+            flags,
         })
     }
 
@@ -102,6 +115,16 @@ impl Buffer {
         data: &[T],
         access: DataAccess,
     ) -> Result<Self> {
+        Self::with_data_and_flags(device, data, access, BufferFlags::empty())
+    }
+
+    /// Like [`Self::with_data`], with explicit [`BufferFlags`].
+    pub fn with_data_and_flags<T: StructuredBufferElement>(
+        device: &Device,
+        data: &[T],
+        access: DataAccess,
+        flags: BufferFlags,
+    ) -> Result<Self> {
         let bytes = bytemuck::cast_slice(data);
         let element_stride = std::mem::size_of::<T>() as u32;
         let mut backend = device.backend.lock().unwrap();
@@ -110,6 +133,7 @@ impl Buffer {
             bytes.len() as u64,
             access,
             Some(element_stride),
+            flags,
         )?;
         drop(backend);
 
@@ -118,6 +142,7 @@ impl Buffer {
             handle,
             size: bytes.len() as u64,
             access,
+            flags,
         };
         buffer.write(0, bytes)?;
         Ok(buffer)
@@ -131,7 +156,7 @@ impl Buffer {
     /// See [`Buffer::new`] for access pattern documentation.
     pub fn with_bytes(device: &Device, data: &[u8], access: DataAccess) -> Result<Self> {
         // For raw bytes, use stride of 1 (byte-addressable)
-        Self::with_bytes_stride(device, data, access, 1)
+        Self::with_bytes_stride_and_flags(device, data, access, 1, BufferFlags::empty())
     }
 
     /// Create a buffer initialized with raw bytes and a custom element stride.
@@ -147,12 +172,30 @@ impl Buffer {
         access: DataAccess,
         element_stride: u32,
     ) -> Result<Self> {
+        Self::with_bytes_stride_and_flags(
+            device,
+            data,
+            access,
+            element_stride,
+            BufferFlags::empty(),
+        )
+    }
+
+    /// Like [`Self::with_bytes_stride`], with explicit [`BufferFlags`].
+    pub fn with_bytes_stride_and_flags(
+        device: &Device,
+        data: &[u8],
+        access: DataAccess,
+        element_stride: u32,
+        flags: BufferFlags,
+    ) -> Result<Self> {
         let mut backend = device.backend.lock().unwrap();
         let handle = backend.create_buffer(
             device.handle,
             data.len() as u64,
             access,
             Some(element_stride),
+            flags,
         )?;
         drop(backend);
 
@@ -161,6 +204,7 @@ impl Buffer {
             handle,
             size: data.len() as u64,
             access,
+            flags,
         };
         buffer.write(0, data)?;
         Ok(buffer)
@@ -188,6 +232,11 @@ impl Buffer {
     /// Get the buffer's access pattern.
     pub fn access(&self) -> DataAccess {
         self.access
+    }
+
+    /// Creation flags (e.g. [`BufferFlags::CPU_COHERENT`]).
+    pub fn flags(&self) -> BufferFlags {
+        self.flags
     }
 
     /// Get the buffer's index in the global bindless descriptor set.
@@ -245,6 +294,14 @@ impl Buffer {
     pub fn read_to_cpu(&self, device: &Device, output: &mut [u8]) -> Result<()> {
         let mut backend = self.backend.lock().unwrap();
         backend.read_buffer_to_cpu(device.handle, self.handle, output)
+    }
+
+    /// Read from a [`BufferFlags::CPU_COHERENT`] buffer without staging. On Direct3D 12, call
+    /// [`Device::copy_to_coherent_readback`](crate::Device::copy_to_coherent_readback) after
+    /// the GPU work that produced the data.
+    pub fn read_coherent(&self, offset: u64, output: &mut [u8]) -> Result<()> {
+        let backend = self.backend.lock().unwrap();
+        backend.read_buffer_coherent(self.handle, offset, output)
     }
 
     /// Clear the buffer (fill with zeros) from offset for size bytes.

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,7 +7,7 @@
 //! - **Command Recording**: [`CommandEncoder`](crate::CommandEncoder) is completely lock-free.
 //!   You can create and record commands on any thread without any synchronization.
 //!   
-//! - **Resource Creation**: Creating resources ([`Buffer`](crate::Buffer),
+//! - **Resource Creation**: Creating resources ([`Buffer`],
 //!   [`RenderPipeline`](crate::RenderPipeline), etc.) acquires the backend lock.
 //!   These operations are safe from any thread but serialize internally.
 //!
@@ -25,6 +25,7 @@
 //! multi-queue support for parallel command submission if needed.
 
 use crate::backend::{self, AdapterInfo, DeviceHandle, GpuBackend};
+use crate::buffer::Buffer;
 use crate::shader_library::ShaderLibrary;
 use crate::slang::{ShaderTarget, SlangCompiler, StructLayout};
 use crate::types::*;
@@ -380,6 +381,14 @@ impl Device {
     /// Check if the device is still valid.
     pub fn is_valid(&self) -> bool {
         self.backend.lock().unwrap().is_device_valid(self.handle)
+    }
+
+    /// Direct3D 12: after GPU work writes a [`Buffer`] created with [`BufferFlags::CPU_COHERENT`],
+    /// copies from the UAV resource into the persistently mapped readback buffer so
+    /// [`Buffer::read_coherent`] sees the data. No-op on Vulkan and Metal.
+    pub fn copy_to_coherent_readback(&self, buffer: &Buffer) -> Result<()> {
+        let mut backend = self.backend.lock().unwrap();
+        backend.copy_to_coherent_readback(self.handle, buffer.handle)
     }
 
     /// Get device capabilities and format preferences.

--- a/src/types.rs
+++ b/src/types.rs
@@ -299,13 +299,15 @@ pub enum SpatialAccess {
 }
 
 bitflags! {
-    /// Additional buffer flags for copy operations.
+    /// Additional buffer flags for copy operations and CPU readback.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct BufferFlags: u32 {
         /// Can be used as a copy source.
         const COPY_SRC = 1 << 0;
         /// Can be used as a copy destination.
         const COPY_DST = 1 << 1;
+        /// Can be read by the CPU.
+        const CPU_COHERENT = 1 << 2;
     }
 }
 

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use goldy::{
-    types::{SpatialAccess, TextureFlags, TextureFormat},
+    types::{BufferFlags, SpatialAccess, TextureFlags, TextureFormat},
     Buffer, BufferPool, ComputeEncoder, ComputePipeline, DataAccess, DeviceType, Instance,
     ShaderModule, Texture,
 };
@@ -1232,4 +1232,124 @@ void cs_main(uint3 id : SV_DispatchThreadID) {
     assert_eq!(output[1], 0, "G channel should be 0");
     assert_eq!(output[2], 0, "B channel should be 0");
     assert_eq!(output[3], 255, "A channel should be 255");
+}
+
+// ─── CPU_COHERENT buffer tests ────────────────────────────────────────────────
+
+/// A compute shader that doubles each element (same as `DOUBLE_SHADER`). Used by the
+/// coherent tests to avoid a dependency on the module-level constant's exact binding layout.
+const DOUBLE_SHADER_COHERENT: &str = r#"
+import goldy_exp;
+
+#define DATA goldy_dyn_scattered<uint>(0)
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void cs_main(uint3 id : SV_DispatchThreadID) {
+    DATA[id.x] = DATA[id.x] * 2;
+}
+"#;
+
+/// Create a `CPU_COHERENT` storage buffer, run a GPU compute pass that doubles every
+/// element, then read back via `Buffer::read_coherent`.
+///
+/// `read_coherent` performs a pure `memcpy` from the persistent host mapping — no
+/// fence wait, no staging copy on Vulkan/Metal. On DX12 `Device::copy_to_coherent_readback`
+/// is called first to sync the READBACK heap (the test calls it explicitly so the
+/// low-level path is exercised).
+#[test]
+fn test_cpu_coherent_compute_write_and_read() {
+    let device = make_device();
+
+    let shader = ShaderModule::from_slang(&device, DOUBLE_SHADER_COHERENT).expect("compile shader");
+    let pipeline = ComputePipeline::new(&device, &shader).expect("create pipeline");
+
+    const N: usize = 64;
+    let initial: Vec<u32> = (0..N as u32).collect();
+
+    let buffer = Buffer::with_bytes_stride_and_flags(
+        &device,
+        bytemuck::cast_slice(&initial),
+        DataAccess::Scattered,
+        size_of::<u32>() as u32,
+        BufferFlags::CPU_COHERENT,
+    )
+    .expect("create CPU_COHERENT buffer");
+
+    let mut encoder = ComputeEncoder::new();
+    {
+        let mut pass = encoder.begin_compute_pass();
+        pass.set_pipeline(&pipeline);
+        pass.set_push_constants(&[&buffer]);
+        pass.dispatch(1, 1, 1);
+    }
+    encoder.dispatch(&device).expect("dispatch");
+
+    // On DX12 the backend writes to a DEFAULT-heap UAV and must copy to the
+    // persistent READBACK heap so the host mapping reflects current GPU contents.
+    device
+        .copy_to_coherent_readback(&buffer)
+        .expect("copy_to_coherent_readback");
+
+    let mut out = vec![0u8; N * size_of::<u32>()];
+    buffer.read_coherent(0, &mut out).expect("read_coherent");
+
+    let result: &[u32] = bytemuck::cast_slice(&out);
+    for (i, &val) in result.iter().enumerate() {
+        assert_eq!(
+            val,
+            (i as u32) * 2,
+            "element {i}: expected {} got {val}",
+            i * 2
+        );
+    }
+}
+
+/// `read_coherent` reflects CPU writes made directly to the persistent mapping.
+///
+/// On Vulkan and Metal the buffer lives in host-visible/shared memory, so a plain
+/// `buffer.write()` followed immediately by `buffer.read_coherent()` must round-trip
+/// without any GPU involvement. This validates the zero-copy read path.
+///
+/// On DX12 the primary resource is a DEFAULT-heap UAV (not host-visible), so this
+/// test skips the coherent-read assertion on DX12 and only checks that creation and
+/// `copy_to_coherent_readback` do not panic.
+#[test]
+fn test_cpu_coherent_cpu_write_read_roundtrip() {
+    let device = make_device();
+
+    const N: usize = 16;
+    let initial: Vec<u32> = vec![0xABCD_1234u32; N];
+
+    let buffer = Buffer::with_bytes_stride_and_flags(
+        &device,
+        bytemuck::cast_slice(&initial),
+        DataAccess::Scattered,
+        size_of::<u32>() as u32,
+        BufferFlags::CPU_COHERENT,
+    )
+    .expect("create CPU_COHERENT buffer");
+
+    let new_values: Vec<u32> = (100..100 + N as u32).collect();
+    buffer
+        .write(0, bytemuck::cast_slice(&new_values))
+        .expect("write");
+
+    // Ensure the readback path at least completes without error (required for DX12 parity).
+    device
+        .copy_to_coherent_readback(&buffer)
+        .expect("copy_to_coherent_readback");
+
+    let mut out = vec![0u8; N * size_of::<u32>()];
+    buffer.read_coherent(0, &mut out).expect("read_coherent");
+
+    let result: &[u32] = bytemuck::cast_slice(&out);
+    for (i, &val) in result.iter().enumerate() {
+        assert_eq!(
+            val,
+            100 + i as u32,
+            "element {i}: expected {} got {val}",
+            100 + i
+        );
+    }
 }


### PR DESCRIPTION
- Introduced `BufferFlags::CPU_COHERENT` to enable direct CPU access to buffer data without staging.
- Updated buffer creation methods to accept flags, ensuring compatibility with the new coherent readback feature.
- Enhanced Vulkan, DX12, and Metal backends to support coherent read operations, allowing for zero-copy reads from CPU-mapped buffers.
- Added tests to validate the functionality of CPU_COHERENT buffers, ensuring correct behavior during GPU compute operations and direct CPU writes.