### PR TITLE
Add shader caching and pipeline state object (PSO) management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ foreign-types = { version = "0.5", optional = true }
 block = { version = "0.1", optional = true }
 
 [dev-dependencies]
+tempfile = "3"
+
 # PNG output for examples / integration tests that save images
 image = "0.25"
 
@@ -88,6 +90,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Windowing for interactive examples
 winit = "0.30"
+
+zstd = "0.13"
 
 [features]
 # Default enables all platform-appropriate backends

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ bytemuck = { version = "1.21", features = ["derive"] }
 image = { version = "0.25", optional = true }
 dirs = "6.0"
 scopeguard = "1.2"
+bincode = { version = "2", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+zstd = "0.13"
 
 # Windowing / Surface support
 raw-window-handle = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,30 @@ struct PlatformInfo {
     primary: String,
 }
 
+/// `GOLDY_CACHE_VERSION` for on-disk shader bytecode cache invalidation.
+fn emit_goldy_cache_version(slang_semver_label: Option<&str>) {
+    let pkg = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".into());
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let git = std::process::Command::new("git")
+        .current_dir(&manifest_dir)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "nogit".into());
+
+    let sl = slang_semver_label.unwrap_or("noslang");
+    println!("cargo:rustc-env=GOLDY_CACHE_VERSION=v{pkg}-g{git}-slang{sl}");
+}
+
 fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=.git/logs/HEAD");
     println!("cargo:rerun-if-env-changed=GOLDY_SLANG_PATH");
     println!("cargo:rerun-if-changed=slang/manifest.json");
 
@@ -35,6 +58,7 @@ fn main() {
         Err(e) => {
             println!("cargo:warning=Failed to load slang/manifest.json: {}", e);
             generate_empty_embedded_module();
+            emit_goldy_cache_version(None);
             return;
         }
     };
@@ -45,6 +69,7 @@ fn main() {
         None => {
             println!("cargo:warning=Platform {} not in manifest", platform_dir);
             generate_empty_embedded_module();
+            emit_goldy_cache_version(Some(manifest.version.as_str()));
             return;
         }
     };
@@ -78,12 +103,14 @@ fn main() {
             println!("cargo:warning=Failed to download Slang: {}", e);
             println!("cargo:warning=Run: cd slang && ./download.sh");
             generate_empty_embedded_module();
+            emit_goldy_cache_version(Some(manifest.version.as_str()));
             return;
         }
     }
 
     // Generate the embedded module
     generate_embedded_module(&manifest.version, &vendored_dir, platform_info);
+    emit_goldy_cache_version(Some(manifest.version.as_str()));
 }
 
 /// Generate an empty embedded module (for unsupported platforms or missing binaries)

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -1,6 +1,7 @@
 //! Compute pipeline and dispatch logic.
 
 use super::barriers;
+use super::pso_cache;
 use super::shader;
 use super::staging;
 use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, Dx12State};
