### PR TITLE
Enhance example support in Goldy FFI by adding new compute and triang…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Goldy - Modern Graphics Library"
 repository = "https://github.com/koubaa/goldy"
 keywords = ["gpu", "graphics", "vulkan", "rendering"]
 categories = ["graphics", "rendering"]
+autoexamples = false
 
 # Allow unexpected_cfgs for objc crate's deprecated cargo-clippy cfg checks
 [lints.rust]
@@ -79,20 +80,9 @@ block = { version = "0.1", optional = true }
 [dev-dependencies]
 tempfile = "3"
 
-# PNG output for examples / integration tests that save images
-image = "0.25"
-
 # FLIP perceptual image comparison for screenshot tests
 nv-flip = "0.1"
 png = "0.18"
-
-# Tracing subscriber for examples
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# Windowing for interactive examples
-winit = "0.30"
-
-zstd = "0.13"
 
 [features]
 # Default enables all platform-appropriate backends
@@ -105,82 +95,103 @@ metal = ["dep:metal", "dep:cocoa", "dep:objc", "dep:core-graphics-types", "dep:f
 update-screenshots = ["dep:image"]
 # Structured instrumentation with named observation points (zero-cost when disabled)
 instrumentation = ["dep:tracing-subscriber"]
+# Interactive `examples/*.rs` (winit); avoids compiling winit for tests / lib-only builds
+examples = ["dep:winit"]
 
 [[example]]
 name = "triangle"
 path = "examples/triangle.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "digital_clock"
 path = "examples/digital_clock.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "gradient"
 path = "examples/gradient.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "plasma"
 path = "examples/plasma.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "starfield"
 path = "examples/starfield.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "mandelbrot"
 path = "examples/mandelbrot.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "bouncing_lines"
 path = "examples/bouncing_lines.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "spinning_cube"
 path = "examples/spinning_cube.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "metaballs"
 path = "examples/metaballs.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "checkerboard"
 path = "examples/checkerboard.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "instancing"
 path = "examples/instancing.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "particles"
 path = "examples/particles.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "waveform"
 path = "examples/waveform.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "tunnel"
 path = "examples/tunnel.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "multi_window"
 path = "examples/multi_window.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "compute_particles"
 path = "examples/compute_particles.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "game_of_life"
 path = "examples/game_of_life.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "depth_quads"
 path = "examples/depth_quads.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "compute_to_surface"
 path = "examples/compute_to_surface.rs"
+required-features = ["examples"]
 
 [[bin]]
 name = "update-screenshots"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -8,11 +8,15 @@ repository = "https://github.com/koubaa/goldy"
 keywords = ["gpu", "graphics", "ffi", "c-bindings"]
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+# `rlib` is required for Rust integration tests / examples; C interop uses cdylib/staticlib.
+crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
 # Core goldy library - default-features = false allows feature passthrough
 goldy = { path = "..", default-features = false }
+
+# Windowing for in-tree Rust examples (optional; see `examples` feature)
+winit = { version = "0.30", optional = true }
 
 # Error handling
 anyhow = "1.0"
@@ -26,6 +30,9 @@ once_cell = "1.19"
 # Raw window handles for surface creation
 raw-window-handle = "0.6"
 
+[dev-dependencies]
+bytemuck = { version = "1.21", features = ["derive"] }
+
 [build-dependencies]
 # C header generation
 cbindgen = "0.29"
@@ -37,3 +44,15 @@ default = ["vulkan", "dx12", "metal"]
 vulkan = ["goldy/vulkan"]
 dx12 = ["goldy/dx12"]
 metal = ["goldy/metal"]
+# Interactive Rust examples (`ffi/examples/`); enables winit on this crate and goldy
+examples = ["dep:winit", "goldy/examples"]
+
+[[example]]
+name = "triangle"
+path = "examples/triangle.rs"
+required-features = ["examples"]
+
+[[example]]
+name = "compute_simple"
+path = "examples/compute_simple.rs"
+required-features = ["examples"]

--- a/ffi/examples/compute_simple.rs
+++ b/ffi/examples/compute_simple.rs
@@ -1,0 +1,93 @@
+//! Headless compute example using the Goldy C ABI from Rust.
+//!
+//! Run from `goldy/ffi`:
+//! `cargo run --example compute_simple --features examples`
+
+use goldy_ffi::{
+    goldy_buffer_create_with_data, goldy_buffer_destroy, goldy_compute_encoder_bind_resources,
+    goldy_compute_encoder_create, goldy_compute_encoder_destroy, goldy_compute_encoder_dispatch,
+    goldy_compute_encoder_execute, goldy_compute_encoder_set_pipeline,
+    goldy_compute_pipeline_create, goldy_compute_pipeline_destroy, goldy_device_destroy,
+    goldy_get_last_error, goldy_instance_create, goldy_instance_create_device,
+    goldy_instance_destroy, goldy_shader_create, goldy_shader_destroy, GoldyBuffer,
+    GoldyComputeEncoder, GoldyComputePipeline, GoldyDataAccess, GoldyDevice, GoldyDeviceType,
+    GoldyInstance, GoldyResult, GoldyShaderModule,
+};
+use std::ffi::{CStr, CString};
+
+const COMPUTE_SRC: &str = r#"
+import goldy_exp;
+
+[goldy_compute]
+[numthreads(64, 1, 1)]
+void cs_main(Scattered<float> data, ThreadId id) {
+    uint idx = id.x;
+    if (idx < 64u) {
+        data[idx] = float(idx) * 2.0;
+    }
+}
+"#;
+
+fn last_ffi_message() -> String {
+    unsafe {
+        let p = goldy_get_last_error();
+        if p.is_null() {
+            return "(no message)".into();
+        }
+        CStr::from_ptr(p).to_string_lossy().into_owned()
+    }
+}
+
+fn main() {
+    println!("Goldy FFI compute_simple (Rust client of the C ABI)\n");
+
+    unsafe {
+        let instance: *mut GoldyInstance = goldy_instance_create();
+        assert!(!instance.is_null(), "{}", last_ffi_message());
+
+        let device: *mut GoldyDevice =
+            goldy_instance_create_device(instance, GoldyDeviceType::DiscreteGpu);
+        assert!(!device.is_null(), "{}", last_ffi_message());
+
+        let data = [0f32; 64];
+        let buf = goldy_buffer_create_with_data(
+            device,
+            bytemuck::cast_slice(&data).as_ptr(),
+            std::mem::size_of_val(&data),
+            GoldyDataAccess::Scattered,
+        );
+        assert!(!buf.is_null(), "{}", last_ffi_message());
+
+        let c_src = CString::new(COMPUTE_SRC).expect("shader source has no interior nul");
+        let shader: *mut GoldyShaderModule = goldy_shader_create(device, c_src.as_ptr());
+        assert!(!shader.is_null(), "{}", last_ffi_message());
+
+        let pipeline: *mut GoldyComputePipeline = goldy_compute_pipeline_create(device, shader);
+        assert!(!pipeline.is_null(), "{}", last_ffi_message());
+
+        let encoder: *mut GoldyComputeEncoder = goldy_compute_encoder_create();
+        assert!(!encoder.is_null());
+
+        goldy_compute_encoder_set_pipeline(encoder, pipeline);
+        let buf_ptr: *const GoldyBuffer = buf;
+        let bind = [buf_ptr];
+        goldy_compute_encoder_bind_resources(encoder, bind.as_ptr(), 1);
+        goldy_compute_encoder_dispatch(encoder, 1, 1, 1);
+
+        assert_eq!(
+            goldy_compute_encoder_execute(encoder, device),
+            GoldyResult::Ok,
+            "{}",
+            last_ffi_message()
+        );
+
+        println!("Compute dispatch completed successfully.");
+
+        goldy_compute_encoder_destroy(encoder);
+        goldy_compute_pipeline_destroy(pipeline);
+        goldy_shader_destroy(shader);
+        goldy_buffer_destroy(buf);
+        goldy_device_destroy(device);
+        goldy_instance_destroy(instance);
+    }
+}

--- a/ffi/examples/triangle.rs
+++ b/ffi/examples/triangle.rs
@@ -1,0 +1,303 @@
+//! Triangle window example using the Goldy C ABI from Rust (in-tree FFI client).
+//!
+//! Run from `goldy/ffi`:
+//! `cargo run --example triangle --features examples`
+
+use goldy_ffi::winit_surface::goldy_surface_from_winit_window;
+use goldy_ffi::{
+    goldy_buffer_create_with_data, goldy_buffer_destroy, goldy_device_destroy, goldy_encoder_clear,
+    goldy_encoder_create, goldy_encoder_draw, goldy_encoder_set_pipeline,
+    goldy_encoder_set_vertex_buffer, goldy_get_last_error, goldy_instance_create,
+    goldy_instance_create_device, goldy_instance_destroy, goldy_render_pipeline_create,
+    goldy_render_pipeline_destroy, goldy_shader_builtin_vertex_color_2d, goldy_shader_create,
+    goldy_shader_destroy, goldy_surface_acquire, goldy_surface_destroy, goldy_surface_format,
+    goldy_surface_frame_render, goldy_surface_present, goldy_surface_resize, GoldyBuffer,
+    GoldyColor, GoldyDataAccess, GoldyDevice, GoldyDeviceType, GoldyInstance,
+    GoldyPrimitiveTopology, GoldyRenderPipeline, GoldyRenderPipelineDesc, GoldyResult,
+    GoldyShaderModule, GoldySurface, GoldyVertexAttribute, GoldyVertexFormat,
+};
+use std::ffi::CStr;
+use std::mem::size_of;
+use std::sync::Arc;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
+    window::{Window, WindowId},
+};
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Vertex {
+    position: [f32; 2],
+    color: [f32; 4],
+}
+
+fn last_ffi_message() -> String {
+    unsafe {
+        let p = goldy_get_last_error();
+        if p.is_null() {
+            return "(no message)".into();
+        }
+        CStr::from_ptr(p).to_string_lossy().into_owned()
+    }
+}
+
+struct App {
+    instance: *mut GoldyInstance,
+    device: *mut GoldyDevice,
+    surface: *mut GoldySurface,
+    vertex_buffer: *mut GoldyBuffer,
+    shader: *mut GoldyShaderModule,
+    pipeline: *mut GoldyRenderPipeline,
+    window: Option<Arc<Window>>,
+    frame_count: u64,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            instance: std::ptr::null_mut(),
+            device: std::ptr::null_mut(),
+            surface: std::ptr::null_mut(),
+            vertex_buffer: std::ptr::null_mut(),
+            shader: std::ptr::null_mut(),
+            pipeline: std::ptr::null_mut(),
+            window: None,
+            frame_count: 0,
+        }
+    }
+
+    unsafe fn init_gpu(&mut self, window: &Arc<Window>) -> Result<(), String> {
+        self.instance = goldy_instance_create();
+        if self.instance.is_null() {
+            return Err(format!("goldy_instance_create: {}", last_ffi_message()));
+        }
+
+        self.device = goldy_instance_create_device(self.instance, GoldyDeviceType::DiscreteGpu);
+        if self.device.is_null() {
+            return Err(format!(
+                "goldy_instance_create_device: {}",
+                last_ffi_message()
+            ));
+        }
+
+        self.surface = goldy_surface_from_winit_window(self.device, window.as_ref());
+        if self.surface.is_null() {
+            return Err(format!(
+                "goldy_surface_from_winit_window: {}",
+                last_ffi_message()
+            ));
+        }
+
+        let vertices = [
+            Vertex {
+                position: [0.0, -0.5],
+                color: [1.0, 0.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [-0.5, 0.5],
+                color: [0.0, 1.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [0.5, 0.5],
+                color: [0.0, 0.0, 1.0, 1.0],
+            },
+        ];
+        let vb_bytes = bytemuck::cast_slice(&vertices);
+        self.vertex_buffer = goldy_buffer_create_with_data(
+            self.device,
+            vb_bytes.as_ptr(),
+            vb_bytes.len(),
+            GoldyDataAccess::Scattered,
+        );
+        if self.vertex_buffer.is_null() {
+            return Err(format!(
+                "goldy_buffer_create_with_data: {}",
+                last_ffi_message()
+            ));
+        }
+
+        let src = goldy_shader_builtin_vertex_color_2d();
+        self.shader = goldy_shader_create(self.device, src);
+        if self.shader.is_null() {
+            return Err(format!("goldy_shader_create: {}", last_ffi_message()));
+        }
+
+        let attrs = [
+            GoldyVertexAttribute {
+                location: 0,
+                format: GoldyVertexFormat::Float32x2,
+                offset: 0,
+            },
+            GoldyVertexAttribute {
+                location: 1,
+                format: GoldyVertexFormat::Float32x4,
+                offset: 8,
+            },
+        ];
+        let pipeline_desc = GoldyRenderPipelineDesc {
+            vertex_attributes: attrs.as_ptr(),
+            vertex_attribute_count: attrs.len() as u32,
+            vertex_stride: size_of::<Vertex>() as u32,
+            topology: GoldyPrimitiveTopology::TriangleList,
+            target_format: goldy_surface_format(self.surface),
+            depth_enabled: false,
+            ..Default::default()
+        };
+
+        self.pipeline =
+            goldy_render_pipeline_create(self.device, self.shader, self.shader, &pipeline_desc);
+        if self.pipeline.is_null() {
+            return Err(format!(
+                "goldy_render_pipeline_create: {}",
+                last_ffi_message()
+            ));
+        }
+
+        Ok(())
+    }
+
+    unsafe fn render_frame(&mut self) -> Result<(), String> {
+        let window = self.window.as_ref().unwrap();
+        let size = window.inner_size();
+        if size.width == 0 || size.height == 0 {
+            return Ok(());
+        }
+
+        let t = (self.frame_count as f32 * 0.02).sin() * 0.5 + 0.5;
+        let bg = GoldyColor {
+            r: 0.1 + t * 0.1,
+            g: 0.1 + t * 0.05,
+            b: 0.2 + t * 0.1,
+            a: 1.0,
+        };
+
+        let frame = goldy_surface_acquire(self.surface);
+        if frame.is_null() {
+            return Err(format!("goldy_surface_acquire: {}", last_ffi_message()));
+        }
+
+        let encoder = goldy_encoder_create();
+        if encoder.is_null() {
+            return Err("goldy_encoder_create returned null".into());
+        }
+
+        goldy_encoder_clear(encoder, bg);
+        goldy_encoder_set_pipeline(encoder, self.pipeline);
+        goldy_encoder_set_vertex_buffer(encoder, 0, self.vertex_buffer);
+        goldy_encoder_draw(encoder, 0, 3, 0, 1);
+
+        if goldy_surface_frame_render(frame, encoder) != GoldyResult::Ok {
+            return Err(format!(
+                "goldy_surface_frame_render: {}",
+                last_ffi_message()
+            ));
+        }
+
+        if goldy_surface_present(self.surface, frame) != GoldyResult::Ok {
+            return Err(format!("goldy_surface_present: {}", last_ffi_message()));
+        }
+
+        self.frame_count += 1;
+        Ok(())
+    }
+
+    unsafe fn cleanup(&mut self) {
+        if !self.pipeline.is_null() {
+            goldy_render_pipeline_destroy(self.pipeline);
+            self.pipeline = std::ptr::null_mut();
+        }
+        if !self.shader.is_null() {
+            goldy_shader_destroy(self.shader);
+            self.shader = std::ptr::null_mut();
+        }
+        if !self.vertex_buffer.is_null() {
+            goldy_buffer_destroy(self.vertex_buffer);
+            self.vertex_buffer = std::ptr::null_mut();
+        }
+        if !self.surface.is_null() {
+            goldy_surface_destroy(self.surface);
+            self.surface = std::ptr::null_mut();
+        }
+        if !self.device.is_null() {
+            goldy_device_destroy(self.device);
+            self.device = std::ptr::null_mut();
+        }
+        if !self.instance.is_null() {
+            goldy_instance_destroy(self.instance);
+            self.instance = std::ptr::null_mut();
+        }
+    }
+}
+
+impl Drop for App {
+    fn drop(&mut self) {
+        unsafe {
+            self.cleanup();
+        }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+        let attrs = Window::default_attributes()
+            .with_title("Goldy FFI — Triangle (C ABI)")
+            .with_inner_size(winit::dpi::LogicalSize::new(800, 600));
+
+        let window = Arc::new(event_loop.create_window(attrs).unwrap());
+        self.window = Some(window.clone());
+
+        unsafe {
+            if let Err(e) = self.init_gpu(&window) {
+                eprintln!("Init failed: {e}");
+                event_loop.exit();
+                return;
+            }
+        }
+        window.request_redraw();
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::KeyboardInput { event, .. } if event.state.is_pressed() => {
+                if matches!(event.logical_key, Key::Named(NamedKey::Escape)) {
+                    event_loop.exit();
+                }
+            }
+            WindowEvent::RedrawRequested => unsafe {
+                if let Err(e) = self.render_frame() {
+                    eprintln!("Render error: {e}");
+                }
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            },
+            WindowEvent::Resized(new_size) if new_size.width > 0 && new_size.height > 0 => unsafe {
+                goldy_surface_resize(self.surface, new_size.width, new_size.height);
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            },
+            _ => {}
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Goldy FFI triangle example (Rust client of the C ABI)");
+    println!("Run from goldy/ffi: cargo run --example triangle --features examples\n");
+
+    let event_loop = EventLoop::new()?;
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let mut app = App::new();
+    event_loop.run_app(&mut app)?;
+
+    Ok(())
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -17,6 +17,13 @@ mod surface;
 mod texture;
 mod types;
 
+/// Cross-platform surface creation for winit windows (Rust examples only).
+///
+/// C/C++ clients use platform entry points from the generated header (e.g. `goldy_surface_create_win32` on Windows).
+/// This helper is not part of the stable C header.
+#[cfg(feature = "examples")]
+pub mod winit_surface;
+
 pub use buffer::*;
 pub use compute::*;
 pub use device::*;

--- a/ffi/src/winit_surface.rs
+++ b/ffi/src/winit_surface.rs
@@ -1,0 +1,30 @@
+//! Create a [`GoldySurface`](crate::surface::GoldySurface) from any winit window.
+//!
+//! This uses Goldy's `Surface::new` internally. Exposed for `goldy-ffi` examples; the
+//! stable C API provides `goldy_surface_create_win32` on Windows instead.
+
+use crate::device::GoldyDevice;
+use crate::error::set_last_error_from_anyhow;
+use crate::surface::GoldySurface;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use std::ptr;
+
+/// Create a swapchain surface for `window` using an existing FFI device pointer.
+///
+/// Returns null on failure; call [`crate::goldy_get_last_error`] for details.
+pub fn goldy_surface_from_winit_window<W: HasWindowHandle + HasDisplayHandle>(
+    device: *const GoldyDevice,
+    window: &W,
+) -> *mut GoldySurface {
+    if device.is_null() {
+        set_last_error_from_anyhow(&anyhow::anyhow!("Device pointer is null"));
+        return ptr::null_mut();
+    }
+    match goldy::Surface::new(unsafe { &(*device).inner }, window) {
+        Ok(surface) => Box::into_raw(Box::new(GoldySurface { inner: surface })),
+        Err(e) => {
+            set_last_error_from_anyhow(&e);
+            ptr::null_mut()
+        }
+    }
+}

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -48,7 +48,7 @@ for i in "${!EXAMPLES[@]}"; do
     echo "========================================"
 
     start_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time; print(int(time.time()*1e9))')
-    output=$(cargo run --example "$name" 2>&1) || true
+    output=$(cargo run --example "$name" --features examples 2>&1) || true
     end_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time; print(int(time.time()*1e9))')
 
     echo "$output"


### PR DESCRIPTION
…le examples, and update Cargo.toml to include necessary dependencies and features. The run_all_examples.sh script is modified to enable the 'examples' feature when running examples. Additionally, a new winit_surface module is introduced for creating surfaces from winit windows, improving integration for Rust examples.