### PR TITLE
Fix device lifetime issue (#122)

### DIFF
--- a/examples/compute_to_surface.rs
+++ b/examples/compute_to_surface.rs
@@ -96,12 +96,6 @@ struct App {
 
 struct RenderState {
     window: Arc<Window>,
-    // TODO(#122): resources (Buffer, Surface, ComputePipeline) should hold Arc<Device> internally
-    // so the Device cannot be destroyed while any of its resources are still alive. Until that
-    // refactor lands, callers must keep an explicit Arc<Device> alive for the lifetime of all GPU
-    // resources created from it. See https://github.com/koubaa/goldy/issues/122
-    #[allow(dead_code)]
-    device: Arc<goldy::Device>,
     surface: Surface,
     compute_pipeline: ComputePipeline,
     uniform_buffer: Buffer,
@@ -147,7 +141,6 @@ impl App {
 
         self.state = Some(RenderState {
             window,
-            device,
             surface,
             compute_pipeline,
             uniform_buffer,

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -385,6 +385,9 @@ pub(super) fn destroy(
     if let Some(pipeline) = pipelines.remove(&pipeline_handle) {
         if let Some(device) = devices.get(&pipeline.device_handle) {
             unsafe {
+                // Wait for all in-flight work to finish before freeing a pipeline
+                // that may still be referenced by an in-flight command buffer.
+                device.device.device_wait_idle().ok();
                 if pipeline.pipeline != vk::Pipeline::null() {
                     device.device.destroy_pipeline(pipeline.pipeline, None);
                 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -47,6 +47,7 @@ impl<T: StructuredBufferElement, const N: usize> StructuredBufferElement for [T;
 
 /// A GPU buffer.
 pub struct Buffer {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: BufferHandle,
     size: u64,
@@ -91,11 +92,13 @@ impl Buffer {
         flags: BufferFlags,
     ) -> Result<Self> {
         tracing::debug!(size, ?access, element_stride, ?flags, "Creating buffer");
-        let mut backend = device.backend.lock().unwrap();
-        let handle = backend.create_buffer(device.handle, size, access, element_stride, flags)?;
+        let mut backend = device.inner.backend.lock().unwrap();
+        let handle =
+            backend.create_buffer(device.inner.handle, size, access, element_stride, flags)?;
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
             size,
             access,
@@ -132,9 +135,9 @@ impl Buffer {
     ) -> Result<Self> {
         let bytes = bytemuck::cast_slice(data);
         let element_stride = std::mem::size_of::<T>() as u32;
-        let mut backend = device.backend.lock().unwrap();
+        let mut backend = device.inner.backend.lock().unwrap();
         let handle = backend.create_buffer(
-            device.handle,
+            device.inner.handle,
             bytes.len() as u64,
             access,
             Some(element_stride),
@@ -143,7 +146,8 @@ impl Buffer {
         drop(backend);
 
         let buffer = Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
             size: bytes.len() as u64,
             access,
@@ -194,9 +198,9 @@ impl Buffer {
         element_stride: u32,
         flags: BufferFlags,
     ) -> Result<Self> {
-        let mut backend = device.backend.lock().unwrap();
+        let mut backend = device.inner.backend.lock().unwrap();
         let handle = backend.create_buffer(
-            device.handle,
+            device.inner.handle,
             data.len() as u64,
             access,
             Some(element_stride),
@@ -205,7 +209,8 @@ impl Buffer {
         drop(backend);
 
         let buffer = Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
             size: data.len() as u64,
             access,
@@ -300,13 +305,13 @@ impl Buffer {
     /// GPU copy into a READBACK heap and waits — query capabilities to branch on behavior.
     pub fn read_to_cpu(&self, device: &Device, output: &mut [u8]) -> Result<()> {
         let mut backend = self.backend.lock().unwrap();
-        backend.read_buffer_to_cpu(device.handle, self.handle, output)
+        backend.read_buffer_to_cpu(device.inner.handle, self.handle, output)
     }
 
     /// Clear the buffer (fill with zeros) from offset for size bytes.
     pub fn clear(&self, device: &Device, offset: u64, size: u64) -> Result<()> {
         let mut backend = self.backend.lock().unwrap();
-        backend.clear_buffer(device.handle, self.handle, offset, size)
+        backend.clear_buffer(device.inner.handle, self.handle, offset, size)
     }
 
     /// Create a view into a sub-region of this buffer.
@@ -326,6 +331,7 @@ impl Buffer {
         let mut backend = self.backend.lock().unwrap();
         let handle = backend.create_buffer_view(self.handle, offset, size, element_stride)?;
         Ok(BufferView {
+            _device: self._device.clone(),
             backend: Arc::clone(&self.backend),
             handle,
             parent_handle: self.handle,
@@ -390,6 +396,7 @@ impl BufferSource for Buffer {
 ///
 /// Dropping a `BufferView` unregisters its descriptor but does not free the parent's memory.
 pub struct BufferView {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: BufferHandle,
     parent_handle: BufferHandle,
@@ -462,7 +469,7 @@ impl BufferView {
         }
         let mut backend = self.backend.lock().unwrap();
         backend.clear_buffer(
-            device.handle,
+            device.inner.handle,
             self.parent_handle,
             self.offset + offset,
             clear_size,
@@ -487,7 +494,7 @@ impl BufferView {
         let mut backend = self.backend.lock().unwrap();
         let parent_size = backend.buffer_size(self.parent_handle);
         let mut full = vec![0u8; parent_size as usize];
-        backend.read_buffer_to_cpu(device.handle, self.parent_handle, &mut full)?;
+        backend.read_buffer_to_cpu(device.inner.handle, self.parent_handle, &mut full)?;
         output.copy_from_slice(
             &full[self.offset as usize..self.offset as usize + self.size as usize],
         );

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -35,6 +35,7 @@ use std::sync::{Arc, Mutex};
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 pub struct ComputePipeline {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: ComputePipelineHandle,
 }
@@ -43,14 +44,15 @@ impl ComputePipeline {
     /// Create a new compute pipeline.
     pub fn new(device: &Device, compute_shader: &ShaderModule) -> Result<Self> {
         tracing::debug!("Creating compute pipeline");
-        let mut backend = device.backend.lock().unwrap();
+        let mut backend = device.inner.backend.lock().unwrap();
 
-        let handle = backend.create_compute_pipeline(device.handle, compute_shader.handle)?;
+        let handle = backend.create_compute_pipeline(device.inner.handle, compute_shader.handle)?;
 
         tracing::debug!("Compute pipeline created");
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
         })
     }
@@ -117,16 +119,16 @@ impl ComputeEncoder {
             command_count = self.commands.len(),
             "Dispatching compute commands"
         );
-        let mut backend = device.backend.lock().unwrap();
-        backend.dispatch_compute(device.handle, &self.commands)
+        let mut backend = device.inner.backend.lock().unwrap();
+        backend.dispatch_compute(device.inner.handle, &self.commands)
     }
 
     /// Submit the recorded compute commands without blocking.
     ///
     /// Returns the device timeline value for use with [`Device::gpu_progress`] / [`Device::wait_until`].
     pub fn submit(&self, device: &Device) -> Result<crate::timeline::TimelineValue> {
-        let mut backend = device.backend.lock().unwrap();
-        backend.submit_standalone(device.handle, &self.commands)
+        let mut backend = device.inner.backend.lock().unwrap();
+        backend.submit_standalone(device.inner.handle, &self.commands)
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -145,11 +145,13 @@ impl Instance {
         tracing::info!(adapter_id, ?device_type, "GPU device created");
 
         Ok(Device {
-            backend: Arc::clone(&self.backend),
-            handle,
-            adapter_id,
-            device_type,
-            library_registry: Arc::new(Mutex::new(registry)),
+            inner: Arc::new(DeviceInner {
+                backend: Arc::clone(&self.backend),
+                handle,
+                adapter_id,
+                device_type,
+                library_registry: Arc::new(Mutex::new(registry)),
+            }),
         })
     }
 
@@ -238,8 +240,10 @@ impl Default for DeviceCapabilities {
 
 /// A GPU device - used to create resources and render.
 ///
-/// The `Device` is the primary interface for GPU operations. It is `Send + Sync`,
-/// so it can be safely shared across threads (typically via `Arc<Device>`).
+/// `Device` is a lightweight, cloneable handle (internally reference-counted).
+/// Cloning a `Device` is cheap (`Arc` bump) and gives you another handle to the
+/// same underlying GPU device. The physical device is only torn down once every
+/// `Device` handle **and** every resource created from it have been dropped.
 ///
 /// # Thread Safety
 ///
@@ -266,12 +270,23 @@ impl Default for DeviceCapabilities {
 /// assert!(device.has_library("goldy"));
 /// ```
 pub struct Device {
+    pub(crate) inner: Arc<DeviceInner>,
+}
+
+pub(crate) struct DeviceInner {
     pub(crate) backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: DeviceHandle,
     adapter_id: u32,
     device_type: DeviceType,
-    /// Shader library registry
     library_registry: Arc<Mutex<ShaderLibraryRegistry>>,
+}
+
+impl Clone for Device {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 /// Internal registry for shader libraries.
@@ -381,53 +396,57 @@ impl Drop for ShaderLibraryRegistry {
 impl Device {
     /// Get the adapter ID this device was created on.
     pub fn adapter_id(&self) -> u32 {
-        self.adapter_id
+        self.inner.adapter_id
     }
 
     /// Get the device type (discrete GPU, integrated GPU, CPU/software, etc.).
     pub fn device_type(&self) -> DeviceType {
-        self.device_type
+        self.inner.device_type
     }
 
     /// Graphics backend used by this device (Vulkan, Dx12, Metal, ...).
     pub fn backend_type(&self) -> BackendType {
-        self.backend.lock().unwrap().backend_type()
+        self.inner.backend.lock().unwrap().backend_type()
     }
 
     /// Check if the device is still valid.
     pub fn is_valid(&self) -> bool {
-        self.backend.lock().unwrap().is_device_valid(self.handle)
+        self.inner
+            .backend
+            .lock()
+            .unwrap()
+            .is_device_valid(self.inner.handle)
     }
 
     /// Latest GPU completion counter on this device's timeline (`wait_until(value)` is valid once
     /// `gpu_progress() >= value`).
     pub fn gpu_progress(&self) -> TimelineValue {
-        let backend = self.backend.lock().unwrap();
-        backend.gpu_progress(self.handle)
+        let backend = self.inner.backend.lock().unwrap();
+        backend.gpu_progress(self.inner.handle)
     }
 
     /// Block until the device timeline reaches at least `value`.
     pub fn wait_until(&self, value: TimelineValue) -> Result<()> {
-        let mut backend = self.backend.lock().unwrap();
-        backend.wait_until(self.handle, value)
+        let mut backend = self.inner.backend.lock().unwrap();
+        backend.wait_until(self.inner.handle, value)
     }
 
     /// Like [`wait_until`](Self::wait_until) but returns `Ok(false)` on timeout.
     pub fn wait_until_timeout(&self, value: TimelineValue, timeout_ms: u32) -> Result<bool> {
-        let mut backend = self.backend.lock().unwrap();
-        backend.wait_until_timeout(self.handle, value, timeout_ms)
+        let mut backend = self.inner.backend.lock().unwrap();
+        backend.wait_until_timeout(self.inner.handle, value, timeout_ms)
     }
 
     #[doc(hidden)]
     pub fn deferred_deletion_pending_count(&self) -> usize {
-        let backend = self.backend.lock().unwrap();
-        backend.deferred_deletion_pending_count(self.handle)
+        let backend = self.inner.backend.lock().unwrap();
+        backend.deferred_deletion_pending_count(self.inner.handle)
     }
 
     /// Submit a compiled [`TaskGraph`] on the device timeline (standalone / non-surface compute).
     pub fn submit(&self, graph: &TaskGraph) -> Result<TimelineValue> {
-        let mut backend = self.backend.lock().unwrap();
-        let hints = backend.transient_heap_alignment_hints(self.handle);
+        let mut backend = self.inner.backend.lock().unwrap();
+        let hints = backend.transient_heap_alignment_hints(self.inner.handle);
 
         if !graph.has_transient_resources() {
             return graph.submit_with_backend(self, backend.as_mut(), None, &HashMap::new());
@@ -435,16 +454,16 @@ impl Device {
 
         let total = {
             let b: &mut dyn GpuBackend = &mut **backend;
-            graph.transient_native_heap_total_size(b, self.handle, &hints)?
+            graph.transient_native_heap_total_size(b, self.inner.handle, &hints)?
         };
-        if let Some(heap) = backend.create_transient_heap(self.handle, total)? {
+        if let Some(heap) = backend.create_transient_heap(self.inner.handle, total)? {
             let (buf_map, tex_map) = {
                 let b: &mut dyn GpuBackend = &mut **backend;
-                graph.place_transients_on_native_heap(b, self.handle, heap, &hints)?
+                graph.place_transients_on_native_heap(b, self.inner.handle, heap, &hints)?
             };
             let tv =
                 graph.submit_with_backend(self, backend.as_mut(), buf_map.as_ref(), &tex_map)?;
-            backend.destroy_transient_heap(self.handle, heap)?;
+            backend.destroy_transient_heap(self.inner.handle, heap)?;
             return Ok(tv);
         }
 
@@ -464,7 +483,7 @@ impl Device {
             };
         let buf_ranges_ref = buffer_submit.as_ref().map(|(_, r)| r);
         let (_texture_keepalive, tex_handles) = graph.allocate_transient_textures(self)?;
-        let mut backend = self.backend.lock().unwrap();
+        let mut backend = self.inner.backend.lock().unwrap();
         graph.submit_with_backend(self, backend.as_mut(), buf_ranges_ref, &tex_handles)
     }
 
@@ -495,8 +514,8 @@ impl Device {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn capabilities(&self) -> DeviceCapabilities {
-        let backend = self.backend.lock().unwrap();
-        backend.device_capabilities(self.handle)
+        let backend = self.inner.backend.lock().unwrap();
+        backend.device_capabilities(self.inner.handle)
     }
 
     // --- Shader Library Management ---
@@ -526,7 +545,11 @@ impl Device {
     /// ```
     pub fn register_library(&self, library: ShaderLibrary) -> Result<()> {
         tracing::debug!(library_name = %library.name(), "Registering shader library");
-        self.library_registry.lock().unwrap().register(library)
+        self.inner
+            .library_registry
+            .lock()
+            .unwrap()
+            .register(library)
     }
 
     /// Unregister a shader library.
@@ -539,7 +562,7 @@ impl Device {
     /// Unregistering the built-in `goldy` library is allowed but not recommended,
     /// as many shader utilities depend on it.
     pub fn unregister_library(&self, name: &str) -> bool {
-        self.library_registry.lock().unwrap().unregister(name)
+        self.inner.library_registry.lock().unwrap().unregister(name)
     }
 
     /// Check if a shader library is registered.
@@ -551,14 +574,15 @@ impl Device {
     /// assert!(device.has_library("goldy"));
     /// ```
     pub fn has_library(&self, name: &str) -> bool {
-        self.library_registry.lock().unwrap().has(name)
+        self.inner.library_registry.lock().unwrap().has(name)
     }
 
     /// List all registered shader libraries.
     ///
     /// Returns the names of all currently registered libraries.
     pub fn list_libraries(&self) -> Vec<String> {
-        self.library_registry
+        self.inner
+            .library_registry
             .lock()
             .unwrap()
             .list()
@@ -584,7 +608,11 @@ impl Device {
     /// long-lived pool backing buffer) or at a natural steady-state boundary
     /// such as a resize or scene change.
     pub fn reset_buffer_heaps(&self) {
-        self.backend.lock().unwrap().reset_buffer_heaps(self.handle);
+        self.inner
+            .backend
+            .lock()
+            .unwrap()
+            .reset_buffer_heaps(self.inner.handle);
     }
 
     /// No-op: texture uploads are scheduled via [`crate::task_graph::TaskGraph`].
@@ -598,7 +626,11 @@ impl Device {
 
     /// Get search paths for shader compilation (internal use).
     pub(crate) fn get_shader_search_paths(&self) -> Result<Vec<PathBuf>> {
-        self.library_registry.lock().unwrap().get_search_paths()
+        self.inner
+            .library_registry
+            .lock()
+            .unwrap()
+            .get_search_paths()
     }
 
     /// Reflect the memory layout of a Slang `struct` by compiling `shader_source` once for reflection.
@@ -615,7 +647,7 @@ impl Device {
             .map(|p| p.to_string_lossy().into_owned())
             .collect();
         let path_refs: Vec<&str> = path_strings.iter().map(|s| s.as_str()).collect();
-        let target = match self.backend.lock().unwrap().backend_type() {
+        let target = match self.inner.backend.lock().unwrap().backend_type() {
             BackendType::Vulkan => ShaderTarget::Spirv,
             BackendType::Dx12 => ShaderTarget::Dxil,
             BackendType::Metal => ShaderTarget::Metal,
@@ -637,21 +669,22 @@ impl Device {
             b.create_device(0)?
         };
 
-        // Create registry with built-in goldy_exp library
         let mut registry = ShaderLibraryRegistry::new();
         registry.register(ShaderLibrary::goldy_experimental())?;
 
         Ok(Self {
-            backend,
-            handle,
-            adapter_id: 0,
-            device_type: DeviceType::Other,
-            library_registry: Arc::new(Mutex::new(registry)),
+            inner: Arc::new(DeviceInner {
+                backend,
+                handle,
+                adapter_id: 0,
+                device_type: DeviceType::Other,
+                library_registry: Arc::new(Mutex::new(registry)),
+            }),
         })
     }
 }
 
-impl Drop for Device {
+impl Drop for DeviceInner {
     fn drop(&mut self) {
         tracing::debug!(
             %self.handle,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -60,6 +60,7 @@ impl Default for VertexBufferLayout {
 
 /// A render pipeline.
 pub struct RenderPipeline {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: PipelineHandle,
 }
@@ -79,11 +80,11 @@ impl RenderPipeline {
             "Creating render pipeline"
         );
 
-        let mut backend = device.backend.lock().unwrap();
+        let mut backend = device.inner.backend.lock().unwrap();
 
         let handle = if desc.depth_stencil.is_some() {
             backend.create_pipeline_with_depth(
-                device.handle,
+                device.inner.handle,
                 vertex_shader.handle,
                 fragment_shader.handle,
                 &desc.vertex_layout,
@@ -93,7 +94,7 @@ impl RenderPipeline {
             )?
         } else {
             backend.create_pipeline(
-                device.handle,
+                device.inner.handle,
                 vertex_shader.handle,
                 fragment_shader.handle,
                 &desc.vertex_layout,
@@ -105,7 +106,8 @@ impl RenderPipeline {
         tracing::debug!("Render pipeline created");
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
         })
     }

--- a/src/render_target.rs
+++ b/src/render_target.rs
@@ -51,6 +51,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// Optionally includes a depth buffer for 3D rendering with depth testing.
 pub struct RenderTarget {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     device_handle: u64,
     handle: RenderTargetHandle,
@@ -124,9 +125,9 @@ impl RenderTarget {
             "Creating render target"
         );
         let handle = {
-            let mut backend = device.backend.lock().unwrap();
+            let mut backend = device.inner.backend.lock().unwrap();
             backend.create_render_target_with_depth(
-                device.handle,
+                device.inner.handle,
                 width,
                 height,
                 color_format,
@@ -135,8 +136,9 @@ impl RenderTarget {
         };
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
-            device_handle: device.handle,
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
+            device_handle: device.inner.handle,
             handle,
             width,
             height,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -31,6 +31,7 @@ use std::sync::{Arc, Mutex};
 /// }
 /// ```
 pub struct Sampler {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: SamplerHandle,
 }
@@ -54,12 +55,13 @@ impl Sampler {
             "Creating sampler"
         );
         let handle = {
-            let mut backend = device.backend.lock().unwrap();
-            backend.create_sampler(device.handle, desc)?
+            let mut backend = device.inner.backend.lock().unwrap();
+            backend.create_sampler(device.inner.handle, desc)?
         };
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
         })
     }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -49,6 +49,7 @@ use std::sync::{Arc, Mutex};
 
 /// A compiled shader module.
 pub struct ShaderModule {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: ShaderHandle,
 }
@@ -170,14 +171,14 @@ impl ShaderModule {
 
         let path_refs: Vec<&str> = all_paths.iter().map(|s| s.as_str()).collect();
 
-        let mut backend = device.backend.lock().unwrap();
+        let mut backend = device.inner.backend.lock().unwrap();
         let handle = if validate {
             let owned_checks: Vec<OwnedLayoutCheck> = layout_checks
                 .iter()
                 .map(OwnedLayoutCheck::from_layout_check)
                 .collect();
             backend.create_shader_with_checks(
-                device.handle,
+                device.inner.handle,
                 source,
                 &path_refs,
                 defines,
@@ -186,7 +187,7 @@ impl ShaderModule {
             )?
         } else {
             backend.create_shader_with_paths(
-                device.handle,
+                device.inner.handle,
                 source,
                 &path_refs,
                 defines,
@@ -197,7 +198,8 @@ impl ShaderModule {
         tracing::debug!("Shader module created");
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
             handle,
         })
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 
 /// A GPU surface for zero-copy presentation to a window.
 pub struct Surface {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     device_handle: crate::backend::DeviceHandle,
     handle: SurfaceHandle,
@@ -25,6 +26,7 @@ pub struct Surface {
 
 /// A frame acquired from a surface — explicit bracket for render/compute + present.
 pub struct Frame {
+    _device: Device,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     device_handle: crate::backend::DeviceHandle,
     token: FrameToken,
@@ -65,17 +67,17 @@ impl Surface {
         W: HasWindowHandle + HasDisplayHandle,
     {
         let handle = {
-            let mut backend = device.backend.lock().unwrap();
-            backend.create_surface(device.handle, window, window, config.depth_format)?
+            let mut backend = device.inner.backend.lock().unwrap();
+            backend.create_surface(device.inner.handle, window, window, config.depth_format)?
         };
 
         let (width, height) = {
-            let backend = device.backend.lock().unwrap();
+            let backend = device.inner.backend.lock().unwrap();
             backend.surface_size(handle)
         };
 
         if config.present_mode != PresentMode::Auto {
-            let mut backend = device.backend.lock().unwrap();
+            let mut backend = device.inner.backend.lock().unwrap();
             backend.surface_set_present_mode(handle, config.present_mode)?;
         }
 
@@ -88,8 +90,9 @@ impl Surface {
         );
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
-            device_handle: device.handle,
+            _device: device.clone(),
+            backend: Arc::clone(&device.inner.backend),
+            device_handle: device.inner.handle,
             handle,
             width,
             height,
@@ -115,6 +118,7 @@ impl Surface {
         ));
 
         Ok(Frame {
+            _device: self._device.clone(),
             backend: Arc::clone(&self.backend),
             device_handle: self.device_handle,
             token,

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -150,7 +150,7 @@ impl TaskGraph {
 
         let tv = Self::submit_resolved_ir(device, backend, &ir)?;
         if self.needs_transient_gpu_wait() {
-            backend.wait_until(device.handle, tv)?;
+            backend.wait_until(device.inner.handle, tv)?;
         }
         Ok(tv)
     }
@@ -167,12 +167,12 @@ impl TaskGraph {
 
         if has_render {
             let g = Self::compile_graph_commands_for_ir(ir);
-            backend.submit_graph(device.handle, &g)
+            backend.submit_graph(device.inner.handle, &g)
         } else {
             let edges = analysis::build_edges(ir);
             let schedule = analysis::schedule_waves(ir, &edges);
             let cmds = analysis::emit_commands(ir, &schedule);
-            backend.submit_standalone(device.handle, &cmds)
+            backend.submit_standalone(device.inner.handle, &cmds)
         }
     }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -16,18 +16,14 @@ use std::sync::{Arc, Mutex};
 /// for sampling operations (e.g., applying textures to 3D models).
 #[derive(Clone)]
 pub struct Texture {
+    _device: Option<Device>,
     backend: Arc<Mutex<Box<dyn GpuBackend>>>,
     pub(crate) handle: TextureHandle,
     width: u32,
     height: u32,
     format: TextureFormat,
-    /// Access pattern chosen at creation time. Determines the bindless category
-    /// (`Interpolated` → `Texture`, `Direct` → `StorageImage`).
     access: SpatialAccess,
-    /// Creation flags ([`TextureFlags`]) passed to `create_texture`.
     flags: TextureFlags,
-    /// Whether this texture owns the underlying GPU resource.
-    /// Borrowed textures (e.g. surface frame drawables) skip destroy on drop.
     owned: bool,
 }
 
@@ -67,12 +63,13 @@ impl Texture {
     ) -> Result<Self> {
         tracing::debug!(width, height, ?format, ?access, ?flags, "Creating texture");
         let handle = {
-            let mut backend = device.backend.lock().unwrap();
-            backend.create_texture(device.handle, width, height, format, access, flags)?
+            let mut backend = device.inner.backend.lock().unwrap();
+            backend.create_texture(device.inner.handle, width, height, format, access, flags)?
         };
 
         Ok(Self {
-            backend: Arc::clone(&device.backend),
+            _device: Some(device.clone()),
+            backend: Arc::clone(&device.inner.backend),
             handle,
             width,
             height,
@@ -316,6 +313,7 @@ impl Texture {
     /// holds the original `Texture`.
     pub fn borrow(&self) -> Self {
         Self {
+            _device: self._device.clone(),
             backend: Arc::clone(&self.backend),
             handle: self.handle,
             width: self.width,
@@ -343,6 +341,7 @@ impl Texture {
         format: TextureFormat,
     ) -> Self {
         Self {
+            _device: None,
             backend,
             handle,
             width,


### PR DESCRIPTION
Device is now a cheap Clone handle over Arc<DeviceInner>, and all resource types (Buffer, BufferView, Texture, Surface, Frame, ComputePipeline, ShaderModule, Sampler, RenderPipeline, RenderTarget) store a Device clone internally so the underlying GPU device stays alive as long as any resource created from it exists. DeviceInner::drop replaces Device::drop for actual backend teardown.