@@ -79,9 +80,11 @@ pub(super) fn create(
 
     let shader_debug_name = format!("compute_shader#{compute_shader}");
 
+    let key = pso_cache::compute_pso_key(&cs_bytecode);
+
     let logical_device = state
         .devices
-        .get(&device_handle)
+        .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
     // Use the shared bindless root signature from the device
@@ -93,21 +96,56 @@ pub(super) fn create(
 
     tracing::debug!("Using shared bindless root signature for compute pipeline");
 
+    let disk_blob = logical_device.compute_pso_blobs.get(&key);
+    let mut try_drop_stale_cached_blob = disk_blob.is_some();
+    let cached_pso = disk_blob
+        .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
+        .unwrap_or_default();
+
     // Create compute PSO
-    let pso_desc = D3D12_COMPUTE_PIPELINE_STATE_DESC {
+    let mut pso_desc = D3D12_COMPUTE_PIPELINE_STATE_DESC {
         pRootSignature: unsafe { std::mem::transmute_copy(&root_signature) },
         CS: D3D12_SHADER_BYTECODE {
             pShaderBytecode: cs_bytecode.as_ptr() as *const _,
             BytecodeLength: cs_bytecode.len(),
         },
         NodeMask: 0,
-        CachedPSO: D3D12_CACHED_PIPELINE_STATE::default(),
+        CachedPSO: cached_pso,
         Flags: D3D12_PIPELINE_STATE_FLAG_NONE,
     };
 
-    let pipeline_state: ID3D12PipelineState =
-        unsafe { logical_device.device.CreateComputePipelineState(&pso_desc) }
-            .context("Failed to create compute pipeline state")?;
+    let pipeline_state: ID3D12PipelineState = loop {
+        match unsafe { logical_device.device.CreateComputePipelineState(&pso_desc) } {
+            Ok(p) => break p,
+            Err(e) if try_drop_stale_cached_blob => {
+                tracing::warn!(
+                    device = device_handle,
+                    error = ?e,
+                    "discarding stale DX12 compute PSO blob; rebuilding without cache entry"
+                );
+                logical_device.compute_pso_blobs.remove(&key);
+                logical_device.pso_disk_cache_dirty = true;
+                pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
+                try_drop_stale_cached_blob = false;
+            }
+            Err(e) => anyhow::bail!("Failed to create compute pipeline state: {:?}", e),
+        }
+    };
+
+    let blob = unsafe {
+        pipeline_state
+            .GetCachedBlob()
+            .context("GetCachedBlob (compute PSO)")?
+    };
+    let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
+
+    match logical_device.compute_pso_blobs.get(&key) {
+        Some(prev) if *prev == new_blob => {}
+        _ => {
+            logical_device.compute_pso_blobs.insert(key, new_blob);
+            logical_device.pso_disk_cache_dirty = true;
+        }
+    }
 
     let handle = state.next_compute_pipeline_handle;
     state.next_compute_pipeline_handle += 1;

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -1,9 +1,11 @@
 //! Device management logic.
 
+use super::pso_cache;
 use super::types::{self, DxgiAdapterInfo, LogicalDevice};
 use super::{utils, DeviceHandle, Dx12State};
 use crate::backend::{AdapterInfo, BackendType};
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use windows::core::Interface;
 use windows::Win32::Graphics::{Direct3D::*, Direct3D12::*, Dxgi::*};
 
@@ -261,6 +263,17 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
     let mut resource_registry = types::ResourceRegistry::new();
     let scratch_clear_uav_offset = resource_registry.alloc_cbv_srv_uav_slot();
 
+    let (graphics_pso_blobs, compute_pso_blobs) = dirs::cache_dir().map_or_else(
+        || (HashMap::new(), HashMap::new()),
+        |cache_root| {
+            pso_cache::load_maps(
+                &cache_root
+                    .join("goldy")
+                    .join(format!("dx12_pso_{adapter_id}.bin")),
+            )
+        },
+    );
+
     state.devices.insert(
         handle,
         LogicalDevice {
@@ -285,6 +298,9 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             cpu_clear_heap,
             scratch_clear_uav_offset,
             deletion_queue: super::types::DeletionQueue::new(),
+            graphics_pso_blobs,
+            compute_pso_blobs,
+            pso_disk_cache_dirty: false,
         },
     );
 

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -28,6 +28,7 @@ mod diagnostic;
 pub(crate) use diagnostic::log_warp_module_path_once;
 mod device;
 mod pipeline;
+mod pso_cache;
 mod render_commands;
 mod render_target;
 mod sampler;
@@ -288,6 +289,25 @@ impl Dx12Backend {
         if let Some(mut logical_device) = self.state.devices.remove(&device_handle) {
             let _ = self.wait_for_gpu(&logical_device);
             logical_device.deletion_queue.flush_all();
+
+            if logical_device.pso_disk_cache_dirty {
+                if let Some(cache_root) = dirs::cache_dir() {
+                    let path = cache_root
+                        .join("goldy")
+                        .join(format!("dx12_pso_{}.bin", logical_device.adapter_id));
+                    if let Err(e) = pso_cache::save_maps(
+                        &path,
+                        &logical_device.graphics_pso_blobs,
+                        &logical_device.compute_pso_blobs,
+                    ) {
+                        tracing::warn!(
+                            error = ?e,
+                            path = ?path,
+                            "failed to save DX12 PSO disk cache"
+                        );
+                    }
+                }
+            }
 
             if let Some(mut belt) = self.state.staging_belts.remove(&device_handle) {
                 unsafe {

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -1,12 +1,11 @@
 //! Pipeline creation and management.
 
 use super::types::PipelineState;
-use super::{shader, utils, DeviceHandle, Dx12State, PipelineHandle, ShaderHandle};
+use super::{pso_cache, shader, utils, DeviceHandle, Dx12State, PipelineHandle, ShaderHandle};
 use crate::types::{DepthStencilState, PrimitiveTopology, TextureFormat, VertexBufferLayout};
 use anyhow::{Context, Result};
 use windows::Win32::Graphics::{Direct3D12::*, Dxgi::Common::*};
 
-/// Create a graphics pipeline state object.
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(super) fn create(
     state: &mut Dx12State,
@@ -25,9 +24,18 @@ pub(super) fn create(
 
     let shader_debug_name = format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})");
 
+    let key = pso_cache::graphics_pso_key(
+        &vs_bytecode,
+        &fs_bytecode,
+        vertex_layout,
+        topology,
+        target_format,
+        None,
+    );
+
     let logical_device = state
         .devices
-        .get(&device_handle)
+        .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
     // Use the shared bindless root signature from the device
@@ -84,8 +92,13 @@ pub(super) fn create(
         })
         .collect();
 
-    // Create PSO
-    let pso_desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+    let disk_blob = logical_device.graphics_pso_blobs.get(&key);
+    let mut try_drop_stale_cached_blob = disk_blob.is_some();
+    let cached_pso = disk_blob
+        .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
+        .unwrap_or_default();
+
+    let mut pso_desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
         pRootSignature: unsafe { std::mem::transmute_copy(&root_signature) },
         VS: D3D12_SHADER_BYTECODE {
             pShaderBytecode: vs_bytecode.as_ptr() as *const _,
@@ -154,12 +167,42 @@ pub(super) fn create(
             Count: 1,
             Quality: 0,
         },
+        CachedPSO: cached_pso,
         ..Default::default()
     };
 
-    let pipeline_state: ID3D12PipelineState =
-        unsafe { logical_device.device.CreateGraphicsPipelineState(&pso_desc) }
-            .context("Failed to create pipeline state")?;
+    let pipeline_state: ID3D12PipelineState = loop {
+        match unsafe { logical_device.device.CreateGraphicsPipelineState(&pso_desc) } {
+            Ok(p) => break p,
+            Err(e) if try_drop_stale_cached_blob => {
+                tracing::warn!(
+                    device = device_handle,
+                    error = ?e,
+                    "discarding stale DX12 graphics PSO blob; rebuilding without cache entry"
+                );
+                logical_device.graphics_pso_blobs.remove(&key);
+                logical_device.pso_disk_cache_dirty = true;
+                pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
+                try_drop_stale_cached_blob = false;
+            }
+            Err(e) => anyhow::bail!("Failed to create DX12 graphics pipeline state: {:?}", e),
+        }
+    };
+
+    let blob = unsafe {
+        pipeline_state
+            .GetCachedBlob()
+            .context("GetCachedBlob (graphics PSO)")?
+    };
+    let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
+
+    match logical_device.graphics_pso_blobs.get(&key) {
+        Some(prev) if *prev == new_blob => {}
+        _ => {
+            logical_device.graphics_pso_blobs.insert(key, new_blob);
+            logical_device.pso_disk_cache_dirty = true;
+        }
+    }
 
     let handle = state.next_pipeline_handle;
     state.next_pipeline_handle += 1;
@@ -201,9 +244,18 @@ pub(super) fn create_with_depth(
 
     let shader_debug_name = format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})");
 
+    let key = pso_cache::graphics_pso_key(
+        &vs_bytecode,
+        &fs_bytecode,
+        vertex_layout,
+        topology,
+        target_format,
+        depth_stencil,
+    );
+
     let logical_device = state
         .devices
-        .get(&device_handle)
+        .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
     let root_signature = logical_device
@@ -271,7 +323,13 @@ pub(super) fn create_with_depth(
         )
     };
 
-    let pso_desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+    let disk_blob = logical_device.graphics_pso_blobs.get(&key);
+    let mut try_drop_stale_cached_blob = disk_blob.is_some();
+    let cached_pso = disk_blob
+        .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
+        .unwrap_or_default();
+
+    let mut pso_desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
         pRootSignature: unsafe { std::mem::transmute_copy(&root_signature) },
         VS: D3D12_SHADER_BYTECODE {
             pShaderBytecode: vs_bytecode.as_ptr() as *const _,
@@ -342,12 +400,45 @@ pub(super) fn create_with_depth(
             Count: 1,
             Quality: 0,
         },
+        CachedPSO: cached_pso,
         ..Default::default()
     };
 
-    let pipeline_state: ID3D12PipelineState =
-        unsafe { logical_device.device.CreateGraphicsPipelineState(&pso_desc) }
-            .context("Failed to create depth pipeline state")?;
+    let pipeline_state: ID3D12PipelineState = loop {
+        match unsafe { logical_device.device.CreateGraphicsPipelineState(&pso_desc) } {
+            Ok(p) => break p,
+            Err(e) if try_drop_stale_cached_blob => {
+                tracing::warn!(
+                    device = device_handle,
+                    error = ?e,
+                    "discarding stale DX12 graphics depth-PSO blob; rebuilding without cache entry"
+                );
+                logical_device.graphics_pso_blobs.remove(&key);
+                logical_device.pso_disk_cache_dirty = true;
+                pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
+                try_drop_stale_cached_blob = false;
+            }
+            Err(e) => anyhow::bail!(
+                "Failed to create DX12 depth graphics pipeline state: {:?}",
+                e
+            ),
+        }
+    };
+
+    let blob = unsafe {
+        pipeline_state
+            .GetCachedBlob()
+            .context("GetCachedBlob (graphics depth PSO)")?
+    };
+    let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
+
+    match logical_device.graphics_pso_blobs.get(&key) {
+        Some(prev) if *prev == new_blob => {}
+        _ => {
+            logical_device.graphics_pso_blobs.insert(key, new_blob);
+            logical_device.pso_disk_cache_dirty = true;
+        }
+    }
 
     let handle = state.next_pipeline_handle;
     state.next_pipeline_handle += 1;

--- a/src/backend/dx12/pso_cache.rs
+++ b/src/backend/dx12/pso_cache.rs
@@ -1,0 +1,255 @@
+//! Persisted DX12 cached PSO blobs (`GetCachedBlob`).
+
+use crate::types::{DepthStencilState, PrimitiveTopology, TextureFormat, VertexBufferLayout};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use windows::Win32::Graphics::Direct3D::ID3DBlob;
+use windows::Win32::Graphics::Direct3D12::D3D12_CACHED_PIPELINE_STATE;
+
+use super::utils;
+
+#[must_use]
+pub(super) fn d3d12_cached_pso(blob: &[u8]) -> D3D12_CACHED_PIPELINE_STATE {
+    D3D12_CACHED_PIPELINE_STATE {
+        pCachedBlob: blob.as_ptr().cast::<std::ffi::c_void>(),
+        CachedBlobSizeInBytes: blob.len(),
+    }
+}
+
+pub(super) unsafe fn id3dblob_to_vec(blob: &ID3DBlob) -> Vec<u8> {
+    let ptr = blob.GetBufferPointer() as *const u8;
+    let len = blob.GetBufferSize();
+    std::slice::from_raw_parts(ptr, len).to_vec()
+}
+const FILE_MAGIC: &[u8; 8] = b"GD12PSOB";
+const FILE_VERSION: u32 = 1;
+
+fn vertex_format_tag(f: crate::types::VertexFormat) -> u8 {
+    use crate::types::VertexFormat as V;
+    match f {
+        V::Float32 => 1,
+        V::Float32x2 => 2,
+        V::Float32x3 => 3,
+        V::Float32x4 => 4,
+        V::Uint32 => 5,
+        V::Sint32 => 6,
+        V::Uint8x4 => 7,
+        V::Unorm8x4 => 8,
+    }
+}
+
+fn depth_format_tag(d: crate::types::DepthFormat) -> u8 {
+    use crate::types::DepthFormat as D;
+    match d {
+        D::Depth16Unorm => 1,
+        D::Depth24Plus => 2,
+        D::Depth24PlusStencil8 => 3,
+        D::Depth32Float => 4,
+        D::Depth32FloatStencil8 => 5,
+    }
+}
+
+fn topology_tag(topology: PrimitiveTopology) -> u8 {
+    use crate::types::PrimitiveTopology as T;
+    match topology {
+        T::PointList => 1,
+        T::LineList => 2,
+        T::LineStrip => 3,
+        T::TriangleList => 4,
+        T::TriangleStrip => 5,
+    }
+}
+
+fn texture_format_tag(f: TextureFormat) -> u8 {
+    match f {
+        TextureFormat::R8Unorm => 1,
+        TextureFormat::Rg8Unorm => 2,
+        TextureFormat::Rgba8UnormSrgb => 3,
+        TextureFormat::Rgba8Unorm => 4,
+        TextureFormat::Bgra8UnormSrgb => 5,
+        TextureFormat::Bgra8Unorm => 6,
+        TextureFormat::Rgba16Float => 7,
+        TextureFormat::Rgba32Float => 8,
+    }
+}
+
+/// FNV-1a 64-bit hash of concatenated blobs (delimiter-separated sections).
+#[must_use]
+pub(super) fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 14695981039346656037;
+    const PRIME: u64 = 1099511628211;
+    let mut hash = OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// Cache key covering shader bytecode plus everything that participates in [`D3D12_GRAPHICS_PIPELINE_STATE_DESC`](windows::Win32::Graphics::Direct3D12::D3D12_GRAPHICS_PIPELINE_STATE_DESC).
+#[must_use]
+pub(super) fn graphics_pso_key(
+    vs: &[u8],
+    fs: &[u8],
+    vertex_layout: &VertexBufferLayout,
+    topology: PrimitiveTopology,
+    target_format: TextureFormat,
+    depth_stencil: Option<&DepthStencilState>,
+) -> u64 {
+    let mut buf = Vec::new();
+
+    buf.extend_from_slice(vs);
+    buf.push(0x01);
+    buf.extend_from_slice(fs);
+    buf.push(0x02);
+    buf.extend_from_slice(&vertex_layout.stride.to_le_bytes());
+    for attr in &vertex_layout.attributes {
+        buf.extend_from_slice(&attr.location.to_le_bytes());
+        buf.push(vertex_format_tag(attr.format));
+        buf.extend_from_slice(&attr.offset.to_le_bytes());
+    }
+    buf.push(0x03);
+    buf.push(topology_tag(topology));
+    buf.extend_from_slice(&(utils::topology_type_to_d3d12(topology).0.to_le_bytes()));
+    buf.push(0x04);
+    buf.push(texture_format_tag(target_format));
+    buf.extend_from_slice(&(utils::format_to_dxgi(target_format).0.to_le_bytes()));
+    buf.push(0x05);
+    if let Some(ds) = depth_stencil {
+        buf.push(1);
+        buf.push(depth_format_tag(ds.format));
+        buf.extend_from_slice(&(utils::depth_format_to_dxgi(ds.format).0.to_le_bytes()));
+        buf.push(if ds.depth_write_enabled { 1 } else { 0 });
+        buf.extend_from_slice(&(utils::compare_to_d3d12(ds.depth_compare).0.to_le_bytes()));
+    } else {
+        buf.push(0);
+    }
+
+    fnv1a64(&buf)
+}
+
+#[must_use]
+pub(super) fn compute_pso_key(cs: &[u8]) -> u64 {
+    let mut buf = Vec::with_capacity(cs.len() + 1);
+    buf.push(0xaa);
+    buf.extend_from_slice(cs);
+    fnv1a64(&buf)
+}
+
+pub(super) type PsoBlobMaps = (HashMap<u64, Vec<u8>>, HashMap<u64, Vec<u8>>);
+
+pub(super) fn load_maps(path: &Path) -> PsoBlobMaps {
+    let empty = (
+        HashMap::<u64, Vec<u8>>::new(),
+        HashMap::<u64, Vec<u8>>::new(),
+    );
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return empty,
+    };
+    let Ok(parsed) = parse_file(&data) else {
+        return empty;
+    };
+    parsed
+}
+
+fn parse_file(data: &[u8]) -> Result<PsoBlobMaps> {
+    if data.len() < 8 + 4 + 8 + 8 {
+        anyhow::bail!("truncated DX12 PSO cache");
+    }
+    let mut cursor = 0usize;
+    if data[cursor..cursor + 8] != FILE_MAGIC[..] {
+        anyhow::bail!("bad DX12 PSO cache magic");
+    }
+    cursor += 8;
+
+    let version = u32::from_le_bytes(data[cursor..cursor + 4].try_into()?);
+    if version != FILE_VERSION {
+        anyhow::bail!("unsupported DX12 PSO cache version {version}");
+    }
+    cursor += 4;
+
+    let n_graphics = usize::try_from(u64::from_le_bytes(data[cursor..cursor + 8].try_into()?))?;
+    cursor += 8;
+
+    let mut graphics = HashMap::with_capacity(n_graphics);
+    for _ in 0..n_graphics {
+        if cursor + 8 + 4 > data.len() {
+            anyhow::bail!("truncated DX12 graphics PSO entries");
+        }
+        let key = u64::from_le_bytes(data[cursor..cursor + 8].try_into()?);
+        cursor += 8;
+        let blob_len = usize::try_from(u32::from_le_bytes(data[cursor..cursor + 4].try_into()?))?;
+        cursor += 4;
+        if cursor + blob_len > data.len() {
+            anyhow::bail!("truncated DX12 graphics PSO blob");
+        }
+        graphics.insert(key, data[cursor..cursor + blob_len].to_vec());
+        cursor += blob_len;
+    }
+
+    if cursor + 8 > data.len() {
+        anyhow::bail!("missing compute section");
+    }
+    let n_compute = usize::try_from(u64::from_le_bytes(data[cursor..cursor + 8].try_into()?))?;
+    cursor += 8;
+
+    let mut compute = HashMap::with_capacity(n_compute);
+    for _ in 0..n_compute {
+        if cursor + 8 + 4 > data.len() {
+            anyhow::bail!("truncated DX12 compute PSO entries");
+        }
+        let key = u64::from_le_bytes(data[cursor..cursor + 8].try_into()?);
+        cursor += 8;
+        let blob_len = usize::try_from(u32::from_le_bytes(data[cursor..cursor + 4].try_into()?))?;
+        cursor += 4;
+        if cursor + blob_len > data.len() {
+            anyhow::bail!("truncated DX12 compute PSO blob");
+        }
+        compute.insert(key, data[cursor..cursor + blob_len].to_vec());
+        cursor += blob_len;
+    }
+
+    Ok((graphics, compute))
+}
+
+pub(super) fn save_maps(
+    path: &Path,
+    graphics: &HashMap<u64, Vec<u8>>,
+    compute: &HashMap<u64, Vec<u8>>,
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut out = Vec::new();
+    out.write_all(FILE_MAGIC)?;
+    out.write_all(&FILE_VERSION.to_le_bytes())?;
+
+    let n_g = graphics.len().min(u64::MAX as usize) as u64;
+    out.write_all(&n_g.to_le_bytes())?;
+    for (&key, blob) in graphics.iter() {
+        out.write_all(&key.to_le_bytes())?;
+        let len = blob.len().min(u64::from(u32::MAX) as usize);
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            out.write_all(&(len as u32).to_le_bytes())?;
+        }
+        out.write_all(&blob[..len])?;
+    }
+
+    let n_c = compute.len().min(u64::MAX as usize) as u64;
+    out.write_all(&n_c.to_le_bytes())?;
+    for (&key, blob) in compute.iter() {
+        out.write_all(&key.to_le_bytes())?;
+        let len = blob.len().min(u64::from(u32::MAX) as usize);
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            out.write_all(&(len as u32).to_le_bytes())?;
+        }
+        out.write_all(&blob[..len])?;
+    }
+
+    std::fs::write(path, out)
+}

--- a/src/backend/dx12/pso_cache.rs
+++ b/src/backend/dx12/pso_cache.rs
@@ -253,3 +253,188 @@ pub(super) fn save_maps(
 
     std::fs::write(path, out)
 }
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+    use crate::types::{
+        CompareFunction, DepthFormat, DepthStencilState, PrimitiveTopology, TextureFormat,
+        VertexAttribute, VertexBufferLayout, VertexFormat,
+    };
+    use tempfile::TempDir;
+
+    #[test]
+    fn fnv1a64_deterministic() {
+        let b = b"hello_dx12_pso_hash";
+        assert_eq!(fnv1a64(b), fnv1a64(b));
+    }
+
+    #[test]
+    fn fnv1a64_different_inputs_differ() {
+        let mut a = vec![7u8, 42, 1, 2, 3];
+        let h0 = fnv1a64(&a);
+        let last = usize::checked_sub(a.len(), 1).unwrap();
+        a[last] ^= 0xff;
+        assert_ne!(h0, fnv1a64(&a));
+    }
+
+    fn sample_vertex_layout() -> VertexBufferLayout {
+        VertexBufferLayout {
+            stride: 16,
+            attributes: vec![VertexAttribute {
+                location: 0,
+                format: VertexFormat::Float32x3,
+                offset: 0,
+            }],
+        }
+    }
+
+    fn base_gfx_key_args() -> (
+        &'static [u8],
+        &'static [u8],
+        VertexBufferLayout,
+        PrimitiveTopology,
+        TextureFormat,
+        Option<DepthStencilState>,
+    ) {
+        (
+            b"vs bytecode",
+            b"fs bytecode",
+            sample_vertex_layout(),
+            PrimitiveTopology::TriangleList,
+            TextureFormat::R8Unorm,
+            Some(DepthStencilState {
+                format: DepthFormat::Depth24Plus,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Less,
+            }),
+        )
+    }
+
+    #[test]
+    fn graphics_pso_key_sensitive_to_vs() {
+        let (_, fs, vl, topo, tf, ds) = base_gfx_key_args();
+        let k0 = graphics_pso_key(b"vs_a", fs, &vl, topo, tf, ds.as_ref());
+        assert_ne!(
+            k0,
+            graphics_pso_key(b"vs_b", fs, &vl, topo, tf, ds.as_ref()),
+        );
+    }
+
+    #[test]
+    fn graphics_pso_key_sensitive_to_fs() {
+        let (vs, _, vl, topo, tf, ds) = base_gfx_key_args();
+        let k0 = graphics_pso_key(vs, b"fs_a", &vl, topo, tf, ds.as_ref());
+        assert_ne!(
+            k0,
+            graphics_pso_key(vs, b"fs_b", &vl, topo, tf, ds.as_ref()),
+        );
+    }
+
+    #[test]
+    fn graphics_pso_key_sensitive_to_topology() {
+        let (vs, fs, vl, _, tf, ds) = base_gfx_key_args();
+        let line = PrimitiveTopology::LineList;
+        let tri = PrimitiveTopology::TriangleList;
+        assert_ne!(
+            graphics_pso_key(vs, fs, &vl, tri, tf, ds.as_ref()),
+            graphics_pso_key(vs, fs, &vl, line, tf, ds.as_ref()),
+        );
+    }
+
+    #[test]
+    fn graphics_pso_key_sensitive_to_target_format() {
+        let (vs, fs, vl, topo, _, ds) = base_gfx_key_args();
+        assert_ne!(
+            graphics_pso_key(vs, fs, &vl, topo, TextureFormat::R8Unorm, ds.as_ref()),
+            graphics_pso_key(vs, fs, &vl, topo, TextureFormat::Rgba32Float, ds.as_ref(),),
+        );
+    }
+
+    #[test]
+    fn graphics_pso_key_sensitive_to_depth_stencil() {
+        let (vs, fs, vl, topo, tf, _) = base_gfx_key_args();
+        let ds = DepthStencilState {
+            format: DepthFormat::Depth32Float,
+            depth_write_enabled: false,
+            depth_compare: CompareFunction::Always,
+        };
+        assert_ne!(
+            graphics_pso_key(vs, fs, &vl, topo, tf, None),
+            graphics_pso_key(vs, fs, &vl, topo, tf, Some(&ds)),
+        );
+    }
+
+    #[test]
+    fn compute_pso_key_deterministic() {
+        let cs = b"minimal_cs_blob";
+        assert_eq!(compute_pso_key(cs), compute_pso_key(cs));
+    }
+
+    #[test]
+    fn compute_pso_key_differs_with_cs_change() {
+        assert_ne!(compute_pso_key(b"aaa"), compute_pso_key(b"aab"));
+    }
+
+    #[test]
+    fn save_load_roundtrip_empty() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("pso.bin");
+        let g_in = HashMap::<u64, Vec<u8>>::new();
+        let c_in = HashMap::<u64, Vec<u8>>::new();
+        save_maps(&path, &g_in, &c_in).unwrap();
+        let (g_out, c_out) = load_maps(&path);
+        assert!(g_out.is_empty());
+        assert!(c_out.is_empty());
+    }
+
+    #[test]
+    fn save_load_roundtrip_populated() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("pso.bin");
+        let mut g = HashMap::new();
+        g.insert(1u64, vec![10, 20, 30]);
+        g.insert(9u64, vec![255]);
+        let mut c = HashMap::new();
+        c.insert(100u64, vec![1, 2, 3, 4]);
+        save_maps(&path, &g, &c).unwrap();
+        let (g2, c2) = load_maps(&path);
+        assert_eq!(g2, g);
+        assert_eq!(c2, c);
+    }
+
+    #[test]
+    fn load_maps_missing_file_returns_empty() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("never_written.bin");
+        let (g, c) = load_maps(&path);
+        assert!(g.is_empty());
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn parse_file_bad_magic() {
+        let mut data = vec![b'X'; 8];
+        data.extend_from_slice(&FILE_VERSION.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        assert!(parse_file(&data).is_err());
+    }
+
+    #[test]
+    fn parse_file_wrong_version() {
+        let mut data = Vec::new();
+        data.extend_from_slice(FILE_MAGIC);
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        assert!(parse_file(&data).is_err());
+    }
+
+    #[test]
+    fn parse_file_truncated() {
+        let mut data = Vec::new();
+        data.extend_from_slice(FILE_MAGIC);
+        data.extend_from_slice(&FILE_VERSION.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        assert!(parse_file(&data).is_err());
+    }
+}

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -433,6 +433,12 @@ pub(crate) struct LogicalDevice {
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
     pub deletion_queue: DeletionQueue,
+    /// Cached graphics PSO blobs from [`ID3D12PipelineState::GetCachedBlob`] (cold-load via `CachedPSO`).
+    pub graphics_pso_blobs: HashMap<u64, Vec<u8>>,
+    /// Cached compute PSO blobs.
+    pub compute_pso_blobs: HashMap<u64, Vec<u8>>,
+    /// `true` if either blob map changed since loading from [`super::pso_cache`] disk file.
+    pub pso_disk_cache_dirty: bool,
 }
 
 /// GPU buffer state.

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -216,6 +216,7 @@ impl ResourceRegistry {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod registry_tests {
     use super::*;
 
@@ -433,7 +434,7 @@ pub(crate) struct LogicalDevice {
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
     pub deletion_queue: DeletionQueue,
-    /// Cached graphics PSO blobs from [`ID3D12PipelineState::GetCachedBlob`] (cold-load via `CachedPSO`).
+    /// Cached graphics PSO blobs from `ID3D12PipelineState::GetCachedBlob` (cold-load via `CachedPSO`).
     pub graphics_pso_blobs: HashMap<u64, Vec<u8>>,
     /// Cached compute PSO blobs.
     pub compute_pso_blobs: HashMap<u64, Vec<u8>>,
@@ -630,7 +631,7 @@ pub(crate) struct SurfaceState {
     pub pending_frame_compute: Vec<crate::backend::GpuCommand>,
 }
 
-/// Sub-heap for transient task-graph packing ([`GpuBackend::create_transient_heap`]).
+/// Sub-heap for transient task-graph packing ([`GpuBackend::create_transient_heap`](crate::backend::GpuBackend::create_transient_heap)).
 pub(crate) struct TransientHeapEntry {
     pub device_handle: DeviceHandle,
     pub heap: Direct3D12::ID3D12Heap,

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -97,7 +97,7 @@ pub(super) fn create(
 
     let pipelines = unsafe {
         logical_device.device.create_compute_pipelines(
-            vk::PipelineCache::null(),
+            logical_device.pipeline_cache,
             &[pipeline_info],
             None,
         )

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -320,6 +320,18 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
     let timeline_semaphore = unsafe { device.create_semaphore(&timeline_sem_ci, None) }
         .context("Failed to create Vulkan timeline semaphore")?;
 
+    let initial_pipeline_cache_bytes = dirs::cache_dir()
+        .map(|d| {
+            d.join("goldy")
+                .join(format!("pipeline_cache_{adapter_id}.bin"))
+        })
+        .and_then(|path| std::fs::read(path).ok())
+        .unwrap_or_default();
+    let pipeline_cache_ci =
+        vk::PipelineCacheCreateInfo::default().initial_data(&initial_pipeline_cache_bytes);
+    let pipeline_cache = unsafe { device.create_pipeline_cache(&pipeline_cache_ci, None) }
+        .context("Failed to create VkPipelineCache")?;
+
     let handle = state.next_device_handle;
     state.next_device_handle += 1;
 
@@ -341,6 +353,7 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             deletion_queue: types::DeletionQueue::new(),
             timeline_semaphore,
             timeline_next: 1,
+            pipeline_cache,
         },
     );
 
@@ -521,6 +534,33 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                             .destroy_pipeline_layout(pipeline.layout, None);
                     }
                 }
+            }
+
+            // Serialize pipeline cache after all pipelines referencing it are destroyed.
+            let pipeline_cache_disk_path = dirs::cache_dir().map(|d| {
+                d.join("goldy")
+                    .join(format!("pipeline_cache_{}.bin", logical_device.adapter_id))
+            });
+            if logical_device.pipeline_cache != vk::PipelineCache::null() {
+                match logical_device
+                    .device
+                    .get_pipeline_cache_data(logical_device.pipeline_cache)
+                {
+                    Ok(data) => {
+                        if let Some(path) = pipeline_cache_disk_path.as_ref() {
+                            if let Some(parent) = path.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
+                            if let Err(e) = std::fs::write(path, data) {
+                                tracing::warn!(?e, path = ?path, "failed to write VkPipelineCache");
+                            }
+                        }
+                    }
+                    Err(e) => tracing::warn!(?e, "failed vkGetPipelineCacheData"),
+                }
+                logical_device
+                    .device
+                    .destroy_pipeline_cache(logical_device.pipeline_cache, None);
             }
 
             // Destroy render targets owned by this device

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -145,7 +145,7 @@ pub(super) fn create(
 
     let vk_pipelines = unsafe {
         logical_device.device.create_graphics_pipelines(
-            vk::PipelineCache::null(),
+            logical_device.pipeline_cache,
             std::slice::from_ref(&pipeline_info),
             None,
         )
@@ -349,7 +349,7 @@ pub(super) fn create_with_depth(
 
     let vk_pipelines = unsafe {
         logical_device.device.create_graphics_pipelines(
-            vk::PipelineCache::null(),
+            logical_device.pipeline_cache,
             std::slice::from_ref(&pipeline_info),
             None,
         )

--- a/src/backend/vulkan/staging.rs
+++ b/src/backend/vulkan/staging.rs
@@ -55,7 +55,7 @@ impl StagingBelt {
     }
 
     /// Return completed chunks to the free list. Call at the start of each compute submit,
-    /// **before** [`super::compute::reap_signaled_fences`] so `VkFence` handles are valid.
+    /// **before** [`super::compute`] reaps signaled fences so `VkFence` handles are valid.
     ///
     /// `completed_timeline` is the current device timeline counter (from
     /// `vkGetSemaphoreCounterValue`).  Chunks tagged with timeline-semaphore values

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -1106,7 +1106,8 @@ pub(super) struct ComputeTextureScratch {
     pub height: u32,
 }
 
-/// Allocate and CPU-fill staging for [`GpuCommand::WriteTexture`] / [`GpuCommand::WriteTextureRegion`].
+/// Allocate and CPU-fill staging for [`GpuCommand::WriteTexture`](crate::backend::GpuCommand::WriteTexture)
+/// / [`GpuCommand::WriteTextureRegion`](crate::backend::GpuCommand::WriteTextureRegion).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn allocate_compute_texture_staging(
     instance: &ash::Instance,

--- a/src/backend/vulkan/transient.rs
+++ b/src/backend/vulkan/transient.rs
@@ -1,4 +1,5 @@
-//! One [`vk::DeviceMemory`] block with [`vkBindBufferMemory`] / [`vkBindImageMemory`] offsets.
+//! One [`vk::DeviceMemory`] block with sub-allocations bound via Vulkan `vkBindBufferMemory` /
+//! `vkBindImageMemory` at byte offsets.
 
 use super::texture;
 use super::types::{self, TransientHeapEntry};

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -35,22 +35,22 @@ pub const MAX_BINDLESS_RESOURCES: u32 = 16384;
 pub mod bindless_bindings {
     /// Scattered access: any thread, any address, read/write
     /// Maps to: VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-    /// Slang: StructuredBuffer<T>, RWStructuredBuffer<T>
+    /// Slang: `StructuredBuffer<T>`, `RWStructuredBuffer<T>`
     pub const SCATTERED: u32 = 0;
 
     /// Broadcast access: all threads same address, read-only (enables cache optimization)
     /// Maps to: VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
-    /// Slang: ConstantBuffer<T>
+    /// Slang: `ConstantBuffer<T>`
     pub const BROADCAST: u32 = 1;
 
     /// Interpolated access: hardware filtering between neighbors (texture units)
     /// Maps to: VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
-    /// Slang: Texture2D<T> (read with sampler)
+    /// Slang: `Texture2D<T>` (read with sampler)
     pub const INTERPOLATED: u32 = 2;
 
     /// Direct spatial access: 2D/3D indexing without filtering, read/write
     /// Maps to: VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
-    /// Slang: RWTexture2D<T>
+    /// Slang: `RWTexture2D<T>`
     pub const DIRECT_SPATIAL: u32 = 3;
 
     /// Filter configuration: settings for interpolated access (not data)
@@ -366,7 +366,7 @@ pub(crate) struct LogicalDevice {
     pub resource_registry: ResourceRegistry,
     /// Deferred deletion queue for resources that are still in-flight
     pub deletion_queue: DeletionQueue,
-    /// Device timeline semaphore for monotonic GPU progress ([`GpuBackend::gpu_progress`]).
+    /// Device timeline semaphore for monotonic GPU progress ([`GpuBackend::gpu_progress`](crate::backend::GpuBackend::gpu_progress)).
     pub timeline_semaphore: vk::Semaphore,
     /// Next timeline value to signal on `timeline_semaphore`.
     pub timeline_next: u64,
@@ -563,10 +563,10 @@ pub(crate) struct FrameSync {
     /// Device timeline value signaled for this frame slot's last queue submission
     /// (render or compute+present batch). Consumed when presenting.
     pub frame_timeline_value: Option<u64>,
-    /// Compute command buffers recorded in [`GpuBackend::end_frame`] and submitted
+    /// Compute command buffers recorded in [`GpuBackend::end_frame`](crate::backend::GpuBackend::end_frame) and submitted
     /// with the present-barrier batch in [`super::surface::present`].
     pub deferred_compute_cbs: Vec<vk::CommandBuffer>,
-    /// Texture upload staging for [`deferred_compute_cbs`], merged into
+    /// Texture upload staging for `deferred_compute_cbs`, merged into
     /// [`VulkanState::compute_texture_staging_pool`] under the frame's timeline
     /// signal value at present time.
     pub pending_compute_texture_staging: Vec<(vk::Buffer, vk::DeviceMemory)>,
@@ -607,7 +607,7 @@ pub(crate) struct SurfaceState {
     /// registered in the bindless descriptor set as a storage image so compute
     /// shaders can write directly to the swapchain image.
     pub current_texture_handle: Option<super::TextureHandle>,
-    /// Compute commands accumulated for the active frame ([`GpuBackend::record_gpu_work`]).
+    /// Compute commands accumulated for the active frame ([`GpuBackend::record_gpu_work`](crate::backend::GpuBackend::record_gpu_work)).
     pub frame_pending_gpu_commands: Vec<super::GpuCommand>,
 }
 
@@ -809,7 +809,7 @@ pub(super) struct VulkanState {
     pub next_sampler_handle: SamplerHandle,
     /// Per-backend Slang compiler instance (avoids global state issues in tests)
     pub slang_compiler: crate::slang::SlangCompiler,
-    /// Per-submission fences for non-blocking compute; token -> (device, VkFence, Option<VkCommandBuffer>).
+    /// Per-submission fences for non-blocking compute; token -> (device, `VkFence`, `Option<VkCommandBuffer>`).
     /// The command buffer is kept alive until the fence signals (Vulkan spec: must not free a pending CB).
     pub compute_fence_pool: HashMap<u64, (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>)>,
     /// Texture upload staging (VkBuffer/VkDeviceMemory) freed when the matching compute fence

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -370,6 +370,9 @@ pub(crate) struct LogicalDevice {
     pub timeline_semaphore: vk::Semaphore,
     /// Next timeline value to signal on `timeline_semaphore`.
     pub timeline_next: u64,
+
+    /// Optional driver pipeline cache persisted to disk (`~/.cache/goldy/pipeline_cache_<adapter>.bin`).
+    pub pipeline_cache: vk::PipelineCache,
 }
 
 impl LogicalDevice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod texture;
 pub mod texture_pool;
 pub mod types;
 
+pub mod shader_cache;
 pub mod slang;
 pub mod validation_env;
 

--- a/src/shader_cache.rs
+++ b/src/shader_cache.rs
@@ -1,6 +1,6 @@
 //! Persistent Slang compilation cache (`~/.cache/goldy/shader_cache.bin.zst`).
 //!
-//! Invalidated when [`GOLDY_CACHE_VERSION`] (from [`build.rs`](../../build.rs)) changes.
+//! Invalidated when [`GOLDY_CACHE_VERSION`] changes (defined in crate [`build.rs`](../build.rs)).
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -11,10 +11,11 @@ use anyhow::Result;
 use crate::slang::{ffi::SlangStage, CompiledShaderWithReflection, OwnedLayoutCheck, ShaderTarget};
 use crate::types::OptimizationLevel;
 
-pub(crate) const GOLDY_SHADER_CACHE_MAGIC: &[u8; 8] = b"GZ_SHBIN";
+/// Leading bytes of the decompressed shader cache payload.
+pub const GOLDY_SHADER_CACHE_MAGIC: &[u8; 8] = b"GZ_SHBIN";
 
 /// Build-time fingerprint: package version + git short hash + bundled Slang version.
-pub(crate) const GOLDY_CACHE_VERSION: &str = env!("GOLDY_CACHE_VERSION");
+pub const GOLDY_CACHE_VERSION: &str = env!("GOLDY_CACHE_VERSION");
 
 const BINCODE_CFG: bincode::config::Configuration = bincode::config::standard();
 
@@ -112,7 +113,7 @@ fn empty_shader_cache_shell(disk_path: Option<PathBuf>) -> ShaderBytecodeDiskCac
     }
 }
 
-pub(crate) struct ShaderBytecodeDiskCache {
+pub struct ShaderBytecodeDiskCache {
     map: HashMap<u64, Vec<u8>>,
     dirty: bool,
     disk_path: Option<PathBuf>,
@@ -122,12 +123,7 @@ pub(crate) struct ShaderBytecodeDiskCache {
 
 impl ShaderBytecodeDiskCache {
     #[must_use]
-    pub(crate) fn new_load_or_empty() -> Self {
-        let Some(cache_root) = dirs::cache_dir() else {
-            return empty_shader_cache_shell(None);
-        };
-
-        let path = cache_root.join("goldy").join("shader_cache.bin.zst");
+    pub fn new_at_path(path: PathBuf) -> Self {
         let bytes = match std::fs::read(&path) {
             Ok(b) => b,
             Err(_) => {
@@ -144,7 +140,8 @@ impl ShaderBytecodeDiskCache {
                 }
             };
 
-        let Some(body) = decompressed.strip_prefix(GOLDY_SHADER_CACHE_MAGIC) else {
+        let magic = GOLDY_SHADER_CACHE_MAGIC.as_slice();
+        let Some(body) = decompressed.strip_prefix(magic) else {
             tracing::warn!("shader cache magic mismatch — ignoring cached file");
             return empty_shader_cache_shell(Some(path));
         };
@@ -187,6 +184,15 @@ impl ShaderBytecodeDiskCache {
     }
 
     #[must_use]
+    pub(crate) fn new_load_or_empty() -> Self {
+        let Some(cache_root) = dirs::cache_dir() else {
+            return empty_shader_cache_shell(None);
+        };
+
+        Self::new_at_path(cache_root.join("goldy").join("shader_cache.bin.zst"))
+    }
+
+    #[must_use]
     pub(crate) fn get(&mut self, key: u64) -> Option<Result<CompiledShaderWithReflection>> {
         let blob = self.map.get(&key)?.clone();
         Some(decode_cached(&blob))
@@ -216,7 +222,7 @@ impl ShaderBytecodeDiskCache {
         };
 
         let mut uncompressed = Vec::new();
-        let _ = uncompressed.write_all(GOLDY_SHADER_CACHE_MAGIC);
+        let _ = uncompressed.write_all(GOLDY_SHADER_CACHE_MAGIC.as_slice());
         uncompressed
             .write_all(GOLDY_CACHE_VERSION.as_bytes())
             .unwrap();
@@ -243,10 +249,20 @@ impl ShaderBytecodeDiskCache {
         !self.dirty
     }
 
-    #[allow(dead_code)]
+    /// `true` when the backing file decoded with a version matching this build ([`GOLDY_CACHE_VERSION`]).
     #[must_use]
-    pub(crate) fn version_ok_on_disk(&self) -> bool {
+    pub fn version_ok_on_disk(&self) -> bool {
         self.version_ok_on_disk
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
     }
 }
 
@@ -295,4 +311,268 @@ fn flatten_map_to_disk(dest: &mut Vec<u8>, map: &HashMap<u64, Vec<u8>>) -> Resul
         dest.write_all(blob)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slang::{
+        ffi::SlangStage, CompiledShader, CompiledShaderWithReflection, OwnedLayoutCheck,
+        ShaderReflection, ShaderTarget,
+    };
+    use crate::types::OptimizationLevel;
+    use tempfile::TempDir;
+
+    type BaseCompileArgs = (
+        &'static str,
+        ShaderTarget,
+        Vec<(&'static str, SlangStage)>,
+        Vec<(&'static str, &'static str)>,
+        Vec<OwnedLayoutCheck>,
+        OptimizationLevel,
+    );
+
+    fn dummy_compiled() -> CompiledShaderWithReflection {
+        CompiledShaderWithReflection {
+            shader: CompiledShader {
+                data: vec![0xDE, 0xAD, 0xBE, 0xEF],
+                target: ShaderTarget::Spirv,
+            },
+            reflection: ShaderReflection::default(),
+        }
+    }
+
+    fn base_compile_args() -> BaseCompileArgs {
+        (
+            "float4 main() : SV_Target0 { return 0; }",
+            ShaderTarget::Spirv,
+            vec![("main", SlangStage::Fragment)],
+            vec![("A", "1"), ("B", "2")],
+            vec![OwnedLayoutCheck {
+                type_name: "Foo".to_string(),
+                rust_size: 16,
+                rust_fields: vec![("x".to_string(), 0, 4)],
+            }],
+            OptimizationLevel::default(),
+        )
+    }
+
+    #[test]
+    fn compile_cache_key_deterministic() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let k1 = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        let k2 = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn compile_cache_key_define_order_independent() {
+        let (src, tgt, eps, _defs, layouts, opt) = base_compile_args();
+        let d1 = vec![("a", "x"), ("b", "y")];
+        let d2 = vec![("b", "y"), ("a", "x")];
+        assert_eq!(
+            compile_cache_key(src, tgt, &eps, &d1, &layouts, opt),
+            compile_cache_key(src, tgt, &eps, &d2, &layouts, opt),
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_source() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        let alt = "float4 main() : SV_Target0 { return 1; }";
+        assert_ne!(
+            base_key,
+            compile_cache_key(alt, tgt, &eps, &defs, &layouts, opt)
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_target() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        assert_ne!(
+            base_key,
+            compile_cache_key(src, ShaderTarget::Dxil, &eps, &defs, &layouts, opt),
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_entry_point() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        let eps2 = vec![("other", SlangStage::Fragment)];
+        assert_ne!(
+            base_key,
+            compile_cache_key(src, tgt, &eps2, &defs, &layouts, opt)
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_defines() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        let defs2 = vec![("A", "2"), ("B", "2")];
+        assert_ne!(
+            base_key,
+            compile_cache_key(src, tgt, &eps, &defs2, &layouts, opt)
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_optimization_level() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        assert_ne!(
+            base_key,
+            compile_cache_key(src, tgt, &eps, &defs, &layouts, OptimizationLevel::Maximal,),
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_sensitive_to_layout_checks() {
+        let (src, tgt, eps, defs, layouts, opt) = base_compile_args();
+        let base_key = compile_cache_key(src, tgt, &eps, &defs, &layouts, opt);
+        let mut layouts2 = layouts.clone();
+        layouts2[0].rust_size = 32;
+        assert_ne!(
+            base_key,
+            compile_cache_key(src, tgt, &eps, &defs, &layouts2, opt)
+        );
+    }
+
+    #[test]
+    fn cache_cold_start_on_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let c = ShaderBytecodeDiskCache::new_at_path(path.clone());
+        assert!(c.should_skip_save_on_drop());
+        assert!(!path.exists());
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn insert_marks_dirty_get_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let v = dummy_compiled();
+        let mut c = ShaderBytecodeDiskCache::new_at_path(path);
+        assert!(c.should_skip_save_on_drop());
+        c.insert(7, &v).unwrap();
+        assert!(!c.should_skip_save_on_drop());
+        let got = c.get(7).unwrap().unwrap();
+        assert_eq!(got.shader.data, v.shader.data);
+        assert_eq!(got.shader.target, v.shader.target);
+    }
+
+    #[test]
+    fn insert_identical_blob_no_dirty_after_flush_and_re_insert() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let v = dummy_compiled();
+        let mut c = ShaderBytecodeDiskCache::new_at_path(path);
+        c.insert(1, &v).unwrap();
+        c.flush_to_disk_best_effort();
+        assert!(c.should_skip_save_on_drop());
+        c.insert(1, &v).unwrap();
+        assert!(c.should_skip_save_on_drop());
+    }
+
+    #[test]
+    fn flush_not_dirty_no_file_created() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let mut c = ShaderBytecodeDiskCache::new_at_path(path.clone());
+        c.flush_to_disk_best_effort();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn flush_writes_file_and_clears_dirty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let v = dummy_compiled();
+        let mut c = ShaderBytecodeDiskCache::new_at_path(path.clone());
+        c.insert(99, &v).unwrap();
+        assert!(!c.should_skip_save_on_drop());
+        c.flush_to_disk_best_effort();
+        assert!(c.should_skip_save_on_drop());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn drop_flushes_dirty_cache() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let v = dummy_compiled();
+        {
+            let mut c = ShaderBytecodeDiskCache::new_at_path(path.clone());
+            c.insert(123, &v).unwrap();
+        }
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn load_back_after_flush() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let v = dummy_compiled();
+        {
+            let mut c = ShaderBytecodeDiskCache::new_at_path(path.clone());
+            c.insert(42, &v).unwrap();
+            c.flush_to_disk_best_effort();
+        }
+        let mut c2 = ShaderBytecodeDiskCache::new_at_path(path.clone());
+        assert!(c2.version_ok_on_disk(), "fresh load should decode version");
+        let got = c2.get(42).unwrap().unwrap();
+        assert_eq!(got.shader.data, v.shader.data);
+        assert_eq!(got.shader.target, v.shader.target);
+    }
+
+    fn write_compressed_shader_blob(buf: &[u8]) -> Vec<u8> {
+        zstd::encode_all(buf, 10).unwrap()
+    }
+
+    #[test]
+    fn version_mismatch_starts_cold() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let mut uncompressed = Vec::new();
+        uncompressed.extend_from_slice(GOLDY_SHADER_CACHE_MAGIC.as_slice());
+        uncompressed.extend_from_slice(b"this-is-not-the-build-cache-version-string\n");
+        uncompressed.extend_from_slice(&0u64.to_le_bytes());
+        std::fs::write(&path, write_compressed_shader_blob(&uncompressed)).unwrap();
+        let c = ShaderBytecodeDiskCache::new_at_path(path);
+        assert!(!c.version_ok_on_disk());
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn wrong_magic_starts_cold() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let mut uncompressed = Vec::new();
+        uncompressed.extend_from_slice(b"BADMAGIC!!");
+        uncompressed.extend_from_slice(GOLDY_CACHE_VERSION.as_bytes());
+        uncompressed.push(b'\n');
+        uncompressed.extend_from_slice(&0u64.to_le_bytes());
+        std::fs::write(&path, write_compressed_shader_blob(&uncompressed)).unwrap();
+        let c = ShaderBytecodeDiskCache::new_at_path(path);
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn truncated_body_starts_cold() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shader_cache.bin.zst");
+        let mut uncompressed = Vec::new();
+        uncompressed.extend_from_slice(GOLDY_SHADER_CACHE_MAGIC.as_slice());
+        uncompressed.extend_from_slice(GOLDY_CACHE_VERSION.as_bytes());
+        uncompressed.push(b'\n');
+        uncompressed.extend_from_slice(&1u64.to_le_bytes()); // claim 1 entry
+        uncompressed.extend_from_slice(&0u64.to_le_bytes()); // incomplete entry
+        std::fs::write(&path, write_compressed_shader_blob(&uncompressed)).unwrap();
+        let c = ShaderBytecodeDiskCache::new_at_path(path);
+        assert!(c.is_empty());
+    }
 }

--- a/src/shader_cache.rs
+++ b/src/shader_cache.rs
@@ -1,0 +1,298 @@
+//! Persistent Slang compilation cache (`~/.cache/goldy/shader_cache.bin.zst`).
+//!
+//! Invalidated when [`GOLDY_CACHE_VERSION`] (from [`build.rs`](../../build.rs)) changes.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::slang::{ffi::SlangStage, CompiledShaderWithReflection, OwnedLayoutCheck, ShaderTarget};
+use crate::types::OptimizationLevel;
+
+pub(crate) const GOLDY_SHADER_CACHE_MAGIC: &[u8; 8] = b"GZ_SHBIN";
+
+/// Build-time fingerprint: package version + git short hash + bundled Slang version.
+pub(crate) const GOLDY_CACHE_VERSION: &str = env!("GOLDY_CACHE_VERSION");
+
+const BINCODE_CFG: bincode::config::Configuration = bincode::config::standard();
+
+const FNV_OFFSET: u64 = 14695981039346656037;
+const FNV_PRIME: u64 = 1099511628211;
+
+#[inline]
+fn fnv_mix(mut h: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        h ^= u64::from(*byte);
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+#[inline]
+fn hash_string(h: u64, s: &str) -> u64 {
+    fnv_mix(h, s.as_bytes())
+}
+
+fn stage_tag(s: SlangStage) -> u8 {
+    match s {
+        SlangStage::None => 0,
+        SlangStage::Vertex => 1,
+        SlangStage::Hull => 2,
+        SlangStage::Domain => 3,
+        SlangStage::Geometry => 4,
+        SlangStage::Fragment => 5,
+        SlangStage::Compute => 6,
+        SlangStage::RayGeneration => 7,
+        SlangStage::Intersection => 8,
+        SlangStage::AnyHit => 9,
+        SlangStage::ClosestHit => 10,
+        SlangStage::Miss => 11,
+        SlangStage::Callable => 12,
+        SlangStage::Mesh => 13,
+        SlangStage::Amplification => 14,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compile_cache_key(
+    source: &str,
+    target: ShaderTarget,
+    entry_points: &[(&str, SlangStage)],
+    defines: &[(&str, &str)],
+    layout_checks: &[OwnedLayoutCheck],
+    optimization_level: OptimizationLevel,
+) -> u64 {
+    let mut h = FNV_OFFSET;
+    h = hash_string(h, source);
+    h = fnv_mix(h, &[target as u8]);
+    h = fnv_mix(h, &(entry_points.len() as u64).to_le_bytes());
+    for &(name, st) in entry_points {
+        h = hash_string(h, name);
+        h = fnv_mix(h, &[stage_tag(st)]);
+    }
+    let mut defs: Vec<(&str, &str)> = defines.to_vec();
+    defs.sort_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(b.1)));
+    h = fnv_mix(h, &(defs.len() as u64).to_le_bytes());
+    for &(k, v) in &defs {
+        h = hash_string(h, k);
+        h = hash_string(h, v);
+    }
+    h = fnv_mix(h, &(layout_checks.len() as u64).to_le_bytes());
+    for chk in layout_checks {
+        h = hash_string(h, &chk.type_name);
+        h = fnv_mix(h, &chk.rust_size.to_le_bytes());
+        h = fnv_mix(h, &(chk.rust_fields.len() as u64).to_le_bytes());
+        for (n, off, sz) in &chk.rust_fields {
+            h = hash_string(h, n);
+            h = fnv_mix(h, &off.to_le_bytes());
+            h = fnv_mix(h, &sz.to_le_bytes());
+        }
+    }
+    h = fnv_mix(h, &[optimization_level as u8]);
+    h
+}
+
+fn encode_cached(value: &CompiledShaderWithReflection) -> Result<Vec<u8>> {
+    bincode::serde::encode_to_vec(value, BINCODE_CFG).map_err(Into::into)
+}
+
+fn decode_cached(bytes: &[u8]) -> Result<CompiledShaderWithReflection> {
+    Ok(bincode::serde::decode_from_slice(bytes, BINCODE_CFG)?.0)
+}
+
+#[inline]
+fn empty_shader_cache_shell(disk_path: Option<PathBuf>) -> ShaderBytecodeDiskCache {
+    ShaderBytecodeDiskCache {
+        map: HashMap::new(),
+        dirty: false,
+        disk_path,
+        version_ok_on_disk: false,
+    }
+}
+
+pub(crate) struct ShaderBytecodeDiskCache {
+    map: HashMap<u64, Vec<u8>>,
+    dirty: bool,
+    disk_path: Option<PathBuf>,
+    /// `true` iff the disk file envelope matches [`GOLDY_CACHE_VERSION`].
+    version_ok_on_disk: bool,
+}
+
+impl ShaderBytecodeDiskCache {
+    #[must_use]
+    pub(crate) fn new_load_or_empty() -> Self {
+        let Some(cache_root) = dirs::cache_dir() else {
+            return empty_shader_cache_shell(None);
+        };
+
+        let path = cache_root.join("goldy").join("shader_cache.bin.zst");
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => {
+                return empty_shader_cache_shell(Some(path));
+            }
+        };
+
+        let decompressed =
+            match zstd::decode_all(std::io::Cursor::new(&bytes)).map_err(|e| anyhow::anyhow!(e)) {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(?e, "failed ZSTD-decompress shader cache; ignoring");
+                    return empty_shader_cache_shell(Some(path));
+                }
+            };
+
+        let Some(body) = decompressed.strip_prefix(GOLDY_SHADER_CACHE_MAGIC) else {
+            tracing::warn!("shader cache magic mismatch — ignoring cached file");
+            return empty_shader_cache_shell(Some(path));
+        };
+
+        let Some(nl_pos) = body.iter().position(|&b| b == b'\n') else {
+            tracing::warn!("shader cache malformed (no version nl) — ignoring");
+            return empty_shader_cache_shell(Some(path));
+        };
+
+        let ver = match std::str::from_utf8(&body[..nl_pos]) {
+            Ok(v) => v.to_string(),
+            Err(_) => {
+                tracing::warn!("shader cache version not utf-8 — ignoring");
+                return empty_shader_cache_shell(Some(path));
+            }
+        };
+
+        let rest = &body[nl_pos + 1..];
+        if ver != GOLDY_CACHE_VERSION {
+            tracing::debug!(
+                disk = %ver,
+                build = GOLDY_CACHE_VERSION,
+                "shader cache version mismatch — starting cold"
+            );
+            return empty_shader_cache_shell(Some(path));
+        }
+
+        match parse_flat_map(rest) {
+            Ok(map) => Self {
+                map,
+                dirty: false,
+                disk_path: Some(path),
+                version_ok_on_disk: true,
+            },
+            Err(e) => {
+                tracing::warn!(?e, "failed to parse shader cache body — ignoring");
+                empty_shader_cache_shell(Some(path))
+            }
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn get(&mut self, key: u64) -> Option<Result<CompiledShaderWithReflection>> {
+        let blob = self.map.get(&key)?.clone();
+        Some(decode_cached(&blob))
+    }
+
+    pub(crate) fn insert(&mut self, key: u64, value: &CompiledShaderWithReflection) -> Result<()> {
+        let blob = encode_cached(value)?;
+        match self.map.get(&key) {
+            Some(prev) if *prev == blob => return Ok(()),
+            _ => {
+                self.map.insert(key, blob);
+                self.dirty = true;
+            }
+        }
+        Ok(())
+    }
+
+    /// Write through to disk when dirty. Safe to skip if unavailable.
+    pub(crate) fn flush_to_disk_best_effort(&mut self) {
+        if !self.dirty {
+            return;
+        }
+
+        let Some(path) = &self.disk_path else {
+            tracing::trace!("shader cache dirty but no dirs::cache_dir() — skipping write");
+            return;
+        };
+
+        let mut uncompressed = Vec::new();
+        let _ = uncompressed.write_all(GOLDY_SHADER_CACHE_MAGIC);
+        uncompressed
+            .write_all(GOLDY_CACHE_VERSION.as_bytes())
+            .unwrap();
+        uncompressed.write_all(b"\n").unwrap();
+        if flatten_map_to_disk(&mut uncompressed, &self.map).is_ok() {
+            match zstd::encode_all(uncompressed.as_slice(), 10) {
+                Ok(z) => {
+                    if let Some(parent) = path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    if std::fs::write(path, &z).is_ok() {
+                        self.dirty = false;
+                        self.version_ok_on_disk = true;
+                    }
+                }
+                Err(e) => tracing::warn!(?e, "zstd shader cache encode failed"),
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    #[must_use]
+    pub(crate) fn should_skip_save_on_drop(&self) -> bool {
+        !self.dirty
+    }
+
+    #[allow(dead_code)]
+    #[must_use]
+    pub(crate) fn version_ok_on_disk(&self) -> bool {
+        self.version_ok_on_disk
+    }
+}
+
+impl Drop for ShaderBytecodeDiskCache {
+    fn drop(&mut self) {
+        self.flush_to_disk_best_effort();
+    }
+}
+
+fn parse_flat_map(body: &[u8]) -> Result<HashMap<u64, Vec<u8>>> {
+    let mut cursor = 0usize;
+    if cursor + 8 > body.len() {
+        anyhow::bail!("shader cache truncate (count)");
+    }
+    let n = usize::try_from(u64::from_le_bytes(body[cursor..cursor + 8].try_into()?))?;
+    cursor += 8;
+    let mut out = HashMap::with_capacity(n);
+    for _ in 0..n {
+        if cursor + 8 + 4 > body.len() {
+            anyhow::bail!("shader cache truncate (entry hdr)");
+        }
+        let key = u64::from_le_bytes(body[cursor..cursor + 8].try_into()?);
+        cursor += 8;
+        let len = usize::try_from(u32::from_le_bytes(body[cursor..cursor + 4].try_into()?))?;
+        cursor += 4;
+        if cursor + len > body.len() {
+            anyhow::bail!("shader cache truncate (blob)");
+        }
+        out.insert(key, body[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    Ok(out)
+}
+
+fn flatten_map_to_disk(dest: &mut Vec<u8>, map: &HashMap<u64, Vec<u8>>) -> Result<()> {
+    let n_u64 = u64::try_from(map.len())?;
+    dest.write_all(&n_u64.to_le_bytes())?;
+    let mut keys: Vec<u64> = map.keys().copied().collect();
+    keys.sort_unstable();
+    for k in keys {
+        let blob = map.get(&k).expect("key from map iteration");
+        dest.write_all(&k.to_le_bytes())?;
+        let len_u32 = u32::try_from(blob.len())
+            .map_err(|_| anyhow::anyhow!("shader cache blob too large"))?;
+        dest.write_all(&len_u32.to_le_bytes())?;
+        dest.write_all(blob)?;
+    }
+    Ok(())
+}

--- a/src/slang/compiler.rs
+++ b/src/slang/compiler.rs
@@ -34,7 +34,7 @@ pub fn layout_validation_enabled() -> bool {
 // ============================================================================
 
 /// Kind of resource in a parameter block field
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ResourceKind {
     /// A buffer (StructuredBuffer, RWStructuredBuffer, etc.)
     Buffer,
@@ -55,7 +55,7 @@ pub enum ResourceKind {
 }
 
 /// Layout information for a single field within a ParameterBlock
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FieldLayout {
     /// Name of the field
     pub name: String,
@@ -70,7 +70,7 @@ pub struct FieldLayout {
 }
 
 /// Layout information for a ParameterBlock
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ParameterBlockLayout {
     /// Name of the parameter (from shader)
     pub name: String,
@@ -87,7 +87,7 @@ pub struct ParameterBlockLayout {
 }
 
 /// Complete reflection information for a compiled shader
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ShaderReflection {
     /// All parameter blocks found in the shader
     pub parameter_blocks: Vec<ParameterBlockLayout>,
@@ -219,7 +219,7 @@ pub struct LayoutCheck<'a> {
 }
 
 /// Stored on backend [`ShaderState`](crate::backend) for deferred per-stage compilation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OwnedLayoutCheck {
     pub type_name: String,
     pub rust_size: usize,
@@ -241,7 +241,7 @@ impl OwnedLayoutCheck {
 }
 
 /// Compiled shader output with optional reflection data.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CompiledShaderWithReflection {
     /// The compiled shader
     pub shader: CompiledShader,
@@ -250,7 +250,8 @@ pub struct CompiledShaderWithReflection {
 }
 
 /// Shader compilation target.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ShaderTarget {
     /// SPIR-V bytecode for Vulkan
     Spirv,
@@ -276,7 +277,7 @@ impl ShaderTarget {
 }
 
 /// Compiled shader output.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CompiledShader {
     /// The compiled bytecode or source code
     pub data: Vec<u8>,
@@ -318,6 +319,7 @@ impl CompiledShader {
 pub struct SlangCompiler {
     library: Arc<SlangLibrary>,
     global_session: *mut IGlobalSession,
+    shader_disk_cache: std::sync::Mutex<crate::shader_cache::ShaderBytecodeDiskCache>,
 }
 
 // SlangCompiler is Send + Sync because each compilation creates its own request
@@ -355,6 +357,9 @@ impl SlangCompiler {
         Ok(Self {
             library,
             global_session,
+            shader_disk_cache: std::sync::Mutex::new(
+                crate::shader_cache::ShaderBytecodeDiskCache::new_load_or_empty(),
+            ),
         })
     }
 
@@ -628,7 +633,26 @@ impl SlangCompiler {
         layout_checks: &[OwnedLayoutCheck],
         optimization_level: OptimizationLevel,
     ) -> Result<CompiledShaderWithReflection> {
-        self.with_compiled_request(
+        let cache_key = crate::shader_cache::compile_cache_key(
+            source,
+            target,
+            entry_points,
+            defines,
+            layout_checks,
+            optimization_level,
+        );
+
+        {
+            let mut disk = self
+                .shader_disk_cache
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(hit) = disk.get(cache_key) {
+                return hit.with_context(|| "decode shader disk cache");
+            }
+        }
+
+        let out = self.with_compiled_request(
             source,
             target,
             entry_points,
@@ -660,7 +684,19 @@ impl SlangCompiler {
                     reflection,
                 })
             },
-        )
+        )?;
+
+        {
+            let mut disk = self
+                .shader_disk_cache
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Err(e) = disk.insert(cache_key, &out) {
+                tracing::warn!(?e, "failed to serialize shader disk cache entry");
+            }
+        }
+
+        Ok(out)
     }
 
     fn validate_owned_layout_checks(

--- a/src/slang/ffi.rs
+++ b/src/slang/ffi.rs
@@ -358,7 +358,7 @@ pub enum SlangCompileTarget {
 
 /// Shader stage enum
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SlangStage {
     None = 0,
     Vertex = 1,

--- a/src/task_graph/analysis.rs
+++ b/src/task_graph/analysis.rs
@@ -20,7 +20,7 @@
 //!
 //! 4. **Command emission**: waves are serialized into a flat
 //!    `Vec<GpuCommand>` with `ResourceBarrier` commands between waves.
-//!    Each [`NodeKind`](super::ir::NodeKind) variant emits different commands.
+//!    Each [`NodeKind`] variant emits different commands.
 
 use std::collections::{HashMap, HashSet};
 

--- a/src/task_graph/mod.rs
+++ b/src/task_graph/mod.rs
@@ -158,9 +158,9 @@ pub(crate) enum ResourceId {
         offset: u64,
         len: u64,
     },
-    /// Graph-scoped transient; lowered to [`BufferRange`] before submission.
+    /// Graph-scoped transient; lowered to [`ResourceId::BufferRange`] before submission.
     TransientBuffer(TransientId),
-    /// Graph-scoped transient texture; lowered to [`Texture`] before submission.
+    /// Graph-scoped transient texture; lowered to [`crate::Texture`] before submission.
     TransientTexture(TransientTextureId),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,7 +165,7 @@ pub enum DataAccess {
 /// Capturing the category alongside the index lets the CPU API and the
 /// shader-side `goldy_exp` access functions be type-checked against each
 /// other — see [`BindlessHandle`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BindlessCategory {
     /// Storage-buffer slot. Used with `goldy_scattered<T>` / `goldy_buf_ro<T>`
     /// (both shader functions index the same pool).
@@ -486,7 +486,10 @@ pub enum DeviceType {
 /// Controls how aggressively the Slang compiler optimizes generated SPIR-V / DXIL / Metal IR.
 /// Use `None` to work around driver bugs in software renderers (e.g. lavapipe SSA corruption
 /// across barriers).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u8)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum OptimizationLevel {
     /// No optimization — preserves all loads and barriers exactly as written.
     None,

--- a/tests/cache_integration.rs
+++ b/tests/cache_integration.rs
@@ -43,6 +43,10 @@ fn vk_pipeline_cache_file_written_on_drop() {
         ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
     let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
 
+    // Drop pipeline and shader first so their Arc<DeviceInner> refs are released,
+    // allowing `drop(device)` to actually trigger DeviceInner::drop → backend destroy.
+    drop(_pipeline);
+    drop(shader);
     drop(device);
 
     assert!(
@@ -63,6 +67,8 @@ fn vk_pipeline_cache_survives_reload() {
     let shader =
         ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
     let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
+    drop(_pipeline);
+    drop(shader);
     drop(device);
 
     let device2 = instance
@@ -103,6 +109,8 @@ fn shader_cache_file_written_after_compile() {
         ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
     let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
 
+    drop(_pipeline);
+    drop(shader);
     drop(device);
     drop(instance);
 

--- a/tests/cache_integration.rs
+++ b/tests/cache_integration.rs
@@ -1,0 +1,134 @@
+//! Pipeline and shader bytecode cache integration checks.
+#![cfg(any(feature = "vulkan", feature = "dx12"))]
+
+use goldy::shader_cache::{ShaderBytecodeDiskCache, GOLDY_SHADER_CACHE_MAGIC};
+use goldy::{types::BackendType, ComputePipeline, DeviceType, Instance, ShaderModule};
+/// Simple compute shader (same intent as [`compute_integration::DOUBLE_SHADER`]).
+const CACHE_TEST_COMPUTE: &str = r#"
+import goldy_exp;
+
+[goldy_compute]
+[numthreads(64, 1, 1)]
+void cs_main(Scattered<uint> data, ThreadId id) {
+    data[id.x] = data[id.x] * 2;
+}
+"#;
+
+#[cfg(feature = "vulkan")]
+fn try_vulkan_gpu() -> Option<(Instance, goldy::Device)> {
+    let instance = Instance::new().ok()?;
+    let device = instance
+        .create_device(DeviceType::DiscreteGpu)
+        .or_else(|_| instance.create_device(DeviceType::IntegratedGpu))
+        .ok()?;
+    (device.backend_type() == BackendType::Vulkan).then_some((instance, device))
+}
+
+/// [`VkPipelineCache`] is serialized on Vulkan device teardown.
+#[cfg(feature = "vulkan")]
+#[test]
+fn vk_pipeline_cache_file_written_on_drop() {
+    let Some(cache_root) = dirs::cache_dir() else {
+        return;
+    };
+    let Some((instance, device)) = try_vulkan_gpu() else {
+        return;
+    };
+    let adapter_id = device.adapter_id();
+    let expected = cache_root
+        .join("goldy")
+        .join(format!("pipeline_cache_{adapter_id}.bin"));
+
+    let shader =
+        ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
+    let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
+
+    drop(device);
+
+    assert!(
+        expected.exists(),
+        "expected Vulkan pipeline cache at {:?}",
+        expected
+    );
+    drop(instance);
+}
+
+/// Loading a serialized [`VkPipelineCache`] on a subsequent device must not fail.
+#[cfg(feature = "vulkan")]
+#[test]
+fn vk_pipeline_cache_survives_reload() {
+    let Some((instance, device)) = try_vulkan_gpu() else {
+        return;
+    };
+    let shader =
+        ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
+    let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
+    drop(device);
+
+    let device2 = instance
+        .create_device(DeviceType::DiscreteGpu)
+        .or_else(|_| instance.create_device(DeviceType::IntegratedGpu))
+        .expect("second device create");
+    assert_eq!(
+        device2.backend_type(),
+        BackendType::Vulkan,
+        "second device backend mismatch"
+    );
+    let shader2 = ShaderModule::from_slang(&device2, CACHE_TEST_COMPUTE).expect("compile phase 2");
+    let _pipeline2 =
+        ComputePipeline::new(&device2, &shader2).expect("compute pipeline after reload");
+}
+
+/// Compiled Slang shaders flush `shader_cache.bin.zst` on [`Device`] / compiler teardown.
+#[test]
+fn shader_cache_file_written_after_compile() {
+    let Some(cache_root) = dirs::cache_dir() else {
+        return;
+    };
+    let path = cache_root.join("goldy").join("shader_cache.bin.zst");
+
+    let instance = match Instance::new() {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+    let device = match instance
+        .create_device(DeviceType::DiscreteGpu)
+        .or_else(|_| instance.create_device(DeviceType::IntegratedGpu))
+    {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let shader =
+        ShaderModule::from_slang(&device, CACHE_TEST_COMPUTE).expect("compile CACHE_TEST_COMPUTE");
+    let _pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
+
+    drop(device);
+    drop(instance);
+
+    assert!(
+        path.exists(),
+        "expected Slang bytecode cache file at {:?}",
+        path
+    );
+}
+
+/// Wrong version line in envelope → cold [`ShaderBytecodeDiskCache`] (does not corrupt process cache).
+#[test]
+fn shader_cache_stale_version_is_ignored() {
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let path = td.path().join("shader_cache.bin.zst");
+    let mut uncompressed = Vec::new();
+    uncompressed.extend_from_slice(GOLDY_SHADER_CACHE_MAGIC.as_slice());
+    uncompressed.extend_from_slice(b"fictional-stale-goldy-version\n");
+    uncompressed.extend_from_slice(&0u64.to_le_bytes());
+    let compressed = zstd::encode_all(uncompressed.as_slice(), 10).expect("zstd encode");
+    std::fs::write(&path, compressed).expect("write test cache blob");
+
+    let cache = ShaderBytecodeDiskCache::new_at_path(path);
+    assert!(
+        !cache.version_ok_on_disk(),
+        "stale envelope must not flag version_ok"
+    );
+    assert!(cache.is_empty(), "cold map when version mismatches build");
+}

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -1314,8 +1314,8 @@ void cs_main(DirectSpatial<float4> output, ThreadId id) {
     )
     .expect("texture");
 
-    let wg_x = (width + 7) / 8;
-    let wg_y = (height + 7) / 8;
+    let wg_x = width.div_ceil(8);
+    let wg_y = height.div_ceil(8);
     let mut encoder = ComputeEncoder::new();
     {
         let mut pass = encoder.begin_compute_pass();
@@ -1650,6 +1650,7 @@ void cs_main(Scattered<float> out, float value, ThreadId id) {
     let pipeline = ComputePipeline::new(&device, &shader).expect("pipeline");
     let out = Buffer::with_data(&device, &[0u32; 1], DataAccess::Scattered).expect("out");
 
+    #[allow(clippy::approx_constant)]
     let value: f32 = 3.14159;
     let bits = value.to_bits();
 


### PR DESCRIPTION
- Introduced a persistent shader compilation cache in `shader_cache.rs`, allowing for efficient reuse of compiled shaders.
- Implemented cache versioning in `build.rs` to invalidate the cache when necessary.
- Added PSO caching mechanisms in the DX12 backend, including loading and saving cached PSO blobs to disk.
- Updated the `LogicalDevice` struct to manage cached PSO blobs and track cache state.
- Enhanced Vulkan backend to support pipeline cache persistence across device lifetimes.
- Integrated `serde` for serialization and deserialization of various data structures, improving data handling in shader and resource management.
- Updated relevant modules to utilize the new caching mechanisms, optimizing shader compilation and pipeline state management.