### PR TITLE
Align shader disk cache key with post–virtual-main Slang source

### DIFF
--- a/src/shader_cache.rs
+++ b/src/shader_cache.rs
@@ -57,6 +57,10 @@ fn stage_tag(s: SlangStage) -> u8 {
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Stable disk-cache key for a Slang compile.
+///
+/// `source` must be the exact translation-unit text Slang compiles (after
+/// [`crate::slang::virtual_main::effective_slang_source_for_compile`] when `[goldy_*]` markers apply).
 pub(crate) fn compile_cache_key(
     source: &str,
     target: ShaderTarget,
@@ -317,8 +321,10 @@ fn flatten_map_to_disk(dest: &mut Vec<u8>, map: &HashMap<u64, Vec<u8>>) -> Resul
 mod tests {
     use super::*;
     use crate::slang::{
-        ffi::SlangStage, CompiledShader, CompiledShaderWithReflection, OwnedLayoutCheck,
-        ShaderReflection, ShaderTarget,
+        ffi::SlangStage,
+        virtual_main::{effective_slang_source_for_compile, transform_virtual_main},
+        CompiledShader, CompiledShaderWithReflection, OwnedLayoutCheck, ShaderReflection,
+        ShaderTarget,
     };
     use crate::types::OptimizationLevel;
     use tempfile::TempDir;
@@ -438,6 +444,92 @@ mod tests {
         assert_ne!(
             base_key,
             compile_cache_key(src, tgt, &eps, &defs, &layouts2, opt)
+        );
+    }
+
+    /// Disk cache keys must follow the same effective source as Slang (`compile_with_reflection`).
+    #[test]
+    fn compile_cache_key_stable_for_effective_goldy_source() {
+        let goldy_src = r#"import goldy_exp;
+
+[goldy_compute]
+[numthreads(64, 1, 1)]
+void cs_main(Scattered<uint> data, ThreadId id) {
+    data[id.x] = data[id.x] * 2;
+}
+"#;
+        let (tgt, eps, defs, layouts, opt) = (
+            ShaderTarget::Spirv,
+            vec![("cs_main", SlangStage::Compute)],
+            vec![("X", "1")],
+            Vec::<OwnedLayoutCheck>::new(),
+            OptimizationLevel::None,
+        );
+        let transformed = transform_virtual_main(goldy_src);
+        let k_effective = compile_cache_key(
+            effective_slang_source_for_compile(goldy_src).as_ref(),
+            tgt,
+            &eps,
+            &defs,
+            &layouts,
+            opt,
+        );
+        let k_transformed_only =
+            compile_cache_key(transformed.as_str(), tgt, &eps, &defs, &layouts, opt);
+        assert_eq!(
+            k_effective, k_transformed_only,
+            "cache key must hash post-transform source, matching transform_virtual_main output"
+        );
+    }
+
+    /// Raw `[goldy_*]` source differs from what Slang compiles; keys must not use raw alone.
+    #[test]
+    fn compile_cache_key_goldy_raw_differs_from_effective() {
+        let goldy_src = r#"[goldy_compute]
+[numthreads(8, 8, 1)]
+void cs_main(Scattered<uint> buf, ThreadId id) { buf[id.x] = 0; }
+"#;
+        let (tgt, eps, defs, layouts, opt) = (
+            ShaderTarget::Spirv,
+            vec![("cs_main", SlangStage::Compute)],
+            vec![] as Vec<(&str, &str)>,
+            Vec::<OwnedLayoutCheck>::new(),
+            OptimizationLevel::Default,
+        );
+        assert_ne!(
+            compile_cache_key(goldy_src, tgt, &eps, &defs, &layouts, opt),
+            compile_cache_key(
+                effective_slang_source_for_compile(goldy_src).as_ref(),
+                tgt,
+                &eps,
+                &defs,
+                &layouts,
+                opt,
+            ),
+            "pre-transform and effective sources must not collide in the cache key"
+        );
+    }
+
+    #[test]
+    fn compile_cache_key_plain_source_matches_effective_helper() {
+        let src = "float4 main() : SV_Target0 { return 0; }";
+        let (tgt, eps, defs, layouts, opt) = (
+            ShaderTarget::Spirv,
+            vec![("main", SlangStage::Fragment)],
+            vec![] as Vec<(&str, &str)>,
+            Vec::<OwnedLayoutCheck>::new(),
+            OptimizationLevel::Default,
+        );
+        assert_eq!(
+            compile_cache_key(src, tgt, &eps, &defs, &layouts, opt),
+            compile_cache_key(
+                effective_slang_source_for_compile(src).as_ref(),
+                tgt,
+                &eps,
+                &defs,
+                &layouts,
+                opt,
+            )
         );
     }
 

--- a/src/slang/compiler.rs
+++ b/src/slang/compiler.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use super::ffi::*;
 use super::loader::SlangLibrary;
-use super::virtual_main::transform_virtual_main;
+use super::virtual_main::effective_slang_source_for_compile;
 use crate::types::OptimizationLevel;
 use crate::{goldy_event, goldy_span};
 
@@ -427,6 +427,10 @@ impl SlangCompiler {
     }
 
     /// Shared session + compile path; invokes `f` with the live compile request after `spCompile` succeeds.
+    ///
+    /// `source` must be the effective Slang translation-unit text (after
+    /// [`super::virtual_main::effective_slang_source_for_compile`] when applicable). Virtual-main
+    /// rewriting is not applied here so it runs once per logical compile.
     #[allow(clippy::too_many_arguments)] // mirrors public compile entry points
     fn with_compiled_request<R>(
         &self,
@@ -550,18 +554,6 @@ impl SlangCompiler {
             anyhow::bail!("Failed to add translation unit");
         }
 
-        // Apply virtual-main transform: [goldy_*] entry points → [shader(...)] wrappers.
-        let transformed_source;
-        let source = if source.contains("[goldy_compute]")
-            || source.contains("[goldy_vertex]")
-            || source.contains("[goldy_fragment]")
-        {
-            transformed_source = transform_virtual_main(source);
-            &transformed_source as &str
-        } else {
-            source
-        };
-
         let source_path = CString::new("shader.slang").unwrap();
         let source_cstr = CString::new(source).context("Source contains null bytes")?;
         unsafe {
@@ -633,8 +625,11 @@ impl SlangCompiler {
         layout_checks: &[OwnedLayoutCheck],
         optimization_level: OptimizationLevel,
     ) -> Result<CompiledShaderWithReflection> {
+        // Hash the same string Slang compiles (post virtual-main transform). This runs on cache
+        // hits too; a micro-optimization could cache keys per `(Arc<str>, …)` if needed.
+        let effective = effective_slang_source_for_compile(source);
         let cache_key = crate::shader_cache::compile_cache_key(
-            source,
+            effective.as_ref(),
             target,
             entry_points,
             defines,
@@ -653,7 +648,7 @@ impl SlangCompiler {
         }
 
         let out = self.with_compiled_request(
-            source,
+            effective.as_ref(),
             target,
             entry_points,
             search_paths,
@@ -728,8 +723,9 @@ impl SlangCompiler {
     ) -> Result<StructLayout> {
         let defines = Self::bindless_defines_for_target(target);
         let entry_points = &[("vs_main", SlangStage::Vertex)];
+        let effective = effective_slang_source_for_compile(shader_source);
         self.with_compiled_request(
-            shader_source,
+            effective.as_ref(),
             target,
             entry_points,
             search_paths,

--- a/src/slang/virtual_main.rs
+++ b/src/slang/virtual_main.rs
@@ -37,6 +37,7 @@
 //! }
 //! ```
 
+use std::borrow::Cow;
 use std::ops::Range;
 
 // ---------------------------------------------------------------------------
@@ -176,6 +177,25 @@ pub fn transform_virtual_main(source: &str) -> String {
     // Reset Slang's line counter to 1 so that diagnostics for the user's code
     // are reported at the original source lines, not offset by the generated prefix.
     wrapper_block + "#line 1\n" + &modified
+}
+
+/// Slang translation-unit source after the optional virtual-main rewrite.
+///
+/// This matches the compiler gate: [`transform_virtual_main`] runs only when `source`
+/// contains `[goldy_compute]`, `[goldy_vertex]`, or `[goldy_fragment]` as substrings
+/// (the same [`str::contains`] checks previously used before calling Slang).
+///
+/// Callers that feed Slang directly (disk cache keys, `add_translation_unit_source_string`) should
+/// use this so the hashed text matches the compiled text.
+pub fn effective_slang_source_for_compile(source: &str) -> Cow<'_, str> {
+    if source.contains("[goldy_compute]")
+        || source.contains("[goldy_vertex]")
+        || source.contains("[goldy_fragment]")
+    {
+        Cow::Owned(transform_virtual_main(source))
+    } else {
+        Cow::Borrowed(source)
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Slang disk cache key for `compile_with_reflection` previously hashed the caller’s raw source while compilation could feed Slang `transform_virtual_main` output when `[goldy_compute]`, `[goldy_vertex]`, or `[goldy_fragment]` appeared. That mismatch could serve wrong cached bytecode if the transform or inputs diverged from what was hashed.

## Changes

- Add `effective_slang_source_for_compile` in `src/slang/virtual_main.rs`, using the same `str::contains` gate as before, returning `Cow<str>` (borrowed when no transform).
- `compile_with_reflection` computes effective source once, hashes it for `compile_cache_key`, and passes it into `with_compiled_request`.
- `with_compiled_request` no longer applies the virtual-main transform (callers pass effective source); `reflect_struct_layout` uses the helper as well.
- Document the cache-key source contract on `compile_cache_key` and note that the transform runs on cache hits to build the key.
- New `shader_cache` tests: stable key for effective goldy source vs `transform_virtual_main`, raw goldy differs from effective, plain source matches helper.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features -- -D warnings` and `cargo clippy -- -D warnings`
- `cargo test -p goldy --lib` (349 tests)
- `cargo test -p goldy --test cache_integration` (4 tests)

Note: In this environment `c++` defaulted to Clang without libstdc++ headers for `nv-flip-sys`; dev tests used `CXX=g++ CC=gcc`. Full `cargo test -p goldy` also runs Vulkan validation subprocess tests that require the validation layer when enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ae0147a-322f-417a-9ca9-3b4adda9045a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ae0147a-322f-417a-9ca9-3b4adda9045a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

