### PR TITLE
Add Cursor Cloud development environment instructions to AGENTS.md

### DIFF
--- a/.cursor/cloud-agent.md
+++ b/.cursor/cloud-agent.md
@@ -1,0 +1,42 @@
+# Cursor Cloud Agent Instructions
+
+## Environment variables required for building and testing
+
+All `cargo build`, `cargo test`, `cargo clippy`, and `cargo run` commands that touch the main `goldy` crate need these env vars:
+
+```bash
+export GOLDY_SLANG_PATH=/workspace/slang/bin/linux-x86_64/libslang.so
+export LD_LIBRARY_PATH=/workspace/slang/bin/linux-x86_64
+export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json
+export VK_LAYER_PATH=""
+export CXX=g++-13
+```
+
+- `GOLDY_SLANG_PATH` — full path to the Slang `.so`; used by `build.rs` and at runtime.
+- `LD_LIBRARY_PATH` — directory containing Slang shared libraries (needed at runtime).
+- `VK_ICD_FILENAMES` — forces lavapipe (Mesa software Vulkan) as the only ICD; required since there is no hardware GPU.
+- `VK_LAYER_PATH=""` — disables Vulkan validation layers for CI.
+- `CXX=g++-13` — the `nv-flip-sys` dev-dependency requires C++ compilation; default `c++` (clang) can't find libstdc++ headers without this override.
+
+## Running CI checks
+
+Per the Development section in [AGENTS.md](../AGENTS.md), plus `--features vulkan` for the test step on Linux:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --no-default-features -- -D warnings
+cargo clippy -- -D warnings
+cargo test --features vulkan
+```
+
+## Headless GPU rendering
+
+The Cloud VM has no physical GPU. **Lavapipe** (Mesa's Vulkan 1.4 software renderer) provides the Vulkan backend. All unit tests, integration tests, and screenshot tests pass headlessly.
+
+Interactive examples (Surface API / `winit`) require Wayland and will not work under Xvfb (X11 only). To test rendering output headlessly, use:
+
+```bash
+cargo run --bin update-screenshots --features update-screenshots
+```
+
+This renders triangles, Game of Life, and depth-occlusion scenes to PNG files in `tests/screenshots/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,43 +25,4 @@ For conditional compilation, see [Conditional Compilation](docs/src/architecture
 
 ## Cursor Cloud specific instructions
 
-### Environment variables required for building and testing
-
-All `cargo build`, `cargo test`, `cargo clippy`, and `cargo run` commands that touch the main `goldy` crate need these env vars:
-
-```bash
-export GOLDY_SLANG_PATH=/workspace/slang/bin/linux-x86_64/libslang.so
-export LD_LIBRARY_PATH=/workspace/slang/bin/linux-x86_64
-export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json
-export VK_LAYER_PATH=""
-export CXX=g++-13
-```
-
-- `GOLDY_SLANG_PATH` — full path to the Slang `.so`; used by `build.rs` and at runtime.
-- `LD_LIBRARY_PATH` — directory containing Slang shared libraries (needed at runtime).
-- `VK_ICD_FILENAMES` — forces lavapipe (Mesa software Vulkan) as the only ICD; required since there is no hardware GPU.
-- `VK_LAYER_PATH=""` — disables Vulkan validation layers for CI.
-- `CXX=g++-13` — the `nv-flip-sys` dev-dependency requires C++ compilation; default `c++` (clang) can't find libstdc++ headers without this override.
-
-### Running CI checks
-
-Per the Development section above, plus `--features vulkan` for the test step on Linux:
-
-```bash
-cargo fmt --all -- --check
-cargo clippy --no-default-features -- -D warnings
-cargo clippy -- -D warnings
-cargo test --features vulkan
-```
-
-### Headless GPU rendering
-
-The Cloud VM has no physical GPU. **Lavapipe** (Mesa's Vulkan 1.4 software renderer) provides the Vulkan backend. All unit tests, integration tests, and screenshot tests pass headlessly.
-
-Interactive examples (Surface API / `winit`) require Wayland and will not work under Xvfb (X11 only). To test rendering output headlessly, use:
-
-```bash
-cargo run --bin update-screenshots --features update-screenshots
-```
-
-This renders triangles, Game of Life, and depth-occlusion scenes to PNG files in `tests/screenshots/`.
+See [.cursor/cloud-agent.md](.cursor/cloud-agent.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,46 @@ For debugging tips, see [DEBUGGING.md](DEBUGGING.md).
 For backend selection, see [Backend Architecture](docs/src/architecture/backends.md).
 
 For conditional compilation, see [Conditional Compilation](docs/src/architecture/conditional-compilation.md).
+
+## Cursor Cloud specific instructions
+
+### Environment variables required for building and testing
+
+All `cargo build`, `cargo test`, `cargo clippy`, and `cargo run` commands that touch the main `goldy` crate need these env vars:
+
+```bash
+export GOLDY_SLANG_PATH=/workspace/slang/bin/linux-x86_64/libslang.so
+export LD_LIBRARY_PATH=/workspace/slang/bin/linux-x86_64
+export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json
+export VK_LAYER_PATH=""
+export CXX=g++-13
+```
+
+- `GOLDY_SLANG_PATH` — full path to the Slang `.so`; used by `build.rs` and at runtime.
+- `LD_LIBRARY_PATH` — directory containing Slang shared libraries (needed at runtime).
+- `VK_ICD_FILENAMES` — forces lavapipe (Mesa software Vulkan) as the only ICD; required since there is no hardware GPU.
+- `VK_LAYER_PATH=""` — disables Vulkan validation layers for CI.
+- `CXX=g++-13` — the `nv-flip-sys` dev-dependency requires C++ compilation; default `c++` (clang) can't find libstdc++ headers without this override.
+
+### Running CI checks
+
+Per the Development section above, plus `--features vulkan` for the test step on Linux:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --no-default-features -- -D warnings
+cargo clippy -- -D warnings
+cargo test --features vulkan
+```
+
+### Headless GPU rendering
+
+The Cloud VM has no physical GPU. **Lavapipe** (Mesa's Vulkan 1.4 software renderer) provides the Vulkan backend. All unit tests, integration tests, and screenshot tests pass headlessly.
+
+Interactive examples (Surface API / `winit`) require Wayland and will not work under Xvfb (X11 only). To test rendering output headlessly, use:
+
+```bash
+cargo run --bin update-screenshots --features update-screenshots
+```
+
+This renders triangles, Game of Life, and depth-occlusion scenes to PNG files in `tests/screenshots/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with:

- Required environment variables for building and testing (`GOLDY_SLANG_PATH`, `LD_LIBRARY_PATH`, `VK_ICD_FILENAMES`, `VK_LAYER_PATH`, `CXX`)
- CI check commands (fmt, clippy, test with vulkan feature)
- Headless GPU rendering notes (lavapipe, surface API limitations, screenshot generation)

### Environment verified

All CI checks pass on Cloud VM with lavapipe (Mesa software Vulkan 1.4):

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy -- -D warnings`
- `cargo test --features vulkan` — 57 lib tests, 29 compute integration tests, 11 render target integration tests, 9 screenshot tests, 17 doc-tests all pass

### GPU rendering output

Headless rendering via lavapipe produces correct output:

[RGB triangle rendered headlessly via lavapipe](https://cursor.com/agents/bc-db1bf2c3-e05d-4e29-b0a8-a457ca1a259e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frgb_triangle_rendered.png)
[Game of Life (100 steps) rendered headlessly](https://cursor.com/agents/bc-db1bf2c3-e05d-4e29-b0a8-a457ca1a259e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_of_life_rendered.png)
[Depth occlusion test rendered headlessly](https://cursor.com/agents/bc-db1bf2c3-e05d-4e29-b0a8-a457ca1a259e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdepth_occlusion_rendered.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db1bf2c3-e05d-4e29-b0a8-a457ca1a259e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db1bf2c3-e05d-4e29-b0a8-a457ca1a259e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

