### PR TITLE
gitignore: ignore local .cargo-cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target/
 Cargo.lock
 
+# Local Cargo home (e.g. CI/agents when global registry is not writable)
+.cargo-cache/
+
 # Output files from examples (but not test reference screenshots)
 *.png
 !tests/screenshots/*.png


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cargo-cache/` to `.gitignore` so a repo-local `CARGO_HOME` (used when the global Cargo registry is not writable) does not appear as untracked noise or get committed by mistake.

## Context

No functional code changes. Issue #124’s `Device::flush_deferred_deletions()` API is already on `main`; this commit only addresses workspace hygiene after agent/CI builds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70ad4e6-dbb2-4b37-91e1-0046b56bb5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70ad4e6-dbb2-4b37-91e1-0046b56bb5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

