### PR TITLE
fix(dx12): insert explicit barrier for clear operation in compute shader

### DIFF
--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -448,13 +448,6 @@ pub(super) fn resize(
         .context("resize_buffer: command list")?;
         let cmd7: ID3D12GraphicsCommandList7 = cmd.cast().context("ID3D12GraphicsCommandList7")?;
 
-        unsafe {
-            cmd.SetDescriptorHeaps(&[
-                Some(device.cbv_srv_uav_heap.clone()),
-                Some(device.sampler_heap.clone()),
-            ]);
-        }
-
         if need_copy {
             let mut b_src = [barriers::buffer_barrier_full(
                 &old_resource,
@@ -481,49 +474,49 @@ pub(super) fn resize(
 
         if need_tail_clear {
             let tail_len = new_size - old.size;
-            let mut b_to_uav = [if need_copy {
-                barriers::buffer_barrier_full(
+            // If we just copied old content, new_resource is already in COPY_DEST.
+            // Otherwise transition it from COMMON.
+            if !need_copy {
+                let mut b_to_copy = [barriers::buffer_barrier_full(
                     &new_resource,
+                    D3D12_BARRIER_SYNC_ALL,
                     D3D12_BARRIER_SYNC_COPY,
-                    D3D12_BARRIER_SYNC_ALL,
-                    D3D12_BARRIER_ACCESS_COPY_DEST,
-                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                )
-            } else {
-                barriers::buffer_barrier_full(
-                    &new_resource,
-                    D3D12_BARRIER_SYNC_ALL,
-                    D3D12_BARRIER_SYNC_ALL,
                     D3D12_BARRIER_ACCESS_COMMON,
-                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                )
-            }];
-            unsafe {
-                barriers::barrier_buffers(&cmd7, &b_to_uav);
-                barriers::drop_buffer_barriers(&mut b_to_uav);
+                    D3D12_BARRIER_ACCESS_COPY_DEST,
+                )];
+                unsafe {
+                    barriers::barrier_buffers(&cmd7, &b_to_copy);
+                    barriers::drop_buffer_barriers(&mut b_to_copy);
+                }
             }
-            let tmp_state = BufferState {
-                device_handle,
-                resource: new_resource.clone(),
-                size: new_size,
-                allocation_size: new_size,
-                bindless_offset: None,
-                bindless_srv_offset: None,
-                is_storage: true,
-                upload_buffer: None,
-                element_stride: old.element_stride,
-                is_view: false,
-                coherent_readback: None,
-                coherent_readback_mapped: None,
-                flags: old.flags,
-                transient_placed: false,
-                parent_for_view: None,
-                view_byte_offset: None,
-                is_reserved: false,
-                tile_byte_size: 0,
-                reserved_tiles: Vec::new(),
-            };
-            uav_clear(device, &tmp_state, &cmd, old.size, tail_len)?;
+            // Zero-fill the tail via chunked CopyBufferRegion from the device's zero buffer.
+            let zero = &device.zero_buffer;
+            let mut tail_written = 0u64;
+            while tail_written < tail_len {
+                let this_chunk = (tail_len - tail_written).min(ZERO_BUFFER_SIZE);
+                unsafe {
+                    cmd.CopyBufferRegion(
+                        &new_resource,
+                        old.size + tail_written,
+                        zero,
+                        0,
+                        this_chunk,
+                    );
+                }
+                tail_written += this_chunk;
+            }
+            // Transition back to COMMON so the resource can be used as UAV by subsequent work.
+            let mut b_to_common = [barriers::buffer_barrier_full(
+                &new_resource,
+                D3D12_BARRIER_SYNC_COPY,
+                D3D12_BARRIER_SYNC_ALL,
+                D3D12_BARRIER_ACCESS_COPY_DEST,
+                D3D12_BARRIER_ACCESS_COMMON,
+            )];
+            unsafe {
+                barriers::barrier_buffers(&cmd7, &b_to_common);
+                barriers::drop_buffer_barriers(&mut b_to_common);
+            }
         }
 
         unsafe { cmd.Close() }.context("resize_buffer: Close")?;
@@ -1548,6 +1541,10 @@ fn wait_for_fence(fence: &ID3D12Fence, value: u64) -> Result<()> {
 /// Large uploads are split into chunks of this size to avoid massive staging allocations.
 const UPLOAD_CHUNK_SIZE: u64 = 16 * 1024 * 1024; // 16 MB
 
+/// Size of the per-device zero-filled UPLOAD-heap buffer used as the source for
+/// `CopyBufferRegion` clears. Matches `UPLOAD_CHUNK_SIZE` so any single chunk fits.
+pub(super) const ZERO_BUFFER_SIZE: u64 = UPLOAD_CHUNK_SIZE;
+
 /// Ensure the upload (staging) buffer exists for a DEFAULT-heap storage buffer.
 ///
 /// Called by `ComputeCommand::WriteBuffer` handling in `compute::submit` so the
@@ -2102,102 +2099,9 @@ pub(super) fn read_to_cpu(
     Ok(())
 }
 
-/// GPU-side zero fill using ClearUnorderedAccessViewUint.
-///
-/// Always creates a R32_UINT UAV (stride=0) so ClearUnorderedAccessViewUint works
-/// regardless of the buffer's native structured stride. The UAV is created in both
-/// the shader-visible heap (GPU handle) and the non-shader-visible cpu_clear_heap
-/// (CPU handle), as required by the D3D12 API.
-pub(super) fn uav_clear(
-    device: &super::types::LogicalDevice,
-    buffer: &BufferState,
-    command_list: &ID3D12GraphicsCommandList,
-    offset: u64,
-    clear_size: u64,
-) -> Result<()> {
-    let scratch = device.scratch_clear_uav_offset;
-    let num_u32s = (buffer.size / 4) as u32;
-
-    let raw_uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
-        Format: DXGI_FORMAT_R32_UINT,
-        ViewDimension: D3D12_UAV_DIMENSION_BUFFER,
-        Anonymous: D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
-            Buffer: D3D12_BUFFER_UAV {
-                FirstElement: 0,
-                NumElements: num_u32s,
-                StructureByteStride: 0,
-                CounterOffsetInBytes: 0,
-                Flags: D3D12_BUFFER_UAV_FLAG_NONE,
-            },
-        },
-    };
-
-    let scratch_cpu = unsafe {
-        let mut h = device.cbv_srv_uav_heap.GetCPUDescriptorHandleForHeapStart();
-        h.ptr += (scratch * device.cbv_srv_uav_descriptor_size) as usize;
-        h
-    };
-    unsafe {
-        device.device.CreateUnorderedAccessView(
-            &buffer.resource,
-            None,
-            Some(&raw_uav_desc),
-            scratch_cpu,
-        );
-    }
-
-    let gpu_handle = unsafe {
-        let mut h = device.cbv_srv_uav_heap.GetGPUDescriptorHandleForHeapStart();
-        h.ptr += (scratch as u64) * (device.cbv_srv_uav_descriptor_size as u64);
-        h
-    };
-
-    let cpu_handle = unsafe { device.cpu_clear_heap.GetCPUDescriptorHandleForHeapStart() };
-    unsafe {
-        device.device.CreateUnorderedAccessView(
-            &buffer.resource,
-            None,
-            Some(&raw_uav_desc),
-            cpu_handle,
-        );
-    }
-
-    if offset == 0 && clear_size == buffer.size {
-        unsafe {
-            command_list.ClearUnorderedAccessViewUint(
-                gpu_handle,
-                cpu_handle,
-                &buffer.resource,
-                &[0u32; 4],
-                &[],
-            );
-        }
-    } else {
-        let first_element = offset / 4;
-        let num_elements = clear_size / 4;
-        let rect = windows::Win32::Foundation::RECT {
-            left: first_element as i32,
-            top: 0,
-            right: (first_element + num_elements) as i32,
-            bottom: 1,
-        };
-        unsafe {
-            command_list.ClearUnorderedAccessViewUint(
-                gpu_handle,
-                cpu_handle,
-                &buffer.resource,
-                &[0u32; 4],
-                &[rect],
-            );
-        }
-    }
-
-    Ok(())
-}
-
 /// Fill buffer region with zeros (standalone, synchronous version).
 ///
-/// For DEFAULT heap buffers (storage), uses ClearUnorderedAccessViewUint (no staging needed).
+/// For DEFAULT heap buffers (storage), uses CopyBufferRegion from the device's zero buffer.
 /// For UPLOAD heap buffers (uniform), zeroes directly via Map.
 pub(super) fn clear(
     state: &mut Dx12State,
@@ -2221,7 +2125,9 @@ pub(super) fn clear(
     }
 
     if buffer.is_storage {
-        // DEFAULT heap storage buffer: use ClearUnorderedAccessViewUint (GPU-side, no staging)
+        // DEFAULT heap storage buffer: zero-fill via CopyBufferRegion from the device's
+        // zero buffer. Unlike ClearUnorderedAccessViewUint, CopyBufferRegion has no
+        // per-device shared-descriptor aliasing hazard.
         let device = state
             .devices
             .get(&device_handle)
@@ -2243,16 +2149,44 @@ pub(super) fn clear(
             )
         }
         .context("Failed to create command list")?;
+        let cmd_list7: ID3D12GraphicsCommandList7 =
+            cmd_list.cast().context("ID3D12GraphicsCommandList7")?;
 
-        // Bind descriptor heaps (required for ClearUnorderedAccessViewUint)
+        let buf_resource = buffer.resource.clone();
+        let zero = device.zero_buffer.clone();
+
+        let mut b_to_copy = [barriers::buffer_barrier_full(
+            &buf_resource,
+            D3D12_BARRIER_SYNC_ALL,
+            D3D12_BARRIER_SYNC_COPY,
+            D3D12_BARRIER_ACCESS_COMMON,
+            D3D12_BARRIER_ACCESS_COPY_DEST,
+        )];
         unsafe {
-            cmd_list.SetDescriptorHeaps(&[
-                Some(device.cbv_srv_uav_heap.clone()),
-                Some(device.sampler_heap.clone()),
-            ]);
+            barriers::barrier_buffers(&cmd_list7, &b_to_copy);
+            barriers::drop_buffer_barriers(&mut b_to_copy);
         }
 
-        uav_clear(device, buffer, &cmd_list, offset, clear_size)?;
+        let mut written = 0u64;
+        while written < clear_size {
+            let this_chunk = (clear_size - written).min(ZERO_BUFFER_SIZE);
+            unsafe {
+                cmd_list.CopyBufferRegion(&buf_resource, offset + written, &zero, 0, this_chunk);
+            }
+            written += this_chunk;
+        }
+
+        let mut b_to_common = [barriers::buffer_barrier_full(
+            &buf_resource,
+            D3D12_BARRIER_SYNC_COPY,
+            D3D12_BARRIER_SYNC_ALL,
+            D3D12_BARRIER_ACCESS_COPY_DEST,
+            D3D12_BARRIER_ACCESS_COMMON,
+        )];
+        unsafe {
+            barriers::barrier_buffers(&cmd_list7, &b_to_common);
+            barriers::drop_buffer_barriers(&mut b_to_common);
+        }
 
         unsafe { cmd_list.Close() }.context("Failed to close command list")?;
 
@@ -2268,7 +2202,7 @@ pub(super) fn clear(
 
         let removed_reason = unsafe { device.device.GetDeviceRemovedReason() };
         if removed_reason.is_err() {
-            anyhow::bail!("Device removed during UAV clear: {:?}", removed_reason);
+            anyhow::bail!("Device removed during buffer clear: {:?}", removed_reason);
         }
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -532,8 +532,13 @@ pub(super) fn submit(
                 // which is correct (just less precise).
                 if use_global_buffer_barriers || buf_handles.is_empty() {
                     if !buf_handles.is_empty() {
+                        // Use SYNC_ALL for SyncBefore so this barrier covers all
+                        // preceding work regardless of sync scope: UAV clears run in
+                        // CLEAR_UNORDERED_ACCESS_VIEW, copies run in COPY, and indirect
+                        // dispatches run in EXECUTE_INDIRECT. A wave may mix all of
+                        // these, so SYNC_ALL is the only correct conservative choice.
                         let g = D3D12_GLOBAL_BARRIER {
-                            SyncBefore: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                            SyncBefore: D3D12_BARRIER_SYNC_ALL,
                             SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
                             AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                             AccessAfter: D3D12_BARRIER_ACCESS(
@@ -1168,8 +1173,11 @@ pub(super) fn submit_graph(
                 } => {
                     if use_global_buffer_barriers || buf_handles.is_empty() {
                         if !buf_handles.is_empty() {
+                            // SYNC_ALL covers UAV clears (CLEAR_UNORDERED_ACCESS_VIEW),
+                            // buffer copies (COPY), and indirect dispatches
+                            // (EXECUTE_INDIRECT) that may have run in the prior wave.
                             let g = D3D12_GLOBAL_BARRIER {
-                                SyncBefore: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                                SyncBefore: D3D12_BARRIER_SYNC_ALL,
                                 SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
                                 AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                                 AccessAfter: D3D12_BARRIER_ACCESS(

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -334,6 +334,13 @@ pub(super) fn submit(
     let mut texture_upload_idx = 0usize;
     let mut current_compute_pipeline: Option<super::ComputePipelineHandle> = None;
 
+    // Track which GPU sync scopes and access types have been used since the
+    // last wave-boundary barrier. The ResourceBarrier handler uses these to
+    // emit a precise SyncBefore/AccessBefore that covers exactly the work
+    // that was issued, rather than a conservative SYNC_ALL.
+    let mut pending_sync = D3D12_BARRIER_SYNC(0);
+    let mut pending_access = D3D12_BARRIER_ACCESS(0);
+
     // Process commands
     for command in commands {
         match command {
@@ -437,13 +444,11 @@ pub(super) fn submit(
                 workgroups_y,
                 workgroups_z,
             } => {
-                // No per-dispatch barrier: the graph scheduler emits ResourceBarrier
-                // commands at wave boundaries where cross-wave data dependencies
-                // exist. Dispatches within the same wave are independent and can
-                // overlap on the GPU.
                 unsafe {
                     command_list.Dispatch(*workgroups_x, *workgroups_y, *workgroups_z);
                 }
+                pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
             }
             GpuCommand::DispatchIndirect { buffer, offset } => {
                 let logical_device = state
@@ -509,38 +514,57 @@ pub(super) fn submit(
                     unsafe { barriers::barrier_buffers(&command_list7, &to_uav) };
                     unsafe { barriers::drop_buffer_barriers(&mut to_uav) };
                 }
+                pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
             }
             GpuCommand::Barrier => {
+                let sync_before = if pending_sync.0 != 0 {
+                    pending_sync
+                } else {
+                    D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                };
+                let access_before = if pending_access.0 != 0 {
+                    pending_access
+                } else {
+                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                };
                 let g = D3D12_GLOBAL_BARRIER {
-                    SyncBefore: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                    SyncBefore: sync_before,
                     SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                    AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                    AccessBefore: access_before,
                     AccessAfter: D3D12_BARRIER_ACCESS(
                         D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                             | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
                     ),
                 };
                 unsafe { barriers::barrier_globals(&command_list7, &[g]) };
+                pending_sync = D3D12_BARRIER_SYNC(0);
+                pending_access = D3D12_BARRIER_ACCESS(0);
             }
             GpuCommand::ResourceBarrier {
                 buffers: buf_handles,
                 textures: tex_handles,
             } => {
+                let sync_before = if pending_sync.0 != 0 {
+                    pending_sync
+                } else {
+                    D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                };
+                let access_before = if pending_access.0 != 0 {
+                    pending_access
+                } else {
+                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                };
                 // WARP silently removes the device when D3D12_BARRIER_TYPE_BUFFER
                 // enhanced barriers are used, causing ExecuteCommandLists to fail
                 // and the subsequent Signal() to AV. Fall back to a global barrier
                 // which is correct (just less precise).
                 if use_global_buffer_barriers || buf_handles.is_empty() {
                     if !buf_handles.is_empty() {
-                        // Use SYNC_ALL for SyncBefore so this barrier covers all
-                        // preceding work regardless of sync scope: UAV clears run in
-                        // CLEAR_UNORDERED_ACCESS_VIEW, copies run in COPY, and indirect
-                        // dispatches run in EXECUTE_INDIRECT. A wave may mix all of
-                        // these, so SYNC_ALL is the only correct conservative choice.
                         let g = D3D12_GLOBAL_BARRIER {
-                            SyncBefore: D3D12_BARRIER_SYNC_ALL,
+                            SyncBefore: sync_before,
                             SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                            AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                            AccessBefore: access_before,
                             AccessAfter: D3D12_BARRIER_ACCESS(
                                 D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                                     | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
@@ -555,9 +579,9 @@ pub(super) fn submit(
                         .map(|bs| {
                             barriers::buffer_barrier_full(
                                 &bs.resource,
+                                sync_before,
                                 D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                access_before,
                                 D3D12_BARRIER_ACCESS(
                                     D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                                         | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
@@ -600,6 +624,8 @@ pub(super) fn submit(
                     .collect();
                 unsafe { barriers::barrier_textures(&command_list7, &tex_barriers) };
                 unsafe { barriers::drop_texture_barriers(&mut tex_barriers) };
+                pending_sync = D3D12_BARRIER_SYNC(0);
+                pending_access = D3D12_BARRIER_ACCESS(0);
             }
             GpuCommand::ClearBuffer {
                 buffer,
@@ -629,21 +655,8 @@ pub(super) fn submit(
                             *offset,
                             clear_size,
                         )?;
-                        // ClearUnorderedAccessViewUint is a CLEAR_UNORDERED_ACCESS_VIEW
-                        // operation, not COMPUTE_SHADING. The TaskGraph-inserted
-                        // ResourceBarrier uses SyncBefore=COMPUTE_SHADING, which does not
-                        // cover the clear. Insert an explicit barrier here so that any
-                        // subsequent compute shader correctly observes the zeroed data.
-                        let g = D3D12_GLOBAL_BARRIER {
-                            SyncBefore: D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW,
-                            SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                            AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                            AccessAfter: D3D12_BARRIER_ACCESS(
-                                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
-                                    | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
-                            ),
-                        };
-                        unsafe { barriers::barrier_globals(&command_list7, &[g]) };
+                        pending_sync.0 |= D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW.0;
+                        pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
                     } else {
                         // UPLOAD heap buffer: CPU-accessible, just memset
                         let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
@@ -708,12 +721,6 @@ pub(super) fn submit(
                             AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                             AccessAfter: D3D12_BARRIER_ACCESS_COPY_DEST,
                         };
-                        let post = D3D12_GLOBAL_BARRIER {
-                            SyncBefore: D3D12_BARRIER_SYNC_COPY,
-                            SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                            AccessBefore: D3D12_BARRIER_ACCESS_COPY_DEST,
-                            AccessAfter: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                        };
                         unsafe {
                             barriers::barrier_globals(&command_list7, &[pre]);
                             command_list.CopyBufferRegion(
@@ -723,7 +730,6 @@ pub(super) fn submit(
                                 upload_off,
                                 data.len() as u64,
                             );
-                            barriers::barrier_globals(&command_list7, &[post]);
                         }
                     } else {
                         let mut b_to_copy = [barriers::buffer_barrier_full(
@@ -732,13 +738,6 @@ pub(super) fn submit(
                             D3D12_BARRIER_SYNC_COPY,
                             D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                             D3D12_BARRIER_ACCESS_COPY_DEST,
-                        )];
-                        let mut b_to_uav = [barriers::buffer_barrier_full(
-                            &buf_state.resource,
-                            D3D12_BARRIER_SYNC_COPY,
-                            D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                            D3D12_BARRIER_ACCESS_COPY_DEST,
-                            D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                         )];
                         unsafe {
                             barriers::barrier_buffers(&command_list7, &b_to_copy);
@@ -750,10 +749,10 @@ pub(super) fn submit(
                                 upload_off,
                                 data.len() as u64,
                             );
-                            barriers::barrier_buffers(&command_list7, &b_to_uav);
-                            barriers::drop_buffer_barriers(&mut b_to_uav);
                         }
                     }
+                    pending_sync.0 |= D3D12_BARRIER_SYNC_COPY.0;
+                    pending_access.0 |= D3D12_BARRIER_ACCESS_COPY_DEST.0;
                 }
             }
             GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {
@@ -1012,6 +1011,9 @@ pub(super) fn submit_graph(
     let mut current_compute_pipeline: Option<super::ComputePipelineHandle> = None;
     let mut rendered_targets: Vec<RenderTargetHandle> = Vec::new();
 
+    let mut pending_sync = D3D12_BARRIER_SYNC(0);
+    let mut pending_access = D3D12_BARRIER_ACCESS(0);
+
     for graph_cmd in commands {
         match graph_cmd {
             GraphCommand::Compute(gpu_cmd) => match gpu_cmd {
@@ -1087,9 +1089,13 @@ pub(super) fn submit_graph(
                     workgroups_x,
                     workgroups_y,
                     workgroups_z,
-                } => unsafe {
-                    command_list.Dispatch(*workgroups_x, *workgroups_y, *workgroups_z);
-                },
+                } => {
+                    unsafe {
+                        command_list.Dispatch(*workgroups_x, *workgroups_y, *workgroups_z);
+                    }
+                    pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                    pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
+                }
                 GpuCommand::DispatchIndirect { buffer, offset } => {
                     let logical_device = state
                         .devices
@@ -1154,32 +1160,53 @@ pub(super) fn submit_graph(
                         unsafe { barriers::barrier_buffers(&command_list7, &to_uav) };
                         unsafe { barriers::drop_buffer_barriers(&mut to_uav) };
                     }
+                    pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                    pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
                 }
                 GpuCommand::Barrier => {
+                    let sync_before = if pending_sync.0 != 0 {
+                        pending_sync
+                    } else {
+                        D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                    };
+                    let access_before = if pending_access.0 != 0 {
+                        pending_access
+                    } else {
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                    };
                     let g = D3D12_GLOBAL_BARRIER {
-                        SyncBefore: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                        SyncBefore: sync_before,
                         SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                        AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                        AccessBefore: access_before,
                         AccessAfter: D3D12_BARRIER_ACCESS(
                             D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                                 | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
                         ),
                     };
                     unsafe { barriers::barrier_globals(&command_list7, &[g]) };
+                    pending_sync = D3D12_BARRIER_SYNC(0);
+                    pending_access = D3D12_BARRIER_ACCESS(0);
                 }
                 GpuCommand::ResourceBarrier {
                     buffers: buf_handles,
                     textures: tex_handles,
                 } => {
+                    let sync_before = if pending_sync.0 != 0 {
+                        pending_sync
+                    } else {
+                        D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                    };
+                    let access_before = if pending_access.0 != 0 {
+                        pending_access
+                    } else {
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                    };
                     if use_global_buffer_barriers || buf_handles.is_empty() {
                         if !buf_handles.is_empty() {
-                            // SYNC_ALL covers UAV clears (CLEAR_UNORDERED_ACCESS_VIEW),
-                            // buffer copies (COPY), and indirect dispatches
-                            // (EXECUTE_INDIRECT) that may have run in the prior wave.
                             let g = D3D12_GLOBAL_BARRIER {
-                                SyncBefore: D3D12_BARRIER_SYNC_ALL,
+                                SyncBefore: sync_before,
                                 SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                AccessBefore: access_before,
                                 AccessAfter: D3D12_BARRIER_ACCESS(
                                     D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                                         | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
@@ -1194,9 +1221,9 @@ pub(super) fn submit_graph(
                             .map(|bs| {
                                 barriers::buffer_barrier_full(
                                     &bs.resource,
+                                    sync_before,
                                     D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                    D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                    access_before,
                                     D3D12_BARRIER_ACCESS(
                                         D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
                                             | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
@@ -1239,6 +1266,8 @@ pub(super) fn submit_graph(
                         .collect();
                     unsafe { barriers::barrier_textures(&command_list7, &tex_barriers) };
                     unsafe { barriers::drop_texture_barriers(&mut tex_barriers) };
+                    pending_sync = D3D12_BARRIER_SYNC(0);
+                    pending_access = D3D12_BARRIER_ACCESS(0);
                 }
                 GpuCommand::ClearBuffer {
                     buffer,
@@ -1267,21 +1296,8 @@ pub(super) fn submit_graph(
                                 *offset,
                                 clear_size,
                             )?;
-                            // ClearUnorderedAccessViewUint runs in CLEAR_UNORDERED_ACCESS_VIEW
-                            // sync scope, not COMPUTE_SHADING. Without this barrier the
-                            // TaskGraph-inserted ResourceBarrier (SyncBefore=COMPUTE_SHADING)
-                            // does not cover the clear, and subsequent dispatches may read
-                            // stale data. Mirror the same barrier present in `submit`.
-                            let g = D3D12_GLOBAL_BARRIER {
-                                SyncBefore: D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW,
-                                SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                                AccessAfter: D3D12_BARRIER_ACCESS(
-                                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
-                                        | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
-                                ),
-                            };
-                            unsafe { barriers::barrier_globals(&command_list7, &[g]) };
+                            pending_sync.0 |= D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW.0;
+                            pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
                         } else {
                             let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
                             let no_read = D3D12_RANGE { Begin: 0, End: 0 };
@@ -1344,12 +1360,6 @@ pub(super) fn submit_graph(
                                 AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                                 AccessAfter: D3D12_BARRIER_ACCESS_COPY_DEST,
                             };
-                            let post = D3D12_GLOBAL_BARRIER {
-                                SyncBefore: D3D12_BARRIER_SYNC_COPY,
-                                SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                AccessBefore: D3D12_BARRIER_ACCESS_COPY_DEST,
-                                AccessAfter: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
-                            };
                             unsafe {
                                 barriers::barrier_globals(&command_list7, &[pre]);
                                 command_list.CopyBufferRegion(
@@ -1359,7 +1369,6 @@ pub(super) fn submit_graph(
                                     upload_off,
                                     data.len() as u64,
                                 );
-                                barriers::barrier_globals(&command_list7, &[post]);
                             }
                         } else {
                             let mut b_to_copy = [barriers::buffer_barrier_full(
@@ -1368,13 +1377,6 @@ pub(super) fn submit_graph(
                                 D3D12_BARRIER_SYNC_COPY,
                                 D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                                 D3D12_BARRIER_ACCESS_COPY_DEST,
-                            )];
-                            let mut b_to_uav = [barriers::buffer_barrier_full(
-                                &buf_state.resource,
-                                D3D12_BARRIER_SYNC_COPY,
-                                D3D12_BARRIER_SYNC_COMPUTE_SHADING,
-                                D3D12_BARRIER_ACCESS_COPY_DEST,
-                                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
                             )];
                             unsafe {
                                 barriers::barrier_buffers(&command_list7, &b_to_copy);
@@ -1386,10 +1388,10 @@ pub(super) fn submit_graph(
                                     upload_off,
                                     data.len() as u64,
                                 );
-                                barriers::barrier_buffers(&command_list7, &b_to_uav);
-                                barriers::drop_buffer_barriers(&mut b_to_uav);
                             }
                         }
+                        pending_sync.0 |= D3D12_BARRIER_SYNC_COPY.0;
+                        pending_access.0 |= D3D12_BARRIER_ACCESS_COPY_DEST.0;
                     }
                 }
                 GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -624,6 +624,21 @@ pub(super) fn submit(
                             *offset,
                             clear_size,
                         )?;
+                        // ClearUnorderedAccessViewUint is a CLEAR_UNORDERED_ACCESS_VIEW
+                        // operation, not COMPUTE_SHADING. The TaskGraph-inserted
+                        // ResourceBarrier uses SyncBefore=COMPUTE_SHADING, which does not
+                        // cover the clear. Insert an explicit barrier here so that any
+                        // subsequent compute shader correctly observes the zeroed data.
+                        let g = D3D12_GLOBAL_BARRIER {
+                            SyncBefore: D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW,
+                            SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                            AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                            AccessAfter: D3D12_BARRIER_ACCESS(
+                                D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
+                                    | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
+                            ),
+                        };
+                        unsafe { barriers::barrier_globals(&command_list7, &[g]) };
                     } else {
                         // UPLOAD heap buffer: CPU-accessible, just memset
                         let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -647,16 +647,50 @@ pub(super) fn submit(
                             .devices
                             .get(&device_handle)
                             .context("ClearBuffer: invalid device")?;
-                        // Storage buffer (DEFAULT heap): GPU-side UAV clear (no staging needed)
-                        super::buffer::uav_clear(
-                            logical_device,
-                            buf_state,
-                            &command_list,
-                            *offset,
-                            clear_size,
-                        )?;
-                        pending_sync.0 |= D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW.0;
-                        pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
+                        // Zero-fill via CopyBufferRegion from the device's zero buffer.
+                        // Mirror the WriteBuffer pattern: pre-copy barrier, chunked copy, then
+                        // track pending_sync/pending_access so the wave-boundary ResourceBarrier
+                        // uses the correct SyncBefore/AccessBefore.
+                        let zero = logical_device.zero_buffer.clone();
+                        let buf_resource = buf_state.resource.clone();
+                        if use_global_buffer_barriers {
+                            let pre = D3D12_GLOBAL_BARRIER {
+                                SyncBefore: D3D12_BARRIER_SYNC_ALL,
+                                SyncAfter: D3D12_BARRIER_SYNC_COPY,
+                                AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                AccessAfter: D3D12_BARRIER_ACCESS_COPY_DEST,
+                            };
+                            unsafe { barriers::barrier_globals(&command_list7, &[pre]) };
+                        } else {
+                            let mut b_to_copy = [barriers::buffer_barrier_full(
+                                &buf_resource,
+                                D3D12_BARRIER_SYNC_ALL,
+                                D3D12_BARRIER_SYNC_COPY,
+                                D3D12_BARRIER_ACCESS_COMMON,
+                                D3D12_BARRIER_ACCESS_COPY_DEST,
+                            )];
+                            unsafe {
+                                barriers::barrier_buffers(&command_list7, &b_to_copy);
+                                barriers::drop_buffer_barriers(&mut b_to_copy);
+                            }
+                        }
+                        let mut cleared = 0u64;
+                        while cleared < clear_size {
+                            let this_chunk =
+                                (clear_size - cleared).min(super::buffer::ZERO_BUFFER_SIZE);
+                            unsafe {
+                                command_list.CopyBufferRegion(
+                                    &buf_resource,
+                                    *offset + cleared,
+                                    &zero,
+                                    0,
+                                    this_chunk,
+                                );
+                            }
+                            cleared += this_chunk;
+                        }
+                        pending_sync.0 |= D3D12_BARRIER_SYNC_COPY.0;
+                        pending_access.0 |= D3D12_BARRIER_ACCESS_COPY_DEST.0;
                     } else {
                         // UPLOAD heap buffer: CPU-accessible, just memset
                         let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
@@ -1289,15 +1323,46 @@ pub(super) fn submit_graph(
                                 .devices
                                 .get(&device_handle)
                                 .context("ClearBuffer: invalid device")?;
-                            super::buffer::uav_clear(
-                                logical_device,
-                                buf_state,
-                                &command_list,
-                                *offset,
-                                clear_size,
-                            )?;
-                            pending_sync.0 |= D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW.0;
-                            pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
+                            let zero = logical_device.zero_buffer.clone();
+                            let buf_resource = buf_state.resource.clone();
+                            if use_global_buffer_barriers {
+                                let pre = D3D12_GLOBAL_BARRIER {
+                                    SyncBefore: D3D12_BARRIER_SYNC_ALL,
+                                    SyncAfter: D3D12_BARRIER_SYNC_COPY,
+                                    AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                    AccessAfter: D3D12_BARRIER_ACCESS_COPY_DEST,
+                                };
+                                unsafe { barriers::barrier_globals(&command_list7, &[pre]) };
+                            } else {
+                                let mut b_to_copy = [barriers::buffer_barrier_full(
+                                    &buf_resource,
+                                    D3D12_BARRIER_SYNC_ALL,
+                                    D3D12_BARRIER_SYNC_COPY,
+                                    D3D12_BARRIER_ACCESS_COMMON,
+                                    D3D12_BARRIER_ACCESS_COPY_DEST,
+                                )];
+                                unsafe {
+                                    barriers::barrier_buffers(&command_list7, &b_to_copy);
+                                    barriers::drop_buffer_barriers(&mut b_to_copy);
+                                }
+                            }
+                            let mut cleared = 0u64;
+                            while cleared < clear_size {
+                                let this_chunk =
+                                    (clear_size - cleared).min(super::buffer::ZERO_BUFFER_SIZE);
+                                unsafe {
+                                    command_list.CopyBufferRegion(
+                                        &buf_resource,
+                                        *offset + cleared,
+                                        &zero,
+                                        0,
+                                        this_chunk,
+                                    );
+                                }
+                                cleared += this_chunk;
+                            }
+                            pending_sync.0 |= D3D12_BARRIER_SYNC_COPY.0;
+                            pending_access.0 |= D3D12_BARRIER_ACCESS_COPY_DEST.0;
                         } else {
                             let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
                             let no_read = D3D12_RANGE { Begin: 0, End: 0 };

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -1259,6 +1259,21 @@ pub(super) fn submit_graph(
                                 *offset,
                                 clear_size,
                             )?;
+                            // ClearUnorderedAccessViewUint runs in CLEAR_UNORDERED_ACCESS_VIEW
+                            // sync scope, not COMPUTE_SHADING. Without this barrier the
+                            // TaskGraph-inserted ResourceBarrier (SyncBefore=COMPUTE_SHADING)
+                            // does not cover the clear, and subsequent dispatches may read
+                            // stale data. Mirror the same barrier present in `submit`.
+                            let g = D3D12_GLOBAL_BARRIER {
+                                SyncBefore: D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW,
+                                SyncAfter: D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                                AccessBefore: D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                                AccessAfter: D3D12_BARRIER_ACCESS(
+                                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0
+                                        | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
+                                ),
+                            };
+                            unsafe { barriers::barrier_globals(&command_list7, &[g]) };
                         } else {
                             let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
                             let no_read = D3D12_RANGE { Begin: 0, End: 0 };

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -250,16 +250,42 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
         sig
     };
 
-    // Non-shader-visible CBV/SRV/UAV heap for ClearUnorderedAccessViewUint
-    let cpu_clear_heap_desc = D3D12_DESCRIPTOR_HEAP_DESC {
-        Type: D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-        NumDescriptors: 1,
-        Flags: D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
-        NodeMask: 0,
+    // Zero-filled UPLOAD-heap buffer used as the source for CopyBufferRegion clears.
+    // UPLOAD heaps are zero-initialized by the D3D12 runtime; no explicit memset needed.
+    // Size matches UPLOAD_CHUNK_SIZE in buffer.rs so any single chunk fits in one copy.
+    let zero_buffer_desc = D3D12_RESOURCE_DESC {
+        Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+        Alignment: 0,
+        Width: super::buffer::ZERO_BUFFER_SIZE,
+        Height: 1,
+        DepthOrArraySize: 1,
+        MipLevels: 1,
+        Format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN,
+        SampleDesc: windows::Win32::Graphics::Dxgi::Common::DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        Flags: D3D12_RESOURCE_FLAG_NONE,
     };
-    let cpu_clear_heap: ID3D12DescriptorHeap =
-        unsafe { device.CreateDescriptorHeap(&cpu_clear_heap_desc) }
-            .context("Failed to create CPU clear heap")?;
+    let zero_heap_props = D3D12_HEAP_PROPERTIES {
+        Type: D3D12_HEAP_TYPE_UPLOAD,
+        ..Default::default()
+    };
+    let mut zero_buffer_opt: Option<ID3D12Resource> = None;
+    unsafe {
+        device.CreateCommittedResource(
+            &zero_heap_props,
+            D3D12_HEAP_FLAG_NONE,
+            &zero_buffer_desc,
+            D3D12_RESOURCE_STATE_GENERIC_READ,
+            None,
+            &mut zero_buffer_opt,
+        )
+    }
+    .context("Failed to create zero buffer")?;
+    let zero_buffer =
+        zero_buffer_opt.context("CreateCommittedResource returned null for zero buffer")?;
 
     // Create fence
     let fence: ID3D12Fence = unsafe { device.CreateFence(0, D3D12_FENCE_FLAG_NONE) }
@@ -276,8 +302,7 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
         fence_value: 0,
     }];
 
-    let mut resource_registry = types::ResourceRegistry::new();
-    let scratch_clear_uav_offset = resource_registry.alloc_cbv_srv_uav_slot();
+    let resource_registry = types::ResourceRegistry::new();
 
     let (graphics_pso_blobs, compute_pso_blobs) = dirs::cache_dir().map_or_else(
         || (HashMap::new(), HashMap::new()),
@@ -317,8 +342,7 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             bindless_root_signature,
             compute_dispatch_indirect_signature,
             resource_registry,
-            cpu_clear_heap,
-            scratch_clear_uav_offset,
+            zero_buffer,
             deletion_queue: super::types::DeletionQueue::new(),
             graphics_pso_blobs,
             compute_pso_blobs,

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -71,6 +71,8 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
     let device = device.context("D3D12CreateDevice returned null")?;
     let device = device_with_enhanced_barriers(device)?;
 
+    super::install_debug_layer_exception_handler();
+
     let mut d3d12_options = D3D12_FEATURE_DATA_D3D12_OPTIONS::default();
     unsafe {
         device
@@ -266,10 +268,12 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
     let handle = state.next_device_handle;
     state.next_device_handle += 1;
 
-    // Initialize compute allocator pool with the primary allocator
+    let compute_initial_allocator: ID3D12CommandAllocator =
+        unsafe { device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }
+            .context("Failed to create compute command allocator")?;
     let compute_allocator_pool = vec![types::ComputeAllocatorSlot {
-        allocator: command_allocator.clone(),
-        fence_value: 0, // Not yet used; GetCompletedValue() >= 0 so slot is free
+        allocator: compute_initial_allocator,
+        fence_value: 0,
     }];
 
     let mut resource_registry = types::ResourceRegistry::new();

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -85,6 +85,50 @@ pub(crate) fn env_disable_reserved_buffers() -> bool {
 
 static DEBUG_LAYER_INIT: Once = Once::new();
 
+/// The D3D12 debug layer raises SEH exception 0x87D when it detects API
+/// violations. Without a handler, the default behaviour terminates the process
+/// with exit code 2173 (= 0x87D). This filter catches the exception so that
+/// the debug layer message is surfaced through the info queue instead.
+pub(super) fn install_debug_layer_exception_handler() {
+    const D3D12_DEBUG_LAYER_EXCEPTION: u32 = 0x87D;
+
+    static HANDLER_INIT: Once = Once::new();
+    HANDLER_INIT.call_once(|| {
+        extern "system" {
+            fn SetUnhandledExceptionFilter(
+                filter: Option<unsafe extern "system" fn(*mut std::ffi::c_void) -> i32>,
+            ) -> Option<unsafe extern "system" fn(*mut std::ffi::c_void) -> i32>;
+        }
+
+        unsafe extern "system" fn d3d12_exception_filter(info: *mut std::ffi::c_void) -> i32 {
+            #[repr(C)]
+            struct ExceptionRecord {
+                exception_code: u32,
+                _rest: [usize; 5],
+            }
+            #[repr(C)]
+            struct ExceptionPointers {
+                exception_record: *mut ExceptionRecord,
+                _context_record: *mut std::ffi::c_void,
+            }
+            let ptrs = info as *const ExceptionPointers;
+            let code = if !ptrs.is_null() && !(*ptrs).exception_record.is_null() {
+                (*(*ptrs).exception_record).exception_code
+            } else {
+                0
+            };
+            if code == D3D12_DEBUG_LAYER_EXCEPTION {
+                -1 // EXCEPTION_CONTINUE_EXECUTION
+            } else {
+                0 // EXCEPTION_CONTINUE_SEARCH
+            }
+        }
+        unsafe {
+            SetUnhandledExceptionFilter(Some(d3d12_exception_filter));
+        }
+    });
+}
+
 /// Shared DX12 backend singleton.
 ///
 /// The D3D12 debug layer tracks all objects process-wide and is not thread-safe
@@ -95,7 +139,11 @@ static SHARED_DX12: OnceLock<Arc<Mutex<Box<dyn super::GpuBackend>>>> = OnceLock:
 
 /// True when the D3D12 debug layer will be enabled (debug build or GOLDY_DX12_DEBUG=1).
 /// Used to decide between singleton (debug) vs per-instance (release) backend.
-fn is_debug_mode() -> bool {
+///
+/// Tests that create multiple D3D12 devices should serialize under a lock when
+/// this returns `true` — the debug layer validates resources process-wide and
+/// is not safe under concurrent device lifetimes.
+pub fn is_debug_mode() -> bool {
     let no_debug = std::env::var("GOLDY_DX12_NO_DEBUG").is_ok_and(|v| v == "1" || v == "true");
     !no_debug
         && (cfg!(debug_assertions)

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -70,9 +70,9 @@ pub(super) fn init_storage_texture_uav_layout(
     let b = barriers::texture_barrier_full(
         resource,
         D3D12_BARRIER_SYNC_NONE,
-        D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+        D3D12_BARRIER_SYNC_NONE,
         D3D12_BARRIER_ACCESS_NO_ACCESS,
-        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+        D3D12_BARRIER_ACCESS_NO_ACCESS,
         last_layout,
         D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS,
     );

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -122,7 +122,7 @@ impl ResourceRegistry {
     }
 
     /// Allocate a raw descriptor slot not tied to any resource handle.
-    /// Used for permanent device-lifetime slots (e.g. `scratch_clear_uav_offset`).
+    /// Used for permanent device-lifetime slots that need a reserved CBV/SRV/UAV index.
     pub fn alloc_cbv_srv_uav_slot(&mut self) -> u32 {
         self.cbv_srv_uav.alloc()
     }
@@ -409,13 +409,13 @@ pub(crate) struct LogicalDevice {
     /// Pool of command allocators for non-blocking compute submission.
     /// Slots can be reused when fence signals completion.
     pub compute_allocator_pool: Vec<ComputeAllocatorSlot>,
-    /// Non-shader-visible CBV/SRV/UAV heap for ClearUnorderedAccessViewUint.
-    /// DX12 requires a CPU descriptor from a non-shader-visible heap for UAV clears.
-    pub cpu_clear_heap: Direct3D12::ID3D12DescriptorHeap,
-    /// Reserved shader-visible descriptor slot for structured buffer clears.
-    /// Used to hold a temporary R32_UINT UAV so the GPU-side descriptor matches
-    /// the clear format at execution time (not just at recording time).
-    pub scratch_clear_uav_offset: u32,
+    /// Device-lifetime zero-filled UPLOAD-heap buffer used as the source for
+    /// `CopyBufferRegion` clears. One buffer per device; clears of any size are
+    /// handled by chunking `CopyBufferRegion` calls. Using a copy instead of
+    /// `ClearUnorderedAccessViewUint` avoids the shared-descriptor aliasing hazard
+    /// that caused silent corruption on WARP when multiple buffers were cleared in
+    /// the same wave (all clears rewrote the same single-slot descriptor heap).
+    pub zero_buffer: Direct3D12::ID3D12Resource,
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
     pub deletion_queue: DeletionQueue,

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -213,9 +213,14 @@ pub(super) fn record_commands_to_buffer(
     macro_rules! ensure_blit {
         () => {
             end_compute!();
-            if guard.blit.is_none() {
-                guard.blit = Some(command_buffer.new_blit_command_encoder());
-            }
+            // End any active blit encoder before opening a new one. Metal does not
+            // guarantee ordering between commands within the same blit encoder (e.g.
+            // fill_buffer and copy_from_buffer targeting the same buffer may execute
+            // in any order). Ending and reopening creates a new encoder boundary which
+            // Metal serializes, so each ClearBuffer/WriteBuffer command executes in
+            // strictly program order relative to every other blit command.
+            end_blit!();
+            guard.blit = Some(command_buffer.new_blit_command_encoder());
         };
     }
 

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -180,6 +180,13 @@ pub(super) fn record_commands_to_buffer(
     };
     let mut current_pipeline: Option<&ComputePipelineState> = None;
 
+    // Set to true once any GPU command (blit or compute) has been recorded
+    // into the current command buffer. The WriteBuffer CPU memcpy fast path
+    // must be skipped when this is true, because prior recorded commands
+    // (e.g. ClearBuffer fill_buffer) haven't executed yet and would overwrite
+    // the memcpy result when the command buffer is later committed.
+    let mut has_recorded_gpu_work = false;
+
     macro_rules! end_compute {
         () => {
             if let Some(enc) = guard.compute.take() {
@@ -207,6 +214,7 @@ pub(super) fn record_commands_to_buffer(
                 }
                 guard.compute = Some(enc);
             }
+            has_recorded_gpu_work = true;
         };
     }
 
@@ -221,6 +229,7 @@ pub(super) fn record_commands_to_buffer(
             // strictly program order relative to every other blit command.
             end_blit!();
             guard.blit = Some(command_buffer.new_blit_command_encoder());
+            has_recorded_gpu_work = true;
         };
     }
 
@@ -262,16 +271,18 @@ pub(super) fn record_commands_to_buffer(
                     *offset + data.len() as u64 <= buf_state.size,
                     "WriteBuffer: write exceeds buffer bounds"
                 );
-                // Direct CPU memcpy is safe only when no previously-committed GPU
-                // work is still in flight: if the GPU has already signaled past the
-                // last committed timeline, all reads from this buffer are complete.
-                // Otherwise we fall through to the staged blit path to avoid a race.
+                // Direct CPU memcpy is safe only when (a) no previously-committed GPU
+                // work is still in flight AND (b) no GPU commands have been recorded
+                // into the current command buffer. Condition (b) is critical: a prior
+                // ClearBuffer fill_buffer is recorded but hasn't executed; a CPU memcpy
+                // here would be overwritten when the command buffer commits.
                 const SMALL_WRITE_THRESHOLD: usize = 4096;
                 let gpu_idle = logical_device
                     .last_committed_timeline
                     .map(|last| logical_device.timeline_event.as_ref().signaled_value() >= last)
                     .unwrap_or(true);
                 if gpu_idle
+                    && !has_recorded_gpu_work
                     && !buf_state
                         .flags
                         .contains(crate::types::BufferFlags::GPU_ONLY)

--- a/tests/task_graph_integration.rs
+++ b/tests/task_graph_integration.rs
@@ -472,3 +472,364 @@ fn write_then_dispatch_reads_uploaded_data() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// GPU synchronization stress tests
+//
+// These tests target the same barrier scenarios that cause `many_bins_test`
+// flakiness in ekrano issue #26. They isolate specific patterns at the goldy
+// layer to narrow down which GPU sync path is broken.
+//
+// Each test should be run in a tight loop (e.g. 100x) to detect intermittent
+// failures:
+//   cargo test -p goldy --test task_graph_integration <name> -- --nocapture
+// ---------------------------------------------------------------------------
+
+/// Stress: clear a large buffer then verify every element is zero.
+///
+/// Uses 16K u32 elements (64 KiB) dispatched across 256 workgroups of 64 threads.
+/// This is the minimal repro shape for the `ClearBuffer → compute dispatch`
+/// barrier path. If the post-clear barrier is missing, some workgroups may read
+/// stale (nonzero) data.
+#[test]
+fn stress_clear_then_dispatch_large() {
+    let device = make_device();
+
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
+    let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
+
+    const N: usize = 16384;
+    let nonzero: Vec<u32> = (1..=N as u32).collect();
+    let buf = Buffer::with_data(&device, &nonzero, DataAccess::Scattered).unwrap();
+    let out = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+
+    let buf_idx = buf.bindless_index().unwrap();
+    let out_idx = out.bindless_index().unwrap();
+
+    let mut graph = TaskGraph::new();
+    graph.clear_buffer(&buf, 0, (N * 4) as u64);
+    graph
+        .node("copy", &copy_pipe)
+        .bind_buffer(&buf, NodeAccess::Read)
+        .bind_buffer(&out, NodeAccess::Write)
+        .bind_resources_raw_slice(&[buf_idx, out_idx])
+        .dispatch((N / 64) as u32, 1, 1);
+
+    graph.dispatch(&device).unwrap();
+
+    let result = readback_u32(&device, &out, N);
+    let nonzero_count = result.iter().filter(|&&v| v != 0).count();
+    assert_eq!(
+        nonzero_count, 0,
+        "expected all zeros after clear, but {nonzero_count}/{N} elements were nonzero"
+    );
+}
+
+/// Stress: many clears + many dispatches reading the cleared buffers in one graph.
+///
+/// Mimics Ekrano's pattern of clearing multiple pool buffers then dispatching
+/// shaders that read them all. If any clear → dispatch barrier is missing,
+/// some dispatches may read stale data.
+#[test]
+fn stress_many_clears_many_dispatches() {
+    let device = make_device();
+
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
+    let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
+
+    const N: usize = 1024;
+    const NUM_BUFS: usize = 8;
+
+    let mut srcs = Vec::new();
+    let mut outs = Vec::new();
+    for _ in 0..NUM_BUFS {
+        let nonzero: Vec<u32> = (1..=N as u32).collect();
+        srcs.push(Buffer::with_data(&device, &nonzero, DataAccess::Scattered).unwrap());
+        outs.push(Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap());
+    }
+
+    let mut graph = TaskGraph::new();
+    for src in &srcs {
+        graph.clear_buffer(src, 0, (N * 4) as u64);
+    }
+    for (src, out) in srcs.iter().zip(outs.iter()) {
+        let src_idx = src.bindless_index().unwrap();
+        let out_idx = out.bindless_index().unwrap();
+        graph
+            .node("copy", &copy_pipe)
+            .bind_buffer(src, NodeAccess::Read)
+            .bind_buffer(out, NodeAccess::Write)
+            .bind_resources_raw_slice(&[src_idx, out_idx])
+            .dispatch((N / 64) as u32, 1, 1);
+    }
+
+    graph.dispatch(&device).unwrap();
+
+    for (i, out) in outs.iter().enumerate() {
+        let result = readback_u32(&device, out, N);
+        let nonzero_count = result.iter().filter(|&&v| v != 0).count();
+        assert_eq!(
+            nonzero_count, 0,
+            "buffer {i}: expected all zeros, but {nonzero_count}/{N} elements were nonzero"
+        );
+    }
+}
+
+/// Stress: clear → write → dispatch chain, exercising both clear and write barriers.
+///
+/// Buffer is first filled with nonzero data, then cleared to zero, then
+/// overwritten with known data via write_buffer, then a dispatch copies it out.
+/// Exercises Clear→Write (WAW) and Write→Dispatch (RAW) barrier insertion.
+#[test]
+fn stress_clear_write_dispatch_chain() {
+    let device = make_device();
+
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
+    let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
+
+    const N: usize = 1024;
+    let nonzero: Vec<u32> = (1..=N as u32).collect();
+    let buf = Buffer::with_data(&device, &nonzero, DataAccess::Scattered).unwrap();
+    let out = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+
+    let buf_idx = buf.bindless_index().unwrap();
+    let out_idx = out.bindless_index().unwrap();
+
+    let known_data: Vec<u32> = (0..N as u32).map(|i| i * 7 + 42).collect();
+    let data_bytes: Vec<u8> = bytemuck::cast_slice(&known_data).to_vec();
+
+    let mut graph = TaskGraph::new();
+    graph.clear_buffer(&buf, 0, (N * 4) as u64);
+    graph.write_buffer(&buf, 0, data_bytes);
+    graph
+        .node("copy", &copy_pipe)
+        .bind_buffer(&buf, NodeAccess::Read)
+        .bind_buffer(&out, NodeAccess::Write)
+        .bind_resources_raw_slice(&[buf_idx, out_idx])
+        .dispatch((N / 64) as u32, 1, 1);
+
+    graph.dispatch(&device).unwrap();
+
+    let result = readback_u32(&device, &out, N);
+    for (i, &val) in result.iter().enumerate() {
+        let expected = known_data[i];
+        assert_eq!(
+            val, expected,
+            "element {i}: expected {expected}, got {val}"
+        );
+    }
+}
+
+/// Stress: two-phase submission — submit one graph, then submit a second graph
+/// that reads the output of the first.
+///
+/// Tests inter-submission synchronization (tail barrier correctness).
+/// Mimics Ekrano's coarse→fine two-phase rendering where flush_mid_frame
+/// submits the coarse graph and then the fine graph reads its output.
+#[test]
+fn stress_two_phase_submission() {
+    let device = make_device();
+
+    let double_shader = ShaderModule::from_slang(&device, DOUBLE_SHADER).unwrap();
+    let add_shader = ShaderModule::from_slang(&device, ADD_TEN_SHADER).unwrap();
+    let double_pipe = ComputePipeline::new(&device, &double_shader).unwrap();
+    let add_pipe = ComputePipeline::new(&device, &add_shader).unwrap();
+
+    const N: usize = 4096;
+    let input: Vec<u32> = (0..N as u32).collect();
+    let buf = Buffer::with_data(&device, &input, DataAccess::Scattered).unwrap();
+    let buf_idx = buf.bindless_index().unwrap();
+
+    // Phase 1: double in-place. Use a tmp buffer since DOUBLE_SHADER reads
+    // from one buffer and writes to another.
+    let tmp = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+    let tmp_idx = tmp.bindless_index().unwrap();
+
+    {
+        let mut graph = TaskGraph::new();
+        graph
+            .node("double", &double_pipe)
+            .bind_buffer(&buf, NodeAccess::Read)
+            .bind_buffer(&tmp, NodeAccess::Write)
+            .bind_resources_raw_slice(&[buf_idx, tmp_idx])
+            .dispatch((N / 64) as u32, 1, 1);
+        let tv = graph.submit(&device).unwrap();
+        device.wait_until(tv).unwrap();
+    }
+
+    // Phase 2: add 10 to the doubled values.
+    {
+        let mut graph = TaskGraph::new();
+        graph
+            .node("add_ten", &add_pipe)
+            .bind_buffer(&tmp, NodeAccess::ReadWrite)
+            .bind_resources_raw_slice(&[tmp_idx])
+            .dispatch((N / 64) as u32, 1, 1);
+        graph.dispatch(&device).unwrap();
+    }
+
+    let result = readback_u32(&device, &tmp, N);
+    for (i, &val) in result.iter().enumerate() {
+        let expected = (i as u32) * 2 + 10;
+        assert_eq!(val, expected, "element {i}: expected {expected}, got {val}");
+    }
+}
+
+/// Stress: rapid back-to-back submissions without waiting.
+///
+/// Submit N graphs in quick succession, each depending on the previous one's
+/// output, using only `submit` (non-blocking). Wait only at the end.
+/// This stresses the queue fence synchronization path.
+#[test]
+fn stress_rapid_submissions() {
+    let device = make_device();
+
+    let add_shader = ShaderModule::from_slang(&device, ADD_TEN_SHADER).unwrap();
+    let add_pipe = ComputePipeline::new(&device, &add_shader).unwrap();
+
+    const N: usize = 256;
+    let zeros: Vec<u32> = vec![0; N];
+    let buf = Buffer::with_data(&device, &zeros, DataAccess::Scattered).unwrap();
+    let idx = buf.bindless_index().unwrap();
+
+    const ROUNDS: u32 = 20;
+    let mut last_tv = None;
+    for _ in 0..ROUNDS {
+        let mut graph = TaskGraph::new();
+        graph
+            .node("add_ten", &add_pipe)
+            .bind_buffer(&buf, NodeAccess::ReadWrite)
+            .bind_resources_raw_slice(&[idx])
+            .dispatch((N / 64) as u32, 1, 1);
+        last_tv = Some(graph.submit(&device).unwrap());
+    }
+
+    device.wait_until(last_tv.unwrap()).unwrap();
+
+    let result = readback_u32(&device, &buf, N);
+    let expected = ROUNDS * 10;
+    for (i, &val) in result.iter().enumerate() {
+        assert_eq!(val, expected, "element {i}: expected {expected}, got {val}");
+    }
+}
+
+/// Stress: clear large buffer with indirect dispatch reading it.
+///
+/// Exercises the ClearBuffer → DispatchIndirect path. The indirect argument
+/// buffer is written by one dispatch, then a second dispatch is launched
+/// indirectly. The cleared data buffer must be fully zero when the indirect
+/// dispatch reads it.
+#[test]
+fn stress_clear_then_indirect_dispatch() {
+    let device = make_device();
+
+    // Shader that writes dispatch args: (N/64, 1, 1) at offset 0
+    let write_args_shader_src = r#"
+import goldy_exp;
+
+[goldy_compute]
+[numthreads(1, 1, 1)]
+void cs_main(Scattered<uint> args, ThreadId id) {
+    args[0] = 4;  // 256/64 workgroups
+    args[1] = 1;
+    args[2] = 1;
+}
+"#;
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
+    let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
+    let write_args_shader =
+        ShaderModule::from_slang(&device, write_args_shader_src).unwrap();
+    let write_args_pipe = ComputePipeline::new(&device, &write_args_shader).unwrap();
+
+    const N: usize = 256;
+
+    let nonzero: Vec<u32> = (1..=N as u32).collect();
+    let buf = Buffer::with_data(&device, &nonzero, DataAccess::Scattered).unwrap();
+    let out = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+    let args = Buffer::new(&device, 12, DataAccess::Scattered).unwrap();
+
+    let buf_idx = buf.bindless_index().unwrap();
+    let out_idx = out.bindless_index().unwrap();
+    let args_idx = args.bindless_index().unwrap();
+
+    let mut graph = TaskGraph::new();
+    graph.clear_buffer(&buf, 0, (N * 4) as u64);
+    graph
+        .node("write_args", &write_args_pipe)
+        .bind_buffer(&args, NodeAccess::Write)
+        .bind_resources_raw_slice(&[args_idx])
+        .dispatch(1, 1, 1);
+    graph
+        .node("copy_indirect", &copy_pipe)
+        .bind_buffer(&buf, NodeAccess::Read)
+        .bind_buffer(&out, NodeAccess::Write)
+        .bind_buffer(&args, NodeAccess::Read)
+        .bind_resources_raw_slice(&[buf_idx, out_idx])
+        .dispatch_indirect(&args, 0);
+
+    graph.dispatch(&device).unwrap();
+
+    let result = readback_u32(&device, &out, N);
+    let nonzero_count = result.iter().filter(|&&v| v != 0).count();
+    assert_eq!(
+        nonzero_count, 0,
+        "expected all zeros after clear + indirect dispatch, but {nonzero_count}/{N} were nonzero"
+    );
+}
+
+/// Stress: write → dispatch → write → dispatch chain.
+///
+/// Two write_buffer nodes each followed by a dispatch that reads the buffer,
+/// all in one graph. The second write overwrites what the first dispatch read.
+/// Tests WAW and RAW barrier insertion in sequence.
+#[test]
+fn stress_alternating_write_dispatch() {
+    let device = make_device();
+
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
+    let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
+
+    const N: usize = 256;
+
+    let buf = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+    let out1 = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+    let out2 = Buffer::new(&device, (N * 4) as u64, DataAccess::Scattered).unwrap();
+
+    let buf_idx = buf.bindless_index().unwrap();
+    let out1_idx = out1.bindless_index().unwrap();
+    let out2_idx = out2.bindless_index().unwrap();
+
+    let data1: Vec<u32> = (0..N as u32).map(|i| i + 100).collect();
+    let data2: Vec<u32> = (0..N as u32).map(|i| i + 200).collect();
+    let bytes1: Vec<u8> = bytemuck::cast_slice(&data1).to_vec();
+    let bytes2: Vec<u8> = bytemuck::cast_slice(&data2).to_vec();
+
+    let mut graph = TaskGraph::new();
+    // Phase 1: write data1 → copy to out1
+    graph.write_buffer(&buf, 0, bytes1);
+    graph
+        .node("copy1", &copy_pipe)
+        .bind_buffer(&buf, NodeAccess::Read)
+        .bind_buffer(&out1, NodeAccess::Write)
+        .bind_resources_raw_slice(&[buf_idx, out1_idx])
+        .dispatch((N / 64) as u32, 1, 1);
+    // Phase 2: write data2 (overwrites buf) → copy to out2
+    graph.write_buffer(&buf, 0, bytes2);
+    graph
+        .node("copy2", &copy_pipe)
+        .bind_buffer(&buf, NodeAccess::Read)
+        .bind_buffer(&out2, NodeAccess::Write)
+        .bind_resources_raw_slice(&[buf_idx, out2_idx])
+        .dispatch((N / 64) as u32, 1, 1);
+
+    graph.dispatch(&device).unwrap();
+
+    let result1 = readback_u32(&device, &out1, N);
+    for (i, &val) in result1.iter().enumerate() {
+        assert_eq!(val, data1[i], "out1[{i}]: expected {}, got {val}", data1[i]);
+    }
+    let result2 = readback_u32(&device, &out2, N);
+    for (i, &val) in result2.iter().enumerate() {
+        assert_eq!(val, data2[i], "out2[{i}]: expected {}, got {val}", data2[i]);
+    }
+}

--- a/tests/task_graph_integration.rs
+++ b/tests/task_graph_integration.rs
@@ -613,10 +613,7 @@ fn stress_clear_write_dispatch_chain() {
     let result = readback_u32(&device, &out, N);
     for (i, &val) in result.iter().enumerate() {
         let expected = known_data[i];
-        assert_eq!(
-            val, expected,
-            "element {i}: expected {expected}, got {val}"
-        );
+        assert_eq!(val, expected, "element {i}: expected {expected}, got {val}");
     }
 }
 
@@ -737,8 +734,7 @@ void cs_main(Scattered<uint> args, ThreadId id) {
 "#;
     let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).unwrap();
     let copy_pipe = ComputePipeline::new(&device, &copy_shader).unwrap();
-    let write_args_shader =
-        ShaderModule::from_slang(&device, write_args_shader_src).unwrap();
+    let write_args_shader = ShaderModule::from_slang(&device, write_args_shader_src).unwrap();
     let write_args_pipe = ComputePipeline::new(&device, &write_args_shader).unwrap();
 
     const N: usize = 256;


### PR DESCRIPTION
This commit adds an explicit resource barrier after the ClearUnorderedAccessViewUint operation to ensure that subsequent compute shaders correctly observe the cleared data. The barrier differentiates between the clear operation and compute shading, addressing synchronization issues in the TaskGraph.