### PR TITLE
Refactor Vulkan backend image handling and synchronization

### DIFF
--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -1131,7 +1131,9 @@ fn present_args(mode: crate::types::PresentMode, allow_tearing: bool) -> (u32, D
             if allow_tearing {
                 (0, DXGI_PRESENT_ALLOW_TEARING)
             } else {
-                (0, DXGI_PRESENT(0))
+                // Flip-model swapchains without DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING: Present(0,0)
+                // without ALLOW_TEARING has triggered DXGI_ERROR_DEVICE_REMOVED on some drivers.
+                (1, DXGI_PRESENT(0))
             }
         }
     }

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -238,11 +238,9 @@ pub(super) fn submit(
         let signal_value = {
             let ld = state
                 .devices
-                .get_mut(&device_handle)
+                .get(&device_handle)
                 .context("Invalid device handle")?;
-            let v = ld.timeline_next;
-            ld.timeline_next += 1;
-            v
+            ld.timeline_next
         };
         let ld = state
             .devices
@@ -254,15 +252,16 @@ pub(super) fn submit(
             .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
         let submit_info2 =
             vk::SubmitInfo2::default().signal_semaphore_infos(std::slice::from_ref(&signal_info));
-        unsafe {
+        let r = unsafe {
             ld.device.queue_submit2(
                 ld.queue,
                 std::slice::from_ref(&submit_info2),
                 vk::Fence::null(),
             )
-        }
-        .context("Failed queue_submit2 for empty compute submit")?;
+        };
+        r.context("Failed queue_submit2 for empty compute submit")?;
         if let Some(ld) = state.devices.get_mut(&device_handle) {
+            ld.timeline_next = signal_value.saturating_add(1);
             ld.process_deletion_queue_up_to_gpu_progress();
         }
         return Ok(signal_value);
@@ -700,11 +699,9 @@ pub(super) fn submit(
     let signal_value = {
         let ld = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
-        let v = ld.timeline_next;
-        ld.timeline_next += 1;
-        v
+        ld.timeline_next
     };
 
     let submit_device_core = state
@@ -736,6 +733,10 @@ pub(super) fn submit(
             "Failed to queue_submit2 command buffer: {:?}",
             e
         ));
+    }
+
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.timeline_next = signal_value.saturating_add(1);
     }
 
     state

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -326,6 +326,8 @@ pub(super) fn create(
     let handle = *next_surface_handle;
     *next_surface_handle += 1;
 
+    let swapchain_image_was_presented = vec![false; swapchain_images.len()];
+
     surfaces.insert(
         handle,
         SurfaceState {
@@ -333,6 +335,7 @@ pub(super) fn create(
             surface,
             swapchain,
             swapchain_images,
+            swapchain_image_was_presented,
             swapchain_image_views,
             width: extent.width,
             height: extent.height,
@@ -631,26 +634,58 @@ pub(super) fn acquire(
             }
             .context("Failed to begin acquire prep command buffer")?;
 
-            let prep_barrier = vk::ImageMemoryBarrier2::default()
-                .src_stage_mask(vk::PipelineStageFlags2::TOP_OF_PIPE)
-                .src_access_mask(vk::AccessFlags2::NONE)
-                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-                .dst_access_mask(
-                    vk::AccessFlags2::SHADER_WRITE
-                        | vk::AccessFlags2::SHADER_READ
-                        | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
-                        | vk::AccessFlags2::TRANSFER_WRITE,
-                )
-                .old_layout(vk::ImageLayout::UNDEFINED)
-                .new_layout(vk::ImageLayout::GENERAL)
-                .image(image)
-                .subresource_range(vk::ImageSubresourceRange {
-                    aspect_mask: vk::ImageAspectFlags::COLOR,
-                    base_mip_level: 0,
-                    level_count: 1,
-                    base_array_layer: 0,
-                    layer_count: 1,
-                });
+            let was_presented = {
+                let surface_state = state.surfaces.get(&surface_handle).unwrap();
+                surface_state
+                    .swapchain_image_was_presented
+                    .get(image_index as usize)
+                    .copied()
+                    .unwrap_or(false)
+            };
+
+            let prep_barrier = if was_presented {
+                vk::ImageMemoryBarrier2::default()
+                    .src_stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
+                    .src_access_mask(vk::AccessFlags2::NONE)
+                    .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                    .dst_access_mask(
+                        vk::AccessFlags2::SHADER_WRITE
+                            | vk::AccessFlags2::SHADER_READ
+                            | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+                            | vk::AccessFlags2::TRANSFER_WRITE,
+                    )
+                    .old_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+                    .new_layout(vk::ImageLayout::GENERAL)
+                    .image(image)
+                    .subresource_range(vk::ImageSubresourceRange {
+                        aspect_mask: vk::ImageAspectFlags::COLOR,
+                        base_mip_level: 0,
+                        level_count: 1,
+                        base_array_layer: 0,
+                        layer_count: 1,
+                    })
+            } else {
+                vk::ImageMemoryBarrier2::default()
+                    .src_stage_mask(vk::PipelineStageFlags2::TOP_OF_PIPE)
+                    .src_access_mask(vk::AccessFlags2::NONE)
+                    .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                    .dst_access_mask(
+                        vk::AccessFlags2::SHADER_WRITE
+                            | vk::AccessFlags2::SHADER_READ
+                            | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+                            | vk::AccessFlags2::TRANSFER_WRITE,
+                    )
+                    .old_layout(vk::ImageLayout::UNDEFINED)
+                    .new_layout(vk::ImageLayout::GENERAL)
+                    .image(image)
+                    .subresource_range(vk::ImageSubresourceRange {
+                        aspect_mask: vk::ImageAspectFlags::COLOR,
+                        base_mip_level: 0,
+                        level_count: 1,
+                        base_array_layer: 0,
+                        layer_count: 1,
+                    })
+            };
             let dep_info = vk::DependencyInfo::default()
                 .image_memory_barriers(std::slice::from_ref(&prep_barrier));
             unsafe {
@@ -663,7 +698,9 @@ pub(super) fn acquire(
                 .context("Failed to end acquire prep command buffer")?;
 
             let wait_semaphores = [image_available_semaphore];
-            let wait_stages = [vk::PipelineStageFlags::TOP_OF_PIPE];
+            // Match WSI acquire guidance: wait at COLOR_ATTACHMENT_OUTPUT, not TOP_OF_PIPE,
+            // so the layout transition cannot start before the presentation engine releases the image.
+            let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
             let signal_semaphores = [image_ready_semaphore];
             let prep_submit = vk::SubmitInfo::default()
                 .wait_semaphores(&wait_semaphores)
@@ -1028,11 +1065,9 @@ where
     // prep submit already consumed the latter to transition the image into `GENERAL`.
     let signal_timeline_value = {
         let ld = devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Surface's device is invalid")?;
-        let v = ld.timeline_next;
-        ld.timeline_next += 1;
-        v
+        ld.timeline_next
     };
     let timeline_sem = devices
         .get(&device_handle)
@@ -1041,10 +1076,12 @@ where
 
     let wait_info = vk::SemaphoreSubmitInfo::default()
         .semaphore(image_ready_semaphore)
+        .value(0)
         .stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT);
     let cmd_info = vk::CommandBufferSubmitInfo::default().command_buffer(cmd);
     let bin_signal = vk::SemaphoreSubmitInfo::default()
         .semaphore(render_finished_semaphore)
+        .value(0)
         .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
     let timeline_signal = vk::SemaphoreSubmitInfo::default()
         .semaphore(timeline_sem)
@@ -1060,14 +1097,17 @@ where
         .get(&device_handle)
         .context("Surface's device is invalid")?;
 
-    unsafe {
+    let submit_r = unsafe {
         logical_device.device.queue_submit2(
             logical_device.queue,
             std::slice::from_ref(&submit2),
             in_flight_fence,
         )
+    };
+    submit_r.context("Failed to submit command buffer")?;
+    if let Some(ld) = devices.get_mut(&device_handle) {
+        ld.timeline_next = signal_timeline_value.saturating_add(1);
     }
-    .context("Failed to submit command buffer")?;
 
     if let Some(surface_state) = surfaces.get_mut(&surface_handle) {
         let fs = &mut surface_state.frame_sync[current_frame];
@@ -1183,11 +1223,17 @@ pub(super) fn present(
             }
             .context("Failed to begin compute-present barrier command buffer")?;
 
+            // Match the graphics present barrier shape (color path uses COLOR_ATTACHMENT_OUTPUT
+            // → BOTTOM_OF_PIPE). Compute writes swapchain images in GENERAL; use compute/transfer
+            // stages—not ALL_COMMANDS + generic MEMORY_*—so WSI sees a well-defined handoff to
+            // PRESENT_SRC_KHR (broad barriers have provoked device loss on some Windows stacks).
             let barrier = vk::ImageMemoryBarrier2::default()
-                .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-                .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
-                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-                .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+                .src_stage_mask(
+                    vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::TRANSFER,
+                )
+                .src_access_mask(vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE)
+                .dst_stage_mask(vk::PipelineStageFlags2::BOTTOM_OF_PIPE)
+                .dst_access_mask(vk::AccessFlags2::NONE)
                 .old_layout(vk::ImageLayout::GENERAL)
                 .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
                 .image(image)
@@ -1227,28 +1273,10 @@ pub(super) fn present(
         let signal_timeline_value = {
             let ld = state
                 .devices
-                .get_mut(&device_handle)
+                .get(&device_handle)
                 .context("Surface's device is invalid")?;
-            let v = ld.timeline_next;
-            ld.timeline_next += 1;
-            v
+            ld.timeline_next
         };
-
-        if !deferred.is_empty() {
-            state
-                .staging_belts
-                .entry(device_handle)
-                .or_insert_with(|| {
-                    super::staging::StagingBelt::new(super::staging::DEFAULT_STAGING_CHUNK_SIZE)
-                })
-                .finish(signal_timeline_value);
-        }
-        if !pending_tex_upload_staging.is_empty() {
-            state.compute_texture_staging_pool.insert(
-                (device_handle, signal_timeline_value),
-                pending_tex_upload_staging,
-            );
-        }
 
         let timeline_sem = state
             .devices
@@ -1265,9 +1293,11 @@ pub(super) fn present(
 
         let wait_info = vk::SemaphoreSubmitInfo::default()
             .semaphore(image_ready_sem_present)
-            .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
+            .value(0)
+            .stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT);
         let bin_signal = vk::SemaphoreSubmitInfo::default()
             .semaphore(render_finished_sem_present)
+            .value(0)
             .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
         let timeline_signal = vk::SemaphoreSubmitInfo::default()
             .semaphore(timeline_sem)
@@ -1290,7 +1320,7 @@ pub(super) fn present(
                 in_flight_fence_present,
             )
         };
-        if let Err(e) = &submit_result {
+        if let Err(e) = submit_result {
             tracing::warn!(
                 surface_handle,
                 %device_handle,
@@ -1299,8 +1329,31 @@ pub(super) fn present(
                 result = ?e,
                 "single-submit compute+present queue_submit2 failed"
             );
+            let s = state.surfaces.get_mut(&surface_handle).unwrap();
+            s.frame_sync[current_frame].deferred_compute_cbs = deferred;
+            s.frame_sync[current_frame].pending_compute_texture_staging =
+                pending_tex_upload_staging;
+            anyhow::bail!("Failed to submit compute+present: {:?}", e);
         }
-        submit_result.context("Failed to submit compute+present")?;
+
+        let ld_timeline = state.devices.get_mut(&device_handle).unwrap();
+        ld_timeline.timeline_next = signal_timeline_value.saturating_add(1);
+
+        if !deferred.is_empty() {
+            state
+                .staging_belts
+                .entry(device_handle)
+                .or_insert_with(|| {
+                    super::staging::StagingBelt::new(super::staging::DEFAULT_STAGING_CHUNK_SIZE)
+                })
+                .finish(signal_timeline_value);
+        }
+        if !pending_tex_upload_staging.is_empty() {
+            state.compute_texture_staging_pool.insert(
+                (device_handle, signal_timeline_value),
+                pending_tex_upload_staging,
+            );
+        }
 
         for cb in &deferred {
             state
@@ -1337,6 +1390,8 @@ pub(super) fn present(
         .image_indices(&image_indices);
 
     let result = unsafe { swapchain_loader.queue_present(present_ld.queue, &present_info) };
+    // `queue_present` returns Ok on SUCCESS and SUBOPTIMAL_KHR; Err on real failures.
+    let mark_image_presented = result.is_ok();
     if let Err(e) = &result {
         tracing::warn!(
             surface_handle,
@@ -1350,12 +1405,20 @@ pub(super) fn present(
 
     // Clear the current image and advance frame counter
     let surface_state = state.surfaces.get_mut(&surface_handle).unwrap();
+    if mark_image_presented {
+        if let Some(flag) = surface_state
+            .swapchain_image_was_presented
+            .get_mut(image_index as usize)
+        {
+            *flag = true;
+        }
+    }
     surface_state.current_image_index = None;
     surface_state.current_frame = (surface_state.current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
 
     // Handle suboptimal or out of date
     match result {
-        Ok(_) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) | Err(vk::Result::SUBOPTIMAL_KHR) => {
+        Ok(_) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
             let timeline_value = {
                 let surface_state = state
                     .surfaces
@@ -1590,6 +1653,8 @@ pub(super) fn resize(
     if let Some(surface_state) = surfaces.get_mut(&surface_handle) {
         surface_state.swapchain = new_swapchain;
         surface_state.swapchain_images = swapchain_images;
+        surface_state.swapchain_image_was_presented =
+            vec![false; surface_state.swapchain_images.len()];
         surface_state.swapchain_image_views = swapchain_image_views;
         surface_state.width = extent.width;
         surface_state.height = extent.height;

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -1078,14 +1078,14 @@ pub(super) fn transition_image_layout(
 
         let cmd_buffers_arr = [cmd];
         let submit_info = vk::SubmitInfo::default().command_buffers(&cmd_buffers_arr);
-        logical_device
-            .device
-            .queue_submit(logical_device.queue, &[submit_info], vk::Fence::null())
-            .context("Failed to submit layout transition")?;
-        logical_device
-            .device
-            .queue_wait_idle(logical_device.queue)
-            .context("Failed to wait for layout transition")?;
+        let sub = logical_device.device.queue_submit(
+            logical_device.queue,
+            &[submit_info],
+            vk::Fence::null(),
+        );
+        sub.context("Failed to submit layout transition")?;
+        let wait = logical_device.device.queue_wait_idle(logical_device.queue);
+        wait.context("Failed to wait for layout transition")?;
 
         logical_device
             .device

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -544,10 +544,10 @@ pub const MAX_FRAMES_IN_FLIGHT: usize = 3;
 pub(crate) struct FrameSync {
     pub command_buffer: vk::CommandBuffer,
     /// Dedicated command buffer for the acquire-time "prep" submit that transitions
-    /// the newly-acquired swapchain image from `UNDEFINED` to `GENERAL` so that compute
-    /// shaders can write it via `RWTexture2D`. Consumes `image_available_semaphore`
-    /// and signals `image_ready_semaphore`; later render/present submits wait on the
-    /// latter.
+    /// the newly-acquired swapchain image to `GENERAL` (`UNDEFINED → GENERAL` on first
+    /// use, `PRESENT_SRC_KHR → GENERAL` after that image has been presented). Consumes
+    /// `image_available_semaphore` and signals `image_ready_semaphore`; later render/present
+    /// submits wait on the latter.
     pub prep_command_buffer: vk::CommandBuffer,
     pub image_available_semaphore: vk::Semaphore,
     /// Signaled by the acquire-time prep submit once the swapchain image is in
@@ -582,6 +582,9 @@ pub(crate) struct SurfaceState {
     pub surface: vk::SurfaceKHR,
     pub swapchain: vk::SwapchainKHR,
     pub swapchain_images: Vec<vk::Image>,
+    /// After an image is successfully presented, the next acquire sees it in
+    /// `PRESENT_SRC_KHR` and must use that as `oldLayout` in the prep barrier.
+    pub swapchain_image_was_presented: Vec<bool>,
     pub swapchain_image_views: Vec<vk::ImageView>,
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
- Updated the Vulkan backend to improve image layout transitions and synchronization during swapchain image acquisition and presentation.
- Introduced a new `swapchain_image_was_presented` vector to track the presentation state of swapchain images, ensuring correct layout transitions based on whether an image has been presented.
- Enhanced error handling for command buffer submissions and added context to improve debugging.
- Adjusted pipeline stage masks to align with WSI acquire guidance, preventing potential device loss issues on certain drivers.

This refactor aims to enhance stability and performance in Vulkan image handling.