### PR TITLE
refactor(backend): PipelineDesc / ShaderDesc for issue #120

### DIFF
--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -540,12 +540,14 @@ impl GpuBackend for Dx12Backend {
     ) -> Result<ShaderHandle> {
         shader::create_with_checks(
             &mut self.state,
-            device_handle,
-            slang_source,
-            search_paths,
-            defines,
-            optimization_level,
-            layout_checks,
+            crate::backend::shared::ShaderDesc::new(
+                device_handle,
+                slang_source,
+                search_paths,
+                defines,
+                optimization_level,
+            )
+            .with_layout_checks(layout_checks),
         )
     }
 
@@ -562,15 +564,15 @@ impl GpuBackend for Dx12Backend {
         topology: PrimitiveTopology,
         target_format: TextureFormat,
     ) -> Result<PipelineHandle> {
-        pipeline::create(
-            &mut self.state,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format);
+        let desc = crate::backend::shared::GraphicsPipelineCreateDesc {
             device_handle,
             vertex_shader,
             fragment_shader,
-            vertex_layout,
-            topology,
-            target_format,
-        )
+            raster: &raster,
+        };
+        pipeline::create(&mut self.state, &desc)
     }
     fn destroy_pipeline(&mut self, pipeline_handle: PipelineHandle) {
         pipeline::destroy(&mut self.state, pipeline_handle);
@@ -744,16 +746,16 @@ impl GpuBackend for Dx12Backend {
         target_format: TextureFormat,
         depth_stencil: Option<&crate::types::DepthStencilState>,
     ) -> Result<PipelineHandle> {
-        pipeline::create_with_depth(
-            &mut self.state,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format)
+                .with_depth_stencil(depth_stencil);
+        let desc = crate::backend::shared::GraphicsPipelineCreateDesc {
             device_handle,
             vertex_shader,
             fragment_shader,
-            vertex_layout,
-            topology,
-            target_format,
-            depth_stencil,
-        )
+            raster: &raster,
+        };
+        pipeline::create_with_depth(&mut self.state, &desc)
     }
 
     fn create_render_target_with_depth(

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -1,21 +1,21 @@
 //! Pipeline creation and management.
 
 use super::types::PipelineState;
-use super::{pso_cache, shader, utils, DeviceHandle, Dx12State, PipelineHandle, ShaderHandle};
-use crate::types::{DepthStencilState, PrimitiveTopology, TextureFormat, VertexBufferLayout};
+use super::{pso_cache, shader, utils, DeviceHandle, Dx12State, PipelineHandle};
 use anyhow::{Context, Result};
 use windows::Win32::Graphics::{Direct3D12::*, Dxgi::Common::*};
 
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 pub(super) fn create(
     state: &mut Dx12State,
-    device_handle: DeviceHandle,
-    vertex_shader: ShaderHandle,
-    fragment_shader: ShaderHandle,
-    vertex_layout: &VertexBufferLayout,
-    topology: PrimitiveTopology,
-    target_format: TextureFormat,
+    desc: &crate::backend::shared::GraphicsPipelineCreateDesc<'_>,
 ) -> Result<PipelineHandle> {
+    let device_handle = desc.device_handle;
+    let vertex_shader = desc.vertex_shader;
+    let fragment_shader = desc.fragment_shader;
+    let vertex_layout = desc.raster.vertex_layout;
+    let topology = desc.raster.topology;
+    let target_format = desc.raster.target_format;
     // Compile shaders on-demand
     let vs_bytecode =
         shader::ensure_stage_compiled(state, vertex_shader, crate::slang::SlangStage::Vertex)?;
@@ -226,17 +226,18 @@ pub(super) fn create(
 }
 
 /// Create a graphics pipeline with depth testing.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 pub(super) fn create_with_depth(
     state: &mut Dx12State,
-    device_handle: DeviceHandle,
-    vertex_shader: ShaderHandle,
-    fragment_shader: ShaderHandle,
-    vertex_layout: &VertexBufferLayout,
-    topology: PrimitiveTopology,
-    target_format: TextureFormat,
-    depth_stencil: Option<&DepthStencilState>,
+    desc: &crate::backend::shared::GraphicsPipelineCreateDesc<'_>,
 ) -> Result<PipelineHandle> {
+    let device_handle = desc.device_handle;
+    let vertex_shader = desc.vertex_shader;
+    let fragment_shader = desc.fragment_shader;
+    let vertex_layout = desc.raster.vertex_layout;
+    let topology = desc.raster.topology;
+    let target_format = desc.raster.target_format;
+    let depth_stencil = desc.raster.depth_stencil;
     let vs_bytecode =
         shader::ensure_stage_compiled(state, vertex_shader, crate::slang::SlangStage::Vertex)?;
     let fs_bytecode =

--- a/src/backend/dx12/shader.rs
+++ b/src/backend/dx12/shader.rs
@@ -6,23 +6,19 @@ use anyhow::{Context, Result};
 
 pub(super) fn create_with_checks(
     state: &mut Dx12State,
-    device_handle: DeviceHandle,
-    slang_source: &str,
-    search_paths: &[&str],
-    defines: &[(&str, &str)],
-    optimization_level: crate::types::OptimizationLevel,
-    layout_checks: Vec<crate::slang::OwnedLayoutCheck>,
+    desc: crate::backend::shared::ShaderDesc<'_>,
 ) -> Result<ShaderHandle> {
     let _ = state
         .devices
-        .get(&device_handle)
+        .get(&desc.device)
         .context("Invalid device handle")?;
 
     let handle = state.next_shader_handle;
     state.next_shader_handle += 1;
 
-    let stored_paths: Vec<String> = search_paths.iter().map(|s| s.to_string()).collect();
-    let stored_defines: Vec<(String, String)> = defines
+    let stored_paths: Vec<String> = desc.search_paths.iter().map(|s| s.to_string()).collect();
+    let stored_defines: Vec<(String, String)> = desc
+        .defines
         .iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
@@ -30,16 +26,16 @@ pub(super) fn create_with_checks(
     state.shaders.insert(
         handle,
         ShaderState {
-            device_handle,
-            slang_source: slang_source.to_string(),
+            device_handle: desc.device,
+            slang_source: desc.slang_source.to_string(),
             search_paths: stored_paths,
             defines: stored_defines,
-            optimization_level,
+            optimization_level: desc.optimization_level,
             vertex_bytecode: None,
             fragment_bytecode: None,
             compute_bytecode: None,
             reflection: None,
-            layout_checks,
+            layout_checks: desc.layout_checks,
         },
     );
 

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -247,12 +247,14 @@ impl GpuBackend for MetalBackend {
             &self.state.devices,
             &mut self.state.shaders,
             &mut self.state.next_shader_handle,
-            device,
-            slang_source,
-            search_paths,
-            defines,
-            optimization_level,
-            layout_checks,
+            crate::backend::shared::ShaderDesc::new(
+                device,
+                slang_source,
+                search_paths,
+                defines,
+                optimization_level,
+            )
+            .with_layout_checks(layout_checks),
         )
     }
 
@@ -269,16 +271,15 @@ impl GpuBackend for MetalBackend {
         topology: PrimitiveTopology,
         target_format: TextureFormat,
     ) -> Result<PipelineHandle> {
-        pipeline::create_with_depth(
-            &mut self.state,
-            device,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format);
+        let desc = crate::backend::shared::GraphicsPipelineCreateDesc {
+            device_handle: device,
             vertex_shader,
             fragment_shader,
-            vertex_layout,
-            topology,
-            target_format,
-            None,
-        )
+            raster: &raster,
+        };
+        pipeline::create_with_depth(&mut self.state, &desc)
     }
 
     fn create_pipeline_with_depth(
@@ -291,16 +292,16 @@ impl GpuBackend for MetalBackend {
         target_format: TextureFormat,
         depth_stencil: Option<&DepthStencilState>,
     ) -> Result<PipelineHandle> {
-        pipeline::create_with_depth(
-            &mut self.state,
-            device,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format)
+                .with_depth_stencil(depth_stencil);
+        let desc = crate::backend::shared::GraphicsPipelineCreateDesc {
+            device_handle: device,
             vertex_shader,
             fragment_shader,
-            vertex_layout,
-            topology,
-            target_format,
-            depth_stencil,
-        )
+            raster: &raster,
+        };
+        pipeline::create_with_depth(&mut self.state, &desc)
     }
 
     fn destroy_pipeline(&mut self, pipeline: PipelineHandle) {

--- a/src/backend/metal/pipeline.rs
+++ b/src/backend/metal/pipeline.rs
@@ -1,32 +1,27 @@
 //! Graphics pipeline management logic.
 
-use super::super::{DeviceHandle, PipelineHandle, ShaderHandle};
+use super::super::shared::GraphicsPipelineCreateDesc;
+use super::super::PipelineHandle;
 use super::types::{MetalState, PipelineState};
 use super::utils::{
     compare_to_mtl, depth_format_to_mtl, format_to_mtl, topology_to_mtl, vertex_format_to_mtl,
 };
 use crate::slang::SlangStage;
-use crate::types::PrimitiveTopology;
-use crate::types::{DepthStencilState, TextureFormat, VertexBufferLayout};
 use ::metal as mtl;
 use anyhow::{Context, Result};
 
 /// Create a graphics pipeline (with optional depth stencil).
-///
-/// The argument count mirrors the Vulkan and DX12 backends for cross-backend navigability.
-/// If this function is ever refactored to a `PipelineDesc` struct, update all three backends
-/// simultaneously to keep the API surface consistent.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn create_with_depth(
     state: &mut MetalState,
-    device_handle: DeviceHandle,
-    vertex_shader: ShaderHandle,
-    fragment_shader: ShaderHandle,
-    vertex_layout: &VertexBufferLayout,
-    topology: PrimitiveTopology,
-    target_format: TextureFormat,
-    depth_stencil: Option<&DepthStencilState>,
+    desc: &GraphicsPipelineCreateDesc<'_>,
 ) -> Result<PipelineHandle> {
+    let device_handle = desc.device_handle;
+    let vertex_shader = desc.vertex_shader;
+    let fragment_shader = desc.fragment_shader;
+    let vertex_layout = desc.raster.vertex_layout;
+    let topology = desc.raster.topology;
+    let target_format = desc.raster.target_format;
+    let depth_stencil = desc.raster.depth_stencil;
     super::shader::ensure_stage_compiled(
         &state.slang_compiler,
         &state.devices,

--- a/src/backend/metal/shader.rs
+++ b/src/backend/metal/shader.rs
@@ -1,8 +1,9 @@
 //! Shader compilation and management logic.
 
+use super::super::shared::{ShaderDesc, ShaderStageCompileDesc};
 use super::super::{DeviceHandle, ShaderHandle};
 use super::types::ShaderState;
-use crate::slang::{OwnedLayoutCheck, ShaderTarget, SlangCompiler, SlangStage};
+use crate::slang::{ShaderTarget, SlangCompiler, SlangStage};
 use ::metal as mtl;
 use anyhow::{Context, Result};
 use mtl::{Device as MTLDevice, Library};
@@ -78,42 +79,28 @@ pub(super) fn patch_vertex_msl_entry_point_params(msl: &str) -> String {
 }
 
 /// Compile a shader stage to MSL and create a Metal library.
-///
-/// The argument count reflects the Slang compile API surface: each parameter
-/// maps to a distinct compile-time concept (source, search paths, entry point,
-/// stage, defines, layout checks, optimization). Grouping them into a struct
-/// would require the same change in the Vulkan and DX12 backends.
-#[allow(clippy::too_many_arguments)]
 fn compile_stage_with_reflection(
     slang_compiler: &SlangCompiler,
     device: &MTLDevice,
-    slang_source: &str,
-    search_paths: &[String],
-    entry_point: &str,
-    stage: SlangStage,
-    extra_defines: &[(&str, &str)],
-    layout_checks: &[OwnedLayoutCheck],
-    optimization_level: crate::types::OptimizationLevel,
+    desc: &ShaderStageCompileDesc<'_>,
 ) -> Result<(Library, Option<crate::slang::ShaderReflection>)> {
-    let search_path_refs: Vec<&str> = search_paths.iter().map(|s| s.as_str()).collect();
-
     let compile_outcome = slang_compiler.compile_bindless_with_reflection_and_defines(
-        slang_source,
+        desc.slang_source,
         ShaderTarget::Metal,
-        &[(entry_point, stage)],
-        &search_path_refs,
-        extra_defines,
-        layout_checks,
-        optimization_level,
+        &[(desc.entry_point, desc.stage)],
+        desc.search_paths,
+        desc.extra_defines,
+        desc.layout_checks,
+        desc.optimization_level,
     );
 
     let result = compile_outcome
-        .with_context(|| format!("Failed to compile {} shader stage", entry_point))?;
+        .with_context(|| format!("Failed to compile {} shader stage", desc.entry_point))?;
 
     if !result.reflection.parameter_blocks.is_empty() {
         tracing::debug!(
             "Shader {} has {} ParameterBlock(s):",
-            entry_point,
+            desc.entry_point,
             result.reflection.parameter_blocks.len()
         );
         for pb in &result.reflection.parameter_blocks {
@@ -144,12 +131,12 @@ fn compile_stage_with_reflection(
         .to_string();
 
     // Apply vertex-shader patch for missing EntryPointParams [[buffer(1)]] binding.
-    let msl_source = if stage == SlangStage::Vertex {
+    let msl_source = if desc.stage == SlangStage::Vertex {
         let patched = patch_vertex_msl_entry_point_params(&raw_msl);
         if patched != raw_msl {
             tracing::debug!(
                 "Applied vertex EntryPointParams [[buffer(1)]] patch for {}",
-                entry_point
+                desc.entry_point
             );
         }
         patched
@@ -159,7 +146,7 @@ fn compile_stage_with_reflection(
 
     tracing::debug!(
         "Compiled MSL {} shader ({} bytes)",
-        entry_point,
+        desc.entry_point,
         msl_source.len()
     );
 
@@ -170,7 +157,7 @@ fn compile_stage_with_reflection(
         let idx = DUMP_IDX.fetch_add(1, Ordering::Relaxed);
         let dir = std::path::Path::new(&dump_dir);
         let _ = std::fs::create_dir_all(dir);
-        let filename = format!("{:03}_{}.metal", idx, entry_point);
+        let filename = format!("{:03}_{}.metal", idx, desc.entry_point);
         if let Ok(mut f) = std::fs::File::create(dir.join(&filename)) {
             let _ = f.write_all(msl_source.as_bytes());
             tracing::info!("Dumped MSL to {}/{}", dump_dir, filename);
@@ -180,7 +167,11 @@ fn compile_stage_with_reflection(
     let library = device
         .new_library_with_source(&msl_source, &mtl::CompileOptions::new())
         .map_err(|e| {
-            anyhow::anyhow!("Failed to create Metal library for {}: {}", entry_point, e)
+            anyhow::anyhow!(
+                "Failed to create Metal library for {}: {}",
+                desc.entry_point,
+                e
+            )
         })?;
 
     Ok((library, Some(result.reflection)))
@@ -238,17 +229,18 @@ pub(super) fn ensure_stage_compiled(
         .get(&device_handle)
         .context("Shader's device no longer valid")?;
 
-    let (library, reflection) = compile_stage_with_reflection(
-        slang_compiler,
-        &logical_device.device,
-        &slang_source,
-        &search_paths,
+    let search_path_refs: Vec<&str> = search_paths.iter().map(|s| s.as_str()).collect();
+    let compile_desc = ShaderStageCompileDesc {
+        slang_source: &slang_source,
+        search_paths: &search_path_refs,
         entry_point,
         stage,
-        &extra_defines,
-        &layout_checks_snapshot,
+        extra_defines: &extra_defines,
+        layout_checks: &layout_checks_snapshot,
         optimization_level,
-    )?;
+    };
+    let (library, reflection) =
+        compile_stage_with_reflection(slang_compiler, &logical_device.device, &compile_desc)?;
 
     let shader = shaders
         .get_mut(&shader_handle)
@@ -280,21 +272,13 @@ pub(super) fn ensure_stage_compiled(
 }
 
 /// Create a shader handle (compilation deferred to pipeline creation).
-#[allow(clippy::too_many_arguments)] // Backend entry point; parameters map 1:1 to GpuBackend::create_shader.
 pub(super) fn create(
     devices: &HashMap<DeviceHandle, super::types::LogicalDevice>,
     shaders: &mut HashMap<ShaderHandle, ShaderState>,
     next_shader_handle: &mut ShaderHandle,
-    device_handle: DeviceHandle,
-    slang_source: &str,
-    search_paths: &[&str],
-    defines: &[(&str, &str)],
-    optimization_level: crate::types::OptimizationLevel,
-    layout_checks: Vec<OwnedLayoutCheck>,
+    desc: ShaderDesc<'_>,
 ) -> Result<ShaderHandle> {
-    devices
-        .get(&device_handle)
-        .context("Invalid device handle")?;
+    devices.get(&desc.device).context("Invalid device handle")?;
 
     let handle = *next_shader_handle;
     *next_shader_handle += 1;
@@ -302,19 +286,20 @@ pub(super) fn create(
     shaders.insert(
         handle,
         ShaderState {
-            device_handle,
-            slang_source: slang_source.to_string(),
-            search_paths: search_paths.iter().map(|s| s.to_string()).collect(),
-            defines: defines
+            device_handle: desc.device,
+            slang_source: desc.slang_source.to_string(),
+            search_paths: desc.search_paths.iter().map(|s| s.to_string()).collect(),
+            defines: desc
+                .defines
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-            optimization_level,
+            optimization_level: desc.optimization_level,
             vertex_library: None,
             fragment_library: None,
             compute_library: None,
             reflection: None,
-            layout_checks,
+            layout_checks: desc.layout_checks,
         },
     );
 

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -5,7 +5,18 @@
 //! re-export them locally without leaking internal details to crate consumers.
 //!
 
+use crate::slang::OwnedLayoutCheck;
+use crate::types::{
+    DepthStencilState, OptimizationLevel, PrimitiveTopology, TextureFormat, VertexBufferLayout,
+};
 use anyhow::Result;
+
+use super::DeviceHandle;
+#[cfg(any(
+    all(feature = "metal", target_os = "macos"),
+    all(feature = "dx12", target_os = "windows"),
+))]
+use super::ShaderHandle;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Push-constant layout
@@ -428,4 +439,102 @@ pub fn resolve_clear_size(buffer_size: u64, offset: u64, size: u64) -> u64 {
     } else {
         size
     }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shader / pipeline creation descriptors (shared across backends)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Deferred shader creation parameters shared by every GPU backend.
+#[derive(Debug)]
+pub struct ShaderDesc<'a> {
+    pub device: DeviceHandle,
+    pub slang_source: &'a str,
+    pub search_paths: &'a [&'a str],
+    pub defines: &'a [(&'a str, &'a str)],
+    pub optimization_level: OptimizationLevel,
+    pub layout_checks: Vec<OwnedLayoutCheck>,
+}
+
+impl<'a> ShaderDesc<'a> {
+    #[inline]
+    pub fn new(
+        device: DeviceHandle,
+        slang_source: &'a str,
+        search_paths: &'a [&'a str],
+        defines: &'a [(&'a str, &'a str)],
+        optimization_level: OptimizationLevel,
+    ) -> Self {
+        Self {
+            device,
+            slang_source,
+            search_paths,
+            defines,
+            optimization_level,
+            layout_checks: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn with_layout_checks(mut self, layout_checks: Vec<OwnedLayoutCheck>) -> Self {
+        self.layout_checks = layout_checks;
+        self
+    }
+}
+
+/// Slang compile inputs for a single shader stage (Metal path; same field set as other backends).
+#[cfg(all(feature = "metal", target_os = "macos"))]
+#[derive(Debug, Clone, Copy)]
+pub struct ShaderStageCompileDesc<'a> {
+    pub slang_source: &'a str,
+    pub search_paths: &'a [&'a str],
+    pub entry_point: &'a str,
+    pub stage: crate::slang::SlangStage,
+    pub extra_defines: &'a [(&'a str, &'a str)],
+    pub layout_checks: &'a [OwnedLayoutCheck],
+    pub optimization_level: OptimizationLevel,
+}
+
+/// Rasterization state for a graphics pipeline, shared across Vulkan, DX12, and Metal.
+#[derive(Debug, Clone, Copy)]
+pub struct PipelineDesc<'a> {
+    pub vertex_layout: &'a VertexBufferLayout,
+    pub topology: PrimitiveTopology,
+    pub target_format: TextureFormat,
+    pub depth_stencil: Option<&'a DepthStencilState>,
+}
+
+impl<'a> PipelineDesc<'a> {
+    #[inline]
+    pub fn new(
+        vertex_layout: &'a VertexBufferLayout,
+        topology: PrimitiveTopology,
+        target_format: TextureFormat,
+    ) -> Self {
+        Self {
+            vertex_layout,
+            topology,
+            target_format,
+            depth_stencil: None,
+        }
+    }
+
+    #[inline]
+    pub fn with_depth_stencil(mut self, depth_stencil: Option<&'a DepthStencilState>) -> Self {
+        self.depth_stencil = depth_stencil;
+        self
+    }
+}
+
+/// Full graphics pipeline creation inputs for backends that resolve shaders by handle.
+#[cfg(any(
+    all(feature = "metal", target_os = "macos"),
+    all(feature = "dx12", target_os = "windows"),
+))]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsPipelineCreateDesc<'a> {
+    pub device_handle: DeviceHandle,
+    pub vertex_shader: ShaderHandle,
+    pub fragment_shader: ShaderHandle,
+    pub raster: &'a PipelineDesc<'a>,
 }

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -436,12 +436,14 @@ impl GpuBackend for VulkanBackend {
             &self.state.devices,
             &mut self.state.shaders,
             &mut self.state.next_shader_handle,
-            device_handle,
-            slang_source,
-            search_paths,
-            defines,
-            optimization_level,
-            layout_checks,
+            crate::backend::shared::ShaderDesc::new(
+                device_handle,
+                slang_source,
+                search_paths,
+                defines,
+                optimization_level,
+            )
+            .with_layout_checks(layout_checks),
         )
     }
 
@@ -468,18 +470,18 @@ impl GpuBackend for VulkanBackend {
             render_push_constant_categories(&self.state.shaders, vertex_shader, fragment_shader);
         let shader_debug_name = format!("shader(vs=#{vertex_shader}, fs=#{fragment_shader})");
 
-        let handle = pipeline::create(
-            &self.state.devices,
-            &mut self.state.pipelines,
-            &mut self.state.next_pipeline_handle,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format);
+        let handle = pipeline::create(pipeline::VulkanGraphicsPipelineCreateBundle {
+            devices: &self.state.devices,
+            pipelines: &mut self.state.pipelines,
+            next_pipeline_handle: &mut self.state.next_pipeline_handle,
             device_handle,
             vs_module,
             fs_module,
-            vertex_layout,
-            topology,
-            target_format,
+            raster: &raster,
             shader_debug_name,
-        )?;
+        })?;
 
         if let Some(ps) = self.state.pipelines.get_mut(&handle) {
             ps.push_constant_categories = cats;
@@ -685,19 +687,19 @@ impl GpuBackend for VulkanBackend {
         let cats =
             render_push_constant_categories(&self.state.shaders, vertex_shader, fragment_shader);
 
-        let handle = pipeline::create_with_depth(
-            &self.state.devices,
-            &mut self.state.pipelines,
-            &mut self.state.next_pipeline_handle,
+        let raster =
+            crate::backend::shared::PipelineDesc::new(vertex_layout, topology, target_format)
+                .with_depth_stencil(depth_stencil);
+        let handle = pipeline::create_with_depth(pipeline::VulkanGraphicsPipelineCreateBundle {
+            devices: &self.state.devices,
+            pipelines: &mut self.state.pipelines,
+            next_pipeline_handle: &mut self.state.next_pipeline_handle,
             device_handle,
             vs_module,
             fs_module,
-            vertex_layout,
-            topology,
-            target_format,
-            depth_stencil,
+            raster: &raster,
             shader_debug_name,
-        )?;
+        })?;
 
         if let Some(ps) = self.state.pipelines.get_mut(&handle) {
             ps.push_constant_categories = cats;

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -5,27 +5,36 @@ use super::utils::{
     compare_to_vk, depth_format_to_vk, format_to_vk, topology_to_vk, vertex_format_to_vk,
 };
 use super::{DeviceHandle, PipelineHandle};
-use crate::types::{
-    CompareFunction, DepthStencilState, PrimitiveTopology, TextureFormat, VertexBufferLayout,
-};
+use crate::types::CompareFunction;
 use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
 
+/// Shader modules plus raster state for Vulkan graphics pipeline creation.
+pub(super) struct VulkanGraphicsPipelineCreateBundle<'a> {
+    pub devices: &'a HashMap<DeviceHandle, types::LogicalDevice>,
+    pub pipelines: &'a mut HashMap<PipelineHandle, PipelineState>,
+    pub next_pipeline_handle: &'a mut PipelineHandle,
+    pub device_handle: DeviceHandle,
+    pub vs_module: vk::ShaderModule,
+    pub fs_module: vk::ShaderModule,
+    pub raster: &'a crate::backend::shared::PipelineDesc<'a>,
+    pub shader_debug_name: String,
+}
+
 /// Create a graphics pipeline without depth testing.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn create(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
-    pipelines: &mut HashMap<PipelineHandle, PipelineState>,
-    next_pipeline_handle: &mut PipelineHandle,
-    device_handle: DeviceHandle,
-    vs_module: vk::ShaderModule,
-    fs_module: vk::ShaderModule,
-    vertex_layout: &VertexBufferLayout,
-    topology: PrimitiveTopology,
-    target_format: TextureFormat,
-    shader_debug_name: String,
-) -> Result<PipelineHandle> {
+pub(super) fn create(bundle: VulkanGraphicsPipelineCreateBundle<'_>) -> Result<PipelineHandle> {
+    let VulkanGraphicsPipelineCreateBundle {
+        devices,
+        pipelines,
+        next_pipeline_handle,
+        device_handle,
+        vs_module,
+        fs_module,
+        raster: raster_desc,
+        shader_debug_name,
+    } = bundle;
+
     let logical_device = devices
         .get(&device_handle)
         .context("Invalid device handle")?;
@@ -45,16 +54,17 @@ pub(super) fn create(
 
     // Vertex input — only declare binding 0 when there are actual attributes
     let binding_descs: Vec<vk::VertexInputBindingDescription> =
-        if vertex_layout.attributes.is_empty() {
+        if raster_desc.vertex_layout.attributes.is_empty() {
             Vec::new()
         } else {
             vec![vk::VertexInputBindingDescription::default()
                 .binding(0)
-                .stride(vertex_layout.stride)
+                .stride(raster_desc.vertex_layout.stride)
                 .input_rate(vk::VertexInputRate::VERTEX)]
         };
 
-    let attribute_descs: Vec<_> = vertex_layout
+    let attribute_descs: Vec<_> = raster_desc
+        .vertex_layout
         .attributes
         .iter()
         .map(|attr| {
@@ -72,7 +82,7 @@ pub(super) fn create(
 
     // Input assembly
     let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::default()
-        .topology(topology_to_vk(topology))
+        .topology(topology_to_vk(raster_desc.topology))
         .primitive_restart_enable(false);
 
     // Viewport/scissor (dynamic)
@@ -116,7 +126,7 @@ pub(super) fn create(
     let owns_layout = false;
 
     // Dynamic rendering (core since Vulkan 1.3, mandatory in 1.4)
-    let color_format = format_to_vk(target_format);
+    let color_format = format_to_vk(raster_desc.target_format);
     let mut rendering_info = vk::PipelineRenderingCreateInfo::default()
         .color_attachment_formats(std::slice::from_ref(&color_format));
 
@@ -173,20 +183,20 @@ pub(super) fn create(
 }
 
 /// Create a graphics pipeline with depth testing support.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn create_with_depth(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
-    pipelines: &mut HashMap<PipelineHandle, PipelineState>,
-    next_pipeline_handle: &mut PipelineHandle,
-    device_handle: DeviceHandle,
-    vs_module: vk::ShaderModule,
-    fs_module: vk::ShaderModule,
-    vertex_layout: &VertexBufferLayout,
-    topology: PrimitiveTopology,
-    target_format: TextureFormat,
-    depth_stencil: Option<&DepthStencilState>,
-    shader_debug_name: String,
+    bundle: VulkanGraphicsPipelineCreateBundle<'_>,
 ) -> Result<PipelineHandle> {
+    let VulkanGraphicsPipelineCreateBundle {
+        devices,
+        pipelines,
+        next_pipeline_handle,
+        device_handle,
+        vs_module,
+        fs_module,
+        raster: raster_desc,
+        shader_debug_name,
+    } = bundle;
+
     let logical_device = devices
         .get(&device_handle)
         .context("Invalid device handle")?;
@@ -206,16 +216,17 @@ pub(super) fn create_with_depth(
 
     // Vertex input — only declare binding 0 when there are actual attributes
     let binding_descs: Vec<vk::VertexInputBindingDescription> =
-        if vertex_layout.attributes.is_empty() {
+        if raster_desc.vertex_layout.attributes.is_empty() {
             Vec::new()
         } else {
             vec![vk::VertexInputBindingDescription::default()
                 .binding(0)
-                .stride(vertex_layout.stride)
+                .stride(raster_desc.vertex_layout.stride)
                 .input_rate(vk::VertexInputRate::VERTEX)]
         };
 
-    let attribute_descs: Vec<_> = vertex_layout
+    let attribute_descs: Vec<_> = raster_desc
+        .vertex_layout
         .attributes
         .iter()
         .map(|attr| {
@@ -233,7 +244,7 @@ pub(super) fn create_with_depth(
 
     // Input assembly
     let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::default()
-        .topology(topology_to_vk(topology))
+        .topology(topology_to_vk(raster_desc.topology))
         .primitive_restart_enable(false);
 
     // Viewport/scissor (dynamic)
@@ -257,7 +268,7 @@ pub(super) fn create_with_depth(
         .rasterization_samples(vk::SampleCountFlags::TYPE_1);
 
     // Depth stencil state
-    let depth_stencil_state = if let Some(ds) = depth_stencil {
+    let depth_stencil_state = if let Some(ds) = raster_desc.depth_stencil {
         vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(
                 ds.depth_write_enabled || ds.depth_compare != CompareFunction::Always,
@@ -314,8 +325,9 @@ pub(super) fn create_with_depth(
     let owns_layout = true;
 
     // Dynamic rendering (core since Vulkan 1.3, mandatory in 1.4)
-    let color_format = format_to_vk(target_format);
-    let depth_format_vk = depth_stencil
+    let color_format = format_to_vk(raster_desc.target_format);
+    let depth_format_vk = raster_desc
+        .depth_stencil
         .map(|ds| depth_format_to_vk(ds.format))
         .unwrap_or(vk::Format::UNDEFINED);
 

--- a/src/backend/vulkan/shader.rs
+++ b/src/backend/vulkan/shader.rs
@@ -7,22 +7,14 @@ use ash::vk;
 use std::collections::HashMap;
 
 /// Create a shader from Slang source code.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn create(
     devices: &HashMap<DeviceHandle, types::LogicalDevice>,
     shaders: &mut HashMap<ShaderHandle, ShaderState>,
     next_shader_handle: &mut ShaderHandle,
-    device_handle: DeviceHandle,
-    slang_source: &str,
-    search_paths: &[&str],
-    defines: &[(&str, &str)],
-    optimization_level: crate::types::OptimizationLevel,
-    layout_checks: Vec<crate::slang::OwnedLayoutCheck>,
+    desc: crate::backend::shared::ShaderDesc<'_>,
 ) -> Result<ShaderHandle> {
     // Just validate the device exists - actual compilation happens at pipeline creation
-    let _ = devices
-        .get(&device_handle)
-        .context("Invalid device handle")?;
+    let _ = devices.get(&desc.device).context("Invalid device handle")?;
 
     let handle = *next_shader_handle;
     *next_shader_handle += 1;
@@ -30,19 +22,20 @@ pub(super) fn create(
     shaders.insert(
         handle,
         ShaderState {
-            device_handle,
-            slang_source: slang_source.to_string(),
-            search_paths: search_paths.iter().map(|s| s.to_string()).collect(),
-            defines: defines
+            device_handle: desc.device,
+            slang_source: desc.slang_source.to_string(),
+            search_paths: desc.search_paths.iter().map(|s| s.to_string()).collect(),
+            defines: desc
+                .defines
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-            optimization_level,
+            optimization_level: desc.optimization_level,
             vertex_module: None,
             fragment_module: None,
             compute_module: None,
             reflection: None,
-            layout_checks,
+            layout_checks: desc.layout_checks,
         },
     );
 
@@ -74,7 +67,6 @@ pub(super) fn destroy(
 }
 
 /// Compile a shader for a specific stage on demand.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn ensure_stage_compiled(
     slang_compiler: &crate::slang::SlangCompiler,
     devices: &HashMap<DeviceHandle, types::LogicalDevice>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [issue #120](https://github.com/koubaa/goldy/issues/120) by replacing `#[allow(clippy::too_many_arguments)]` on graphics pipeline and deferred shader creation with small descriptor types, aligned across backends.

## Changes

- **`ShaderDesc`** in `src/backend/shared.rs`: device, Slang source, search paths, defines, optimization level, and optional layout checks (`new` / `with_layout_checks`). Used by Vulkan, DX12, and Metal `shader::create` / `create_with_checks`.
- **`PipelineDesc`** in shared: vertex layout, topology, color format, and optional depth/stencil (`new` / `with_depth_stencil`). Used when building pipelines everywhere.
- **`VulkanGraphicsPipelineCreateBundle`**: collapses Vulkan `pipeline::create` and `create_with_depth` argument lists into one struct (devices, pipeline maps, modules, raster `PipelineDesc`, debug name).
- **`GraphicsPipelineCreateDesc`** (Metal + DX12): device handle, VS/FS handles, and `&PipelineDesc`; gated with `cfg` so Vulkan-only builds do not see unused types.
- **`ShaderStageCompileDesc`** (Metal): groups Slang compile parameters for `compile_stage_with_reflection`; removes the Metal-only `too_many_arguments` allow there.
- Removed redundant `#[allow(clippy::too_many_arguments)]` on Vulkan `ensure_stage_compiled` (five parameters).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features -- -D warnings` and `cargo clippy -- -D warnings`
- `cargo test --features vulkan --lib` (349 tests). Full `cargo test --features vulkan` may fail validation-layer subprocess tests when Khronos validation is not installed (environment), unrelated to this refactor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c966360e-1001-4eb0-a062-fac8c77d71b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c966360e-1001-4eb0-a062-fac8c77d71b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

