### PR TITLE
Enhance resource management in compute and surface handling

### DIFF
--- a/docs/src/compute/compute-to-surface.md
+++ b/docs/src/compute/compute-to-surface.md
@@ -54,7 +54,7 @@ frame.submit_compute(&graph)?;
 frame.present()?;
 ```
 
-`submit_compute` compiles the task graph into a command stream and records it into the frame's command buffer. Presentation happens when you call `present()` — the compute shader has already written the pixels.
+`submit_compute` resolves any transient resources (buffers, textures), compiles the task graph into a command stream, and records it into the frame's command buffer. Presentation happens when you call `present()` — the compute shader has already written the pixels.
 
 ## The compute shader
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -608,8 +608,13 @@ impl Device {
     /// non-blocking frame drain) can call this to reclaim slots immediately
     /// rather than waiting for the next internal call.
     ///
-    /// Also reclaims any [`DeferredPayload`]s registered via [`defer_release`] whose
-    /// epoch has been reached.
+    /// Drives all epoch-based reclamation: `VramAllocator::reclaim` drops any
+    /// [`DeferredPayload`]s registered via [`defer_release`] whose epoch has been
+    /// reached. This includes:
+    /// - `BufferView`s from the placement heap (for transient buffer lifetimes)
+    /// - `RegionReclaimToken`s from `EpochRegionsAllocator`
+    /// - `FreeRangeToken`s from `HeapTransientAllocator`
+    /// - `ResetToken`s from `BumpResetAllocator`
     ///
     /// [`DeferredPayload`]: crate::vram_allocator::DeferredPayload
     /// [`defer_release`]: Self::defer_release
@@ -696,7 +701,7 @@ impl Device {
     }
 
     /// Default pipeline depth for initial placement heap sizing.
-    const DEFAULT_PIPELINE_DEPTH: u64 = 4;
+    pub(crate) const DEFAULT_PIPELINE_DEPTH: u64 = 4;
 
     /// Resolve transient buffers via the device-owned placement heap and submit.
     ///
@@ -785,11 +790,11 @@ impl Device {
         let tv = resolved_graph.submit_with_backend(self, backend.as_mut(), None, tex_handles)?;
         drop(backend);
 
-        // Stamp and attach views to the region so they're dropped on reclaim.
+        // Stamp the ring entry and immediately defer views to VramAllocator.
+        // This keeps PlacementHeap ring entries free of view ownership (#150).
         let mut heap_guard = self.inner.placement_heap.lock().unwrap();
         let heap = heap_guard.as_mut().unwrap();
-        heap.stamp(tv);
-        heap.attach_views(views);
+        heap.stamp_and_defer_views(tv, views, self);
 
         Ok(tv)
     }

--- a/src/placement_heap.rs
+++ b/src/placement_heap.rs
@@ -3,7 +3,8 @@
 //! A [`PlacementHeap`] owns a single large GPU [`Buffer`] and carves frame-sized
 //! regions from it using a ring allocator. Each frame acquires a contiguous region,
 //! creates [`BufferView`]s at graph-colored offsets within that region, and releases
-//! the region once the GPU retires past its timeline epoch.
+//! the region once the GPU retires past its timeline epoch. View lifetimes are tracked
+//! via [`Device::defer_release`] rather than the ring itself.
 //!
 //! This eliminates per-frame `Buffer::new` overhead: in steady state the backing
 //! buffer is allocated once and reused across all frames. Only lightweight
@@ -13,6 +14,7 @@ use crate::buffer::{Buffer, BufferView};
 use crate::device::Device;
 use crate::timeline::TimelineValue;
 use crate::types::{BufferFlags, DataAccess};
+use crate::vram_allocator::DeferredPayload;
 use anyhow::{Context, Result};
 use std::collections::VecDeque;
 
@@ -41,8 +43,10 @@ pub struct PlacementHeapStats {
 /// - Frame N+1 occupies `[offset_{N+1}, ...)`
 /// - When Frame N retires, its region becomes available for future frames
 ///
-/// Views can be attached to the most recently acquired region via [`Self::attach_views`].
-/// When a region is reclaimed, its views are dropped, freeing their bindless slots.
+/// View lifetimes are managed via [`Device::defer_release`] rather than the ring
+/// itself: callers pass views to [`Self::stamp_and_defer_views`] (standalone path)
+/// or to the [`Frame`](crate::surface::Frame) keepalive (surface path). The ring
+/// tracks only byte-range allocation and timeline values.
 pub struct PlacementHeap {
     buffer: Buffer,
     page_size: u64,
@@ -58,8 +62,6 @@ struct RingEntry {
     /// Rounded-up size (page-aligned).
     size: u64,
     timeline: Option<TimelineValue>,
-    /// Views carved from this region; dropped on reclaim to free bindless slots.
-    views: Vec<BufferView>,
 }
 
 impl PlacementHeap {
@@ -179,31 +181,43 @@ impl PlacementHeap {
         }
     }
 
-    /// Stamp the most recently acquired (unstamped) region with a timeline value.
-    pub fn stamp(&mut self, timeline: TimelineValue) {
+    /// Stamp the most recently acquired region with a timeline value and immediately
+    /// defer `views` to the device's VramAllocator ring.
+    ///
+    /// The views will be dropped when `device.flush_deferred_deletions()` observes
+    /// `gpu_progress >= timeline`, freeing their bindless slots at the right time.
+    /// This is the standalone-submit path; the surface path defers views via
+    /// `Frame::keepalive` instead.
+    pub fn stamp_and_defer_views(
+        &mut self,
+        timeline: TimelineValue,
+        views: Vec<BufferView>,
+        device: &Device,
+    ) {
         if let Some(entry) = self.regions.back_mut() {
             if entry.timeline.is_none() {
                 entry.timeline = Some(timeline);
             }
         }
+        if !views.is_empty() {
+            let mut payload = DeferredPayload::new();
+            for view in views {
+                payload.push(view);
+            }
+            device.defer_release(timeline, payload);
+        }
     }
 
-    /// Stamp all unstamped regions with the given timeline (for surface-present path).
+    /// Stamp all unstamped regions with the given timeline (for the surface-present path).
+    ///
+    /// Views for these regions are already deferred via the frame's keepalive payload
+    /// (see `Frame::resolve_and_compile_transient_buffers`). This method only updates
+    /// the ring's timeline tracking so that `reclaim` can free ring space correctly.
     pub fn stamp_all_pending(&mut self, timeline: TimelineValue) {
         for entry in &mut self.regions {
             if entry.timeline.is_none() {
                 entry.timeline = Some(timeline);
             }
-        }
-    }
-
-    /// Attach views to the most recently acquired region.
-    ///
-    /// These views will be dropped when the region is reclaimed, ensuring
-    /// their bindless slots are freed at the right time.
-    pub fn attach_views(&mut self, views: Vec<BufferView>) {
-        if let Some(entry) = self.regions.back_mut() {
-            entry.views = views;
         }
     }
 
@@ -258,8 +272,18 @@ impl PlacementHeap {
             base_offset: offset,
             size,
             timeline: None,
-            views: Vec::new(),
         });
+    }
+
+    /// Stamp the most recently acquired region without deferring any views.
+    /// Used in tests and in contexts where views were already deferred by the caller.
+    #[cfg(test)]
+    pub(crate) fn stamp(&mut self, timeline: TimelineValue) {
+        if let Some(entry) = self.regions.back_mut() {
+            if entry.timeline.is_none() {
+                entry.timeline = Some(timeline);
+            }
+        }
     }
 }
 
@@ -364,5 +388,32 @@ mod tests {
 
         let count = heap.reclaim(5);
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn stamp_and_defer_views_defers_via_vram_allocator() {
+        // Verify that stamp_and_defer_views registers a DeferredPayload so that
+        // views are dropped when the VramAllocator ring processes them, not by
+        // PlacementHeap reclaim (which no longer holds views).
+        let device = test_device();
+        let mut heap = PlacementHeap::with_capacity(&device, 64 * 1024 * 1024).unwrap();
+
+        let offset = heap.acquire(4 * 1024 * 1024).unwrap();
+        let buf = heap.buffer();
+        let view = buf
+            .create_view(offset, 1024, Some(4))
+            .expect("create_view");
+
+        let epoch: u64 = 1;
+        heap.stamp_and_defer_views(epoch, vec![view], &device);
+
+        // PlacementHeap reclaim should free ring space (returns 1) because the region
+        // is stamped. Views are now managed by the VramAllocator, not the PlacementHeap.
+        let freed = heap.reclaim(epoch);
+        assert_eq!(freed, 1, "ring space should be reclaimed by PlacementHeap");
+
+        // The region has no views attached to it — PlacementHeap ring entries are
+        // now pure ring-space trackers (no view ownership).
+        assert_eq!(heap.in_flight_count(), 0, "no in-flight entries after reclaim");
     }
 }

--- a/src/placement_heap.rs
+++ b/src/placement_heap.rs
@@ -400,9 +400,7 @@ mod tests {
 
         let offset = heap.acquire(4 * 1024 * 1024).unwrap();
         let buf = heap.buffer();
-        let view = buf
-            .create_view(offset, 1024, Some(4))
-            .expect("create_view");
+        let view = buf.create_view(offset, 1024, Some(4)).expect("create_view");
 
         let epoch: u64 = 1;
         heap.stamp_and_defer_views(epoch, vec![view], &device);
@@ -414,6 +412,10 @@ mod tests {
 
         // The region has no views attached to it — PlacementHeap ring entries are
         // now pure ring-space trackers (no view ownership).
-        assert_eq!(heap.in_flight_count(), 0, "no in-flight entries after reclaim");
+        assert_eq!(
+            heap.in_flight_count(),
+            0,
+            "no in-flight entries after reclaim"
+        );
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -10,8 +10,10 @@ use crate::task_graph::TaskGraph;
 use crate::texture::Texture;
 use crate::timeline::TimelineValue;
 use crate::types::{PresentMode, SurfaceConfig, TextureFormat};
-use anyhow::Result;
+use crate::vram_allocator::DeferredPayload;
+use anyhow::{Context, Result};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// A GPU surface for zero-copy presentation to a window.
@@ -34,6 +36,10 @@ pub struct Frame {
     width: u32,
     height: u32,
     presented: bool,
+    /// Resources (e.g. transient textures) that must outlive the frame's GPU work.
+    /// Deferred to the VramAllocator ring at present time. Uses a Mutex so
+    /// submit_compute can push to it via &self without requiring &mut Frame.
+    keepalive: Mutex<DeferredPayload>,
 }
 
 impl Surface {
@@ -126,6 +132,7 @@ impl Surface {
             width: w,
             height: h,
             presented: false,
+            keepalive: Mutex::new(DeferredPayload::new()),
         })
     }
 
@@ -220,10 +227,132 @@ impl Frame {
     }
 
     /// Record analyzed compute / transfer work for this frame (e.g. compute into the swapchain).
+    ///
+    /// Graphs containing transient buffers and/or transient textures are resolved
+    /// automatically using the device-owned placement heap. The caller does not need
+    /// to call [`Device::submit`](crate::Device::submit) for graphs with transients;
+    /// this method handles the full resolution transparently.
     pub fn submit_compute(&self, graph: &TaskGraph) -> Result<()> {
-        let commands = graph.compile_commands();
+        if !graph.has_transient_resources() {
+            let commands = graph.compile_commands();
+            let mut backend = self.backend.lock().unwrap();
+            return backend.record_gpu_work(&self.token, &commands);
+        }
+
+        // Resolve transient textures first (may be needed even without transient buffers).
+        let (tex_keepalive, tex_handles) = graph.allocate_transient_textures(&self._device)?;
+
+        let commands = if graph.has_transient_buffers() {
+            self.resolve_and_compile_transient_buffers(graph, tex_handles)?
+        } else {
+            // Transient textures only — lower the IR and compile.
+            let resolved_ir =
+                TaskGraph::lower_transient_textures(graph.ir(), &tex_handles)?;
+            TaskGraph::compile_ir_to_gpu_commands(&resolved_ir)
+        };
+
+        // Stash textures so they survive until do_present defers them via VramAllocator.
+        if !tex_keepalive.is_empty() {
+            let mut keepalive = self.keepalive.lock().unwrap();
+            for tex in tex_keepalive {
+                keepalive.push(tex);
+            }
+        }
+
         let mut backend = self.backend.lock().unwrap();
         backend.record_gpu_work(&self.token, &commands)
+    }
+
+    /// Acquire a placement-heap region, create BufferViews at colored offsets, lower the
+    /// graph IR, and compile it to a flat GPU command stream.
+    ///
+    /// Mirrors the logic in `Device::submit_with_placement_heap` but targets the
+    /// surface-frame path: views are attached to the heap ring entry *unstamped*;
+    /// `do_present` stamps all pending regions via `stamp_all_pending`.
+    fn resolve_and_compile_transient_buffers(
+        &self,
+        graph: &TaskGraph,
+        tex_handles: HashMap<u32, crate::backend::TextureHandle>,
+    ) -> Result<Vec<crate::backend::GpuCommand>> {
+        use crate::buffer::BufferView;
+        use crate::placement_heap::PlacementHeap;
+
+        let (total_size, base_align, layout) = graph.transient_heap_size_and_layout()?;
+        let alloc_size = (total_size + base_align - 1).max(256);
+
+        let mut heap_guard = self._device.inner.placement_heap.lock().unwrap();
+
+        // Lazily create or grow the placement heap (same logic as Device::submit).
+        if heap_guard.is_none() {
+            let cap = (256 * 1024 * 1024u64).max(alloc_size * crate::device::Device::DEFAULT_PIPELINE_DEPTH);
+            *heap_guard = Some(
+                PlacementHeap::with_capacity(&self._device, cap)
+                    .context("failed to create device placement heap")?,
+            );
+        }
+        let heap = heap_guard.as_mut().unwrap();
+
+        let progress = self._device.gpu_progress();
+        heap.reclaim(progress);
+
+        let raw_offset = match heap.acquire(alloc_size) {
+            Some(off) => off,
+            None => {
+                let progress2 = self._device.gpu_progress();
+                heap.reclaim(progress2);
+                heap.acquire(alloc_size).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "PlacementHeap exhausted: need {} bytes, cap={}, in_flight={}",
+                        alloc_size,
+                        heap.capacity(),
+                        heap.in_flight_bytes(),
+                    )
+                })?
+            }
+        };
+        let base_offset = raw_offset.div_ceil(base_align) * base_align;
+
+        let buf = heap.buffer();
+
+        let mut views: Vec<BufferView> = Vec::with_capacity(layout.len());
+        let mut bindless_map: HashMap<u32, (u32, u32)> = HashMap::with_capacity(layout.len());
+
+        for spec in graph.transient_specs() {
+            let offset = base_offset + layout[&spec.id];
+            let view_stride = spec.stride.max(1);
+            let view = buf.create_view(offset, spec.size, Some(view_stride))?;
+            let uav = view.bindless_index().unwrap_or(u32::MAX);
+            let srv = view.bindless_srv_index().unwrap_or(uav);
+            bindless_map.insert(spec.id, (uav, srv));
+            views.push(view);
+        }
+
+        let range_map = TaskGraph::transient_buffer_range_map_with_base(
+            buf,
+            &layout,
+            graph.transient_specs(),
+            base_offset,
+        );
+        let mut resolved_ir = graph.lower_transient_buffers_with_bindless(&range_map, &bindless_map)?;
+
+        // Also lower transient textures if present.
+        if !tex_handles.is_empty() {
+            resolved_ir = TaskGraph::lower_transient_textures(&resolved_ir, &tex_handles)?;
+        }
+
+        let commands = TaskGraph::compile_ir_to_gpu_commands(&resolved_ir);
+
+        // Defer views via keepalive so they outlive the GPU work.
+        // do_present drains keepalive via device.defer_release(tv, ...).
+        // This keeps PlacementHeap ring entries free of view ownership (#150).
+        {
+            let mut keepalive = self.keepalive.lock().unwrap();
+            for view in views {
+                keepalive.push(view);
+            }
+        }
+
+        Ok(commands)
     }
 
     /// Submit all work and present. Returns the GPU timeline value when this frame completes.
@@ -248,6 +377,15 @@ impl Frame {
             if let Some(ref mut heap) = *heap_guard {
                 heap.stamp_all_pending(tv);
             }
+        }
+        // Defer any keepalive resources (e.g. transient textures from submit_compute)
+        // until the GPU retires this frame's timeline.
+        let keepalive = std::mem::replace(
+            &mut *self.keepalive.lock().unwrap(),
+            DeferredPayload::new(),
+        );
+        if !keepalive.is_empty() {
+            self._device.defer_release(tv, keepalive);
         }
         Ok(tv)
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -246,8 +246,7 @@ impl Frame {
             self.resolve_and_compile_transient_buffers(graph, tex_handles)?
         } else {
             // Transient textures only — lower the IR and compile.
-            let resolved_ir =
-                TaskGraph::lower_transient_textures(graph.ir(), &tex_handles)?;
+            let resolved_ir = TaskGraph::lower_transient_textures(graph.ir(), &tex_handles)?;
             TaskGraph::compile_ir_to_gpu_commands(&resolved_ir)
         };
 
@@ -284,7 +283,8 @@ impl Frame {
 
         // Lazily create or grow the placement heap (same logic as Device::submit).
         if heap_guard.is_none() {
-            let cap = (256 * 1024 * 1024u64).max(alloc_size * crate::device::Device::DEFAULT_PIPELINE_DEPTH);
+            let cap = (256 * 1024 * 1024u64)
+                .max(alloc_size * crate::device::Device::DEFAULT_PIPELINE_DEPTH);
             *heap_guard = Some(
                 PlacementHeap::with_capacity(&self._device, cap)
                     .context("failed to create device placement heap")?,
@@ -333,7 +333,8 @@ impl Frame {
             graph.transient_specs(),
             base_offset,
         );
-        let mut resolved_ir = graph.lower_transient_buffers_with_bindless(&range_map, &bindless_map)?;
+        let mut resolved_ir =
+            graph.lower_transient_buffers_with_bindless(&range_map, &bindless_map)?;
 
         // Also lower transient textures if present.
         if !tex_handles.is_empty() {
@@ -380,10 +381,7 @@ impl Frame {
         }
         // Defer any keepalive resources (e.g. transient textures from submit_compute)
         // until the GPU retires this frame's timeline.
-        let keepalive = std::mem::replace(
-            &mut *self.keepalive.lock().unwrap(),
-            DeferredPayload::new(),
-        );
+        let keepalive = std::mem::take(&mut *self.keepalive.lock().unwrap());
         if !keepalive.is_empty() {
             self._device.defer_release(tv, keepalive);
         }

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -334,7 +334,7 @@ impl TaskGraph {
     /// Produce a new `TaskGraph` with all transient buffer specs cleared and
     /// the IR fully resolved (no `TransientBuffer` resource ids remain).
     /// The returned graph can be submitted via `compile_commands` or
-    /// `Frame::submit_compute` without triggering the transient assert.
+    /// `Frame::submit_compute`.
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn into_resolved(&self, resolved_ir: GraphIR) -> TaskGraph {
         TaskGraph {
@@ -534,7 +534,7 @@ impl TaskGraph {
         Ok((id_to_color, color_keys))
     }
 
-    fn lower_transient_textures(
+    pub(crate) fn lower_transient_textures(
         ir: &GraphIR,
         handles: &HashMap<u32, TextureHandle>,
     ) -> Result<GraphIR> {
@@ -573,7 +573,7 @@ impl TaskGraph {
     }
 
     /// True if the graph contains at least one transient buffer (graph-colored).
-    pub fn has_transient_buffers(&self) -> bool {
+    pub(crate) fn has_transient_buffers(&self) -> bool {
         !self.transient_specs.is_empty()
     }
 
@@ -806,6 +806,11 @@ impl TaskGraph {
         self.ir.nodes.is_empty()
     }
 
+    /// Access the raw IR for internal use (e.g. transient lowering from outside the task_graph module).
+    pub(crate) fn ir(&self) -> &GraphIR {
+        &self.ir
+    }
+
     /// Compile the graph into a flat command stream.
     ///
     /// Runs the dependency analyzer, schedules waves, inserts `ResourceBarrier`
@@ -830,6 +835,18 @@ impl TaskGraph {
         let edges = analysis::build_edges(&self.ir);
         let schedule = analysis::schedule_waves(&self.ir, &edges);
         analysis::emit_commands(&self.ir, &schedule)
+    }
+
+    /// Compile a pre-lowered [`GraphIR`] into a flat GPU command stream.
+    ///
+    /// Unlike [`Self::compile_commands`], this operates directly on a resolved IR that
+    /// contains no transient specs — callers are responsible for lowering transients first.
+    /// Used by `Frame::submit_compute` to compile the resolved IR after placement-heap
+    /// allocation without going through the transient-guarded public path.
+    pub(crate) fn compile_ir_to_gpu_commands(ir: &GraphIR) -> Vec<crate::backend::GpuCommand> {
+        let edges = analysis::build_edges(ir);
+        let schedule = analysis::schedule_waves(ir, &edges);
+        analysis::emit_commands(ir, &schedule)
     }
 
     /// Like [`Self::compile_commands`] but allows graphs that include render-pass nodes.

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -568,7 +568,8 @@ impl TaskGraph {
         Ok(GraphIR { nodes })
     }
 
-    pub(crate) fn has_transient_resources(&self) -> bool {
+    /// True if the graph has any transient resources (buffers and/or textures).
+    pub fn has_transient_resources(&self) -> bool {
         !self.transient_specs.is_empty() || !self.transient_texture_specs.is_empty()
     }
 

--- a/src/transient_allocator.rs
+++ b/src/transient_allocator.rs
@@ -255,7 +255,7 @@ impl Drop for ResetToken {
 /// for debugging, but it serializes the CPU and the GPU — the CPU cannot begin recording
 /// frame N+1 until frame N's GPU work is done.
 ///
-/// When a [`ResetToken`] fires via the VramAllocator ring (`Device::flush_deferred_deletions`),
+/// When the deferred reset token fires via the VramAllocator ring (`Device::flush_deferred_deletions`),
 /// `begin_frame` can reset the pool non-blockingly. Otherwise it falls back to `wait_until`.
 ///
 /// Equivalent to a per-thread arena allocator with synchronous reset.
@@ -263,7 +263,7 @@ pub struct BumpResetAllocator {
     pool: BufferPool,
     last_epoch: Option<TimelineValue>,
     expected_max: u64,
-    /// Set to `true` by [`ResetToken::drop`] once `gpu_progress >= last_epoch`.
+    /// Set to `true` once the deferred reset token is dropped after `gpu_progress >= last_epoch`.
     /// Reset to `false` in `end_frame` when a new token is issued.
     reset_ready: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
@@ -386,7 +386,7 @@ enum RegionState {
     /// The allocator treats these conservatively: they cannot be reclaimed until an epoch
     /// is supplied, but they do not count as Active so the next `begin_frame` can proceed.
     Pending,
-    /// Reclamation has been deferred to the VramAllocator ring via a [`RegionReclaimToken`].
+    /// Reclamation has been deferred to the VramAllocator ring via a reclaim token.
     /// The token's Drop impl adds the region index to `pending_resets`; `begin_frame` then
     /// applies the reset. The epoch is retained for the safety-valve wait path.
     DeferredReclaim { epoch: TimelineValue },
@@ -441,7 +441,7 @@ pub struct EpochRegionsAllocator {
     /// Indices of regions in `Active` state, in the order they were activated this frame.
     /// On `end_frame`, every index here is moved to `DeferredReclaim`.
     active: VecDeque<usize>,
-    /// Region indices enqueued by [`RegionReclaimToken::drop`] once the VramAllocator ring
+    /// Region indices enqueued when a reclaim token is dropped once the VramAllocator ring
     /// has retired their epoch. Drained at the start of `begin_frame`.
     pending_resets: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
 }
@@ -479,13 +479,12 @@ impl EpochRegionsAllocator {
         })
     }
 
-    /// Drain any region indices enqueued by [`RegionReclaimToken::drop`] and reset them.
+    /// Drain any region indices enqueued when reclaim tokens drop and reset them.
     ///
     /// Called at the start of `begin_frame` after `device.flush_deferred_deletions()`.
     fn drain_pending_resets(&mut self) {
-        let indices: Vec<usize> = std::mem::take(
-            &mut *self.pending_resets.lock().expect("pending_resets poisoned"),
-        );
+        let indices: Vec<usize> =
+            std::mem::take(&mut *self.pending_resets.lock().expect("pending_resets poisoned"));
         for idx in indices {
             if matches!(self.regions[idx].state, RegionState::DeferredReclaim { .. }) {
                 self.regions[idx].pool.reset();
@@ -797,7 +796,7 @@ pub struct HeapTransientAllocator {
     /// `None` epoch means the epoch is not yet known (assigned in `end_frame`).
     /// `Some(e)` means the range has a known epoch but hasn't been deferred yet.
     deferred: Vec<DeferredFree>,
-    /// Ranges enqueued by [`FreeRangeToken::drop`] once their epoch retires.
+    /// Ranges enqueued when free-range tokens drop once their epoch retires.
     /// Drained by `begin_frame` via `drain_pending_frees`.
     pending_frees: std::sync::Arc<std::sync::Mutex<Vec<(u64, u64)>>>,
     /// Bytes currently live (allocated minus freed-and-retired).
@@ -830,15 +829,14 @@ impl HeapTransientAllocator {
     /// Move any freed ranges that the VramAllocator ring has already released into the free list.
     /// Called at the start of `begin_frame`.
     fn drain_pending_frees(&mut self) {
-        let ranges: Vec<(u64, u64)> = std::mem::take(
-            &mut *self.pending_frees.lock().expect("pending_frees poisoned"),
-        );
+        let ranges: Vec<(u64, u64)> =
+            std::mem::take(&mut *self.pending_frees.lock().expect("pending_frees poisoned"));
         for (offset, size) in ranges {
             self.insert_free(offset, size);
         }
     }
 
-    /// For any `deferred` frees that have a known epoch, create [`FreeRangeToken`]s and
+    /// For any `deferred` frees that have a known epoch, create deferred free-range tokens and
     /// call `device.defer_release`. Called from `begin_frame` (for `Some(epoch)` frees that
     /// arrived after the last `end_frame`) and from `end_frame` (after stamping `None` frees).
     fn flush_deferred_to_vram(&mut self, device: &Device) {
@@ -1373,8 +1371,15 @@ mod tests {
 
         a.end_frame(&device, tv);
         // Regions are now DeferredReclaim, not Empty.
-        assert!(a.retired_count() >= 1, "active region should be DeferredReclaim");
-        assert_eq!(a.empty_count(), 0, "no Empty regions immediately after end_frame");
+        assert!(
+            a.retired_count() >= 1,
+            "active region should be DeferredReclaim"
+        );
+        assert_eq!(
+            a.empty_count(),
+            0,
+            "no Empty regions immediately after end_frame"
+        );
 
         // Wait for the GPU to retire, then flush — this fires the RegionReclaimToken.
         device.wait_until(tv).expect("wait");
@@ -1382,7 +1387,11 @@ mod tests {
 
         // begin_frame drains pending_resets → regions become Empty.
         a.begin_frame(&device, 0).expect("begin 2");
-        assert_eq!(a.retired_count(), 0, "DeferredReclaim should be gone after flush+begin");
+        assert_eq!(
+            a.retired_count(),
+            0,
+            "DeferredReclaim should be gone after flush+begin"
+        );
     }
 
     #[test]
@@ -1408,7 +1417,9 @@ mod tests {
 
         alloc.begin_frame(&device, 0).unwrap();
         // Now the range should be back in the free list and reusable.
-        let v2 = alloc.alloc(&device, 1024, Some(4)).expect("alloc after reclaim");
+        let v2 = alloc
+            .alloc(&device, 1024, Some(4))
+            .expect("alloc after reclaim");
         assert_eq!(
             v2.offset(),
             offset,

--- a/src/transient_allocator.rs
+++ b/src/transient_allocator.rs
@@ -138,7 +138,9 @@ pub trait TransientAllocator: Send {
     /// Strategies use this epoch to track when in-flight regions become safe to reclaim.
     /// For surface-presented frames, pass the [`TimelineValue`] returned by `Frame::present`.
     /// For headless rendering, pass the value returned by `Device::submit`.
-    fn end_frame(&mut self, epoch: TimelineValue);
+    ///
+    /// `device` is used to call [`Device::defer_release`] for epoch-based resource cleanup.
+    fn end_frame(&mut self, device: &Device, epoch: TimelineValue);
 
     /// Total bytes of GPU memory currently held across all backing storage.
     fn capacity(&self) -> u64;
@@ -233,6 +235,19 @@ impl TransientAllocatorStrategy {
 // BumpReset strategy
 // -----------------------------------------------------------------------
 
+/// Token pushed into a [`DeferredPayload`] at `end_frame`.
+///
+/// When the VramAllocator ring drops this token (after `gpu_progress >= epoch`),
+/// it sets `reset_ready` to `true`. `begin_frame` checks this flag and, if set,
+/// can reset the pool without blocking on `wait_until`.
+struct ResetToken(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for ResetToken {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// Single-pool bump allocator that resets between frames.
 ///
 /// `begin_frame` blocks on the previous frame's epoch (if any) before resetting the bump
@@ -240,11 +255,17 @@ impl TransientAllocatorStrategy {
 /// for debugging, but it serializes the CPU and the GPU — the CPU cannot begin recording
 /// frame N+1 until frame N's GPU work is done.
 ///
+/// When a [`ResetToken`] fires via the VramAllocator ring (`Device::flush_deferred_deletions`),
+/// `begin_frame` can reset the pool non-blockingly. Otherwise it falls back to `wait_until`.
+///
 /// Equivalent to a per-thread arena allocator with synchronous reset.
 pub struct BumpResetAllocator {
     pool: BufferPool,
     last_epoch: Option<TimelineValue>,
     expected_max: u64,
+    /// Set to `true` by [`ResetToken::drop`] once `gpu_progress >= last_epoch`.
+    /// Reset to `false` in `end_frame` when a new token is issued.
+    reset_ready: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl BumpResetAllocator {
@@ -261,20 +282,27 @@ impl BumpResetAllocator {
             pool,
             last_epoch: None,
             expected_max: config.expected_max,
+            reset_ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         })
     }
 }
 
 impl TransientAllocator for BumpResetAllocator {
     fn begin_frame(&mut self, device: &Device, hint_size: u64) -> Result<()> {
-        // Wait for the previous frame's GPU work to finish before reusing the pool. This is
-        // the *fundamental* synchronization cost of the single-pool strategy: a tighter
-        // pipeline requires either a ring of pools or epoch-tagged regions (see
-        // EpochRegionsAllocator).
-        if let Some(tv) = self.last_epoch {
-            if device.gpu_progress() < tv {
-                device.wait_until(tv)?;
+        // Give the VramAllocator a chance to fire the ResetToken non-blockingly.
+        device.flush_deferred_deletions();
+
+        // If the token hasn't fired yet (GPU still in flight), fall back to blocking wait.
+        // This is the same serialization cost as before; the token path is an optimization
+        // for callers that call flush_deferred_deletions eagerly between frames.
+        if !self.reset_ready.load(std::sync::atomic::Ordering::Acquire) {
+            if let Some(tv) = self.last_epoch {
+                if device.gpu_progress() < tv {
+                    device.wait_until(tv)?;
+                }
             }
+            // Drain after wait to catch any newly-fired tokens.
+            device.flush_deferred_deletions();
         }
 
         // Grow to fit the hint if known.
@@ -303,8 +331,17 @@ impl TransientAllocator for BumpResetAllocator {
         self.pool.alloc_bytes(size, element_stride)
     }
 
-    fn end_frame(&mut self, epoch: TimelineValue) {
+    fn end_frame(&mut self, device: &Device, epoch: TimelineValue) {
         self.last_epoch = Some(epoch);
+        // Mark not-ready and issue a ResetToken to the VramAllocator ring.
+        // When the token fires, reset_ready becomes true and begin_frame can
+        // skip the blocking wait_until.
+        self.reset_ready
+            .store(false, std::sync::atomic::Ordering::Release);
+        let token = ResetToken(std::sync::Arc::clone(&self.reset_ready));
+        let mut payload = crate::vram_allocator::DeferredPayload::new();
+        payload.push(token);
+        device.defer_release(epoch, payload);
     }
 
     fn capacity(&self) -> u64 {
@@ -326,6 +363,8 @@ impl TransientAllocator for BumpResetAllocator {
     fn clear(&mut self) {
         self.pool.reset();
         self.last_epoch = None;
+        self.reset_ready
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -347,9 +386,29 @@ enum RegionState {
     /// The allocator treats these conservatively: they cannot be reclaimed until an epoch
     /// is supplied, but they do not count as Active so the next `begin_frame` can proceed.
     Pending,
-    /// Has been written by a frame whose GPU work has not yet completed. Cannot be reused
-    /// until `device.gpu_progress() >= epoch`.
-    Retired { epoch: TimelineValue },
+    /// Reclamation has been deferred to the VramAllocator ring via a [`RegionReclaimToken`].
+    /// The token's Drop impl adds the region index to `pending_resets`; `begin_frame` then
+    /// applies the reset. The epoch is retained for the safety-valve wait path.
+    DeferredReclaim { epoch: TimelineValue },
+}
+
+/// Token pushed into a [`DeferredPayload`] at `end_frame`.
+///
+/// When the VramAllocator ring drops this token (i.e., after `gpu_progress >= epoch`),
+/// the token appends the region indices to the allocator's `pending_resets` list.
+/// The next `begin_frame` call drains `pending_resets` and transitions those regions
+/// to `Empty`, making them available for reuse.
+struct RegionReclaimToken {
+    pending_resets: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
+    indices: Vec<usize>,
+}
+
+impl Drop for RegionReclaimToken {
+    fn drop(&mut self) {
+        if let Ok(mut pending) = self.pending_resets.lock() {
+            pending.extend_from_slice(&self.indices);
+        }
+    }
 }
 
 struct Region {
@@ -380,8 +439,11 @@ pub struct EpochRegionsAllocator {
     config: TransientAllocatorConfig,
     regions: Vec<Region>,
     /// Indices of regions in `Active` state, in the order they were activated this frame.
-    /// On `end_frame`, every index here is moved to `Retired`.
+    /// On `end_frame`, every index here is moved to `DeferredReclaim`.
     active: VecDeque<usize>,
+    /// Region indices enqueued by [`RegionReclaimToken::drop`] once the VramAllocator ring
+    /// has retired their epoch. Drained at the start of `begin_frame`.
+    pending_resets: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
 }
 
 impl EpochRegionsAllocator {
@@ -392,6 +454,7 @@ impl EpochRegionsAllocator {
             config,
             regions: vec![region],
             active: VecDeque::new(),
+            pending_resets: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         })
     }
 
@@ -416,15 +479,17 @@ impl EpochRegionsAllocator {
         })
     }
 
-    /// Promote any retired region whose epoch has passed back to Empty (resetting its bump
-    /// pointer). Cheap — one comparison per region.
-    fn reclaim_completed(&mut self, progress: TimelineValue) {
-        for r in &mut self.regions {
-            if let RegionState::Retired { epoch } = r.state {
-                if progress >= epoch {
-                    r.pool.reset();
-                    r.state = RegionState::Empty;
-                }
+    /// Drain any region indices enqueued by [`RegionReclaimToken::drop`] and reset them.
+    ///
+    /// Called at the start of `begin_frame` after `device.flush_deferred_deletions()`.
+    fn drain_pending_resets(&mut self) {
+        let indices: Vec<usize> = std::mem::take(
+            &mut *self.pending_resets.lock().expect("pending_resets poisoned"),
+        );
+        for idx in indices {
+            if matches!(self.regions[idx].state, RegionState::DeferredReclaim { .. }) {
+                self.regions[idx].pool.reset();
+                self.regions[idx].state = RegionState::Empty;
             }
         }
     }
@@ -444,13 +509,13 @@ impl EpochRegionsAllocator {
             .position(|r| matches!(r.state, RegionState::Empty))
     }
 
-    /// Index of the retired region with the smallest epoch, if any.
-    fn oldest_retired(&self) -> Option<(usize, TimelineValue)> {
+    /// Index of the `DeferredReclaim` region with the smallest epoch (for the safety-valve wait).
+    fn oldest_deferred(&self) -> Option<(usize, TimelineValue)> {
         self.regions
             .iter()
             .enumerate()
             .filter_map(|(i, r)| match r.state {
-                RegionState::Retired { epoch } => Some((i, epoch)),
+                RegionState::DeferredReclaim { epoch } => Some((i, epoch)),
                 _ => None,
             })
             .min_by_key(|(_, e)| *e)
@@ -466,9 +531,9 @@ impl EpochRegionsAllocator {
     /// Acquire a region to allocate from, growing or waiting as needed. Used both at the
     /// start of a frame and when an active region runs out mid-frame.
     fn acquire_region(&mut self, device: &Device, min_size: u64) -> Result<usize> {
-        // Lazy reclaim — cheap; off the steady-state hot path nothing here will succeed.
-        let progress = device.gpu_progress();
-        self.reclaim_completed(progress);
+        // Drain any tokens that fired via VramAllocator reclaim (non-blocking).
+        device.flush_deferred_deletions();
+        self.drain_pending_resets();
 
         if let Some(idx) = self.find_empty(min_size) {
             // Grow the region if it was empty but undersized.
@@ -488,29 +553,35 @@ impl EpochRegionsAllocator {
             return Ok(idx);
         }
 
-        // Pipeline-depth cap hit. Safety valve: wait on the oldest retiree.
-        if let Some((idx, epoch)) = self.oldest_retired() {
+        // Pipeline-depth cap hit. Safety valve: wait on the oldest DeferredReclaim.
+        if let Some((idx, epoch)) = self.oldest_deferred() {
             device.wait_until(epoch)?;
-            self.regions[idx].pool.reset();
+            // After waiting, drain the now-completed tokens.
+            device.flush_deferred_deletions();
+            self.drain_pending_resets();
+            // The region should now be Empty from the token, but force-reset as fallback.
+            if matches!(self.regions[idx].state, RegionState::DeferredReclaim { .. }) {
+                self.regions[idx].pool.reset();
+                self.regions[idx].state = RegionState::Empty;
+            }
             if self.regions[idx].pool.capacity() < min_size {
                 self.regions[idx].pool.resize(min_size)?;
             }
-            self.regions[idx].state = RegionState::Empty;
             self.activate(idx);
             return Ok(idx);
         }
 
-        // No Retired regions — but there may be Pending regions (deferred end_frame).
+        // No DeferredReclaim regions — but there may be Pending regions (deferred end_frame).
         // Force a GPU drain and convert Pending → Empty.
-        let progress = device.gpu_progress();
         for r in &mut self.regions {
             if r.state == RegionState::Pending {
                 r.pool.reset();
                 r.state = RegionState::Empty;
             }
         }
-        // Reclaim anything that completed during the drain.
-        self.reclaim_completed(progress);
+        // Flush again after forcing Pending→Empty.
+        device.flush_deferred_deletions();
+        self.drain_pending_resets();
 
         if let Some(idx) = self.find_empty(min_size) {
             if self.regions[idx].pool.capacity() < min_size {
@@ -532,12 +603,12 @@ impl EpochRegionsAllocator {
         self.regions.len()
     }
 
-    /// Test-only inspection.
+    /// Test-only inspection. Returns the count of `DeferredReclaim` regions.
     #[doc(hidden)]
     pub fn retired_count(&self) -> usize {
         self.regions
             .iter()
-            .filter(|r| matches!(r.state, RegionState::Retired { .. }))
+            .filter(|r| matches!(r.state, RegionState::DeferredReclaim { .. }))
             .count()
     }
 
@@ -578,9 +649,10 @@ impl TransientAllocator for EpochRegionsAllocator {
             self.active.clear();
         }
 
-        // Promote completed retirees. Non-blocking.
-        let progress = device.gpu_progress();
-        self.reclaim_completed(progress);
+        // Drain any RegionReclaimTokens that fired via VramAllocator reclaim.
+        // flush_deferred_deletions() processes all payloads whose epoch <= gpu_progress.
+        device.flush_deferred_deletions();
+        self.drain_pending_resets();
 
         // Pre-acquire one region so the first alloc is hot-path lock-free. If hint_size is 0
         // (caller has no estimate), use min_region_size so we don't allocate a tiny region.
@@ -608,20 +680,37 @@ impl TransientAllocator for EpochRegionsAllocator {
         self.regions[idx].pool.alloc_bytes(size, element_stride)
     }
 
-    fn end_frame(&mut self, epoch: TimelineValue) {
-        // Retire any Active regions from the current frame.
+    fn end_frame(&mut self, device: &Device, epoch: TimelineValue) {
+        // Collect indices to retire from the active set and any Pending regions.
+        let mut retiring: Vec<usize> = Vec::with_capacity(self.active.len());
         for &idx in &self.active {
-            self.regions[idx].state = RegionState::Retired { epoch };
+            retiring.push(idx);
         }
         self.active.clear();
 
-        // Also assign the epoch to any Pending regions from a previous frame whose
-        // end_frame was deferred (surface-presentation path).
-        for r in &mut self.regions {
+        // Also promote Pending regions (surface-path deferred end_frame).
+        for (idx, r) in self.regions.iter_mut().enumerate() {
             if r.state == RegionState::Pending {
-                r.state = RegionState::Retired { epoch };
+                retiring.push(idx);
             }
         }
+
+        if retiring.is_empty() {
+            return;
+        }
+
+        // Transition to DeferredReclaim and push a RegionReclaimToken.
+        for &idx in &retiring {
+            self.regions[idx].state = RegionState::DeferredReclaim { epoch };
+        }
+
+        let token = RegionReclaimToken {
+            pending_resets: std::sync::Arc::clone(&self.pending_resets),
+            indices: retiring,
+        };
+        let mut payload = crate::vram_allocator::DeferredPayload::new();
+        payload.push(token);
+        device.defer_release(epoch, payload);
     }
 
     fn capacity(&self) -> u64 {
@@ -667,6 +756,25 @@ struct DeferredFree {
     epoch: Option<TimelineValue>,
 }
 
+/// Token pushed into a [`DeferredPayload`] when a heap range is freed.
+///
+/// When the VramAllocator ring drops this token (after `gpu_progress >= epoch`),
+/// it enqueues the `(offset, size)` pairs into `pending_frees`. The next
+/// `begin_frame` call drains `pending_frees` and merges them back into the
+/// allocator's free list via `insert_free`.
+struct FreeRangeToken {
+    pending_frees: std::sync::Arc<std::sync::Mutex<Vec<(u64, u64)>>>,
+    ranges: Vec<(u64, u64)>,
+}
+
+impl Drop for FreeRangeToken {
+    fn drop(&mut self) {
+        if let Ok(mut pending) = self.pending_frees.lock() {
+            pending.extend_from_slice(&self.ranges);
+        }
+    }
+}
+
 /// Best-fit free-list allocator inside a single monolithic [`BufferPool`].
 ///
 /// Unlike the bump-only strategies, `HeapTransientAllocator` supports mid-frame
@@ -685,8 +793,13 @@ pub struct HeapTransientAllocator {
     watermark: u64,
     /// Coalesced free ranges available for immediate reuse: `offset -> size`.
     free_list: BTreeMap<u64, u64>,
-    /// Ranges freed this frame or earlier, waiting for their GPU epoch to retire.
+    /// Ranges freed via `free()` awaiting epoch assignment or deferral.
+    /// `None` epoch means the epoch is not yet known (assigned in `end_frame`).
+    /// `Some(e)` means the range has a known epoch but hasn't been deferred yet.
     deferred: Vec<DeferredFree>,
+    /// Ranges enqueued by [`FreeRangeToken::drop`] once their epoch retires.
+    /// Drained by `begin_frame` via `drain_pending_frees`.
+    pending_frees: std::sync::Arc<std::sync::Mutex<Vec<(u64, u64)>>>,
     /// Bytes currently live (allocated minus freed-and-retired).
     live_bytes: u64,
     /// Peak `live_bytes` observed across the lifetime of this allocator (diagnostic).
@@ -708,25 +821,50 @@ impl HeapTransientAllocator {
             watermark: 0,
             free_list: BTreeMap::new(),
             deferred: Vec::new(),
+            pending_frees: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             live_bytes: 0,
             peak_live_bytes: 0,
         })
     }
 
-    /// Move any deferred frees whose epochs have retired into the free list.
-    /// Entries with `epoch = None` are pending the current frame's timeline
-    /// (not yet stamped by `end_frame`) and are skipped.
-    fn drain_retired(&mut self, progress: TimelineValue) {
-        let mut i = 0;
-        while i < self.deferred.len() {
-            if let Some(ep) = self.deferred[i].epoch {
-                if progress >= ep {
-                    let d = self.deferred.swap_remove(i);
-                    self.insert_free(d.offset, d.size);
-                    continue;
-                }
+    /// Move any freed ranges that the VramAllocator ring has already released into the free list.
+    /// Called at the start of `begin_frame`.
+    fn drain_pending_frees(&mut self) {
+        let ranges: Vec<(u64, u64)> = std::mem::take(
+            &mut *self.pending_frees.lock().expect("pending_frees poisoned"),
+        );
+        for (offset, size) in ranges {
+            self.insert_free(offset, size);
+        }
+    }
+
+    /// For any `deferred` frees that have a known epoch, create [`FreeRangeToken`]s and
+    /// call `device.defer_release`. Called from `begin_frame` (for `Some(epoch)` frees that
+    /// arrived after the last `end_frame`) and from `end_frame` (after stamping `None` frees).
+    fn flush_deferred_to_vram(&mut self, device: &Device) {
+        if self.deferred.is_empty() {
+            return;
+        }
+        // Partition: entries with known epochs go to defer_release, None-epoch entries stay.
+        let mut to_defer: std::collections::BTreeMap<u64, Vec<(u64, u64)>> =
+            std::collections::BTreeMap::new();
+        let mut remaining = Vec::new();
+        for d in self.deferred.drain(..) {
+            if let Some(ep) = d.epoch {
+                to_defer.entry(ep).or_default().push((d.offset, d.size));
+            } else {
+                remaining.push(d);
             }
-            i += 1;
+        }
+        self.deferred = remaining;
+        for (epoch, ranges) in to_defer {
+            let token = FreeRangeToken {
+                pending_frees: std::sync::Arc::clone(&self.pending_frees),
+                ranges,
+            };
+            let mut payload = crate::vram_allocator::DeferredPayload::new();
+            payload.push(token);
+            device.defer_release(epoch, payload);
         }
     }
 
@@ -834,8 +972,11 @@ impl HeapTransientAllocator {
 
 impl TransientAllocator for HeapTransientAllocator {
     fn begin_frame(&mut self, device: &Device, _hint_size: u64) -> Result<()> {
-        let progress = device.gpu_progress();
-        self.drain_retired(progress);
+        // Flush any deferred frees with known epochs (e.g., from post-end_frame free calls).
+        self.flush_deferred_to_vram(device);
+        // Process any ranges whose tokens have been dropped by the VramAllocator ring.
+        device.flush_deferred_deletions();
+        self.drain_pending_frees();
         self.compact_watermark();
         Ok(())
     }
@@ -895,7 +1036,7 @@ impl TransientAllocator for HeapTransientAllocator {
         });
     }
 
-    fn end_frame(&mut self, epoch: TimelineValue) {
+    fn end_frame(&mut self, device: &Device, epoch: TimelineValue) {
         // Stamp any mid-frame frees (epoch=None) with this frame's timeline so
         // they become eligible for reuse only after the GPU retires this frame.
         for d in &mut self.deferred {
@@ -903,6 +1044,8 @@ impl TransientAllocator for HeapTransientAllocator {
                 d.epoch = Some(epoch);
             }
         }
+        // Convert all deferred frees to VramAllocator-tracked tokens.
+        self.flush_deferred_to_vram(device);
     }
 
     fn capacity(&self) -> u64 {
@@ -921,6 +1064,9 @@ impl TransientAllocator for HeapTransientAllocator {
         self.watermark = 0;
         self.free_list.clear();
         self.deferred.clear();
+        if let Ok(mut pending) = self.pending_frees.lock() {
+            pending.clear();
+        }
         self.live_bytes = 0;
     }
 }
@@ -1119,7 +1265,7 @@ mod tests {
         );
 
         // Stamp with epoch=1 via end_frame.
-        alloc.end_frame(1);
+        alloc.end_frame(&device, 1);
 
         // Still not available — GPU progress is 0, epoch is 1.
         alloc.begin_frame(&device, 0).unwrap();
@@ -1196,5 +1342,110 @@ mod tests {
         let v1 = alloc.alloc(&device, 2048, Some(4)).unwrap();
         assert!(alloc.capacity() >= 2048);
         assert_eq!(v1.size(), 2048);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for defer_release-driven reclamation (#150)
+    // -----------------------------------------------------------------------
+
+    fn small_config() -> TransientAllocatorConfig {
+        TransientAllocatorConfig {
+            initial_size: 4 * 1024,
+            expected_max: 16 * 1024,
+            min_region_size: 4 * 1024,
+            max_regions: 3,
+            alignment: 256,
+            flags: crate::types::BufferFlags::empty(),
+        }
+    }
+
+    #[test]
+    fn epoch_regions_defer_release_transitions_to_empty() {
+        // After end_frame, regions should be in DeferredReclaim state.
+        // After flush_deferred_deletions + begin_frame, they should be Empty.
+        let device = test_device();
+        let mut a = EpochRegionsAllocator::new(&device, small_config()).expect("create");
+
+        a.begin_frame(&device, 0).expect("begin 1");
+        let _v = a.alloc(&device, 1024, Some(4)).expect("alloc");
+        let graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&graph).expect("submit");
+
+        a.end_frame(&device, tv);
+        // Regions are now DeferredReclaim, not Empty.
+        assert!(a.retired_count() >= 1, "active region should be DeferredReclaim");
+        assert_eq!(a.empty_count(), 0, "no Empty regions immediately after end_frame");
+
+        // Wait for the GPU to retire, then flush — this fires the RegionReclaimToken.
+        device.wait_until(tv).expect("wait");
+        device.flush_deferred_deletions();
+
+        // begin_frame drains pending_resets → regions become Empty.
+        a.begin_frame(&device, 0).expect("begin 2");
+        assert_eq!(a.retired_count(), 0, "DeferredReclaim should be gone after flush+begin");
+    }
+
+    #[test]
+    fn heap_transient_free_range_token_fires_via_vram_reclaim() {
+        // After end_frame, freed ranges should be returned to the free list via
+        // FreeRangeToken (through flush_deferred_deletions + begin_frame).
+        let device = test_device();
+        let mut alloc = HeapTransientAllocator::new(&device, heap_config()).unwrap();
+
+        alloc.begin_frame(&device, 0).unwrap();
+        let v1 = alloc.alloc(&device, 1024, Some(4)).unwrap();
+        let offset = v1.offset();
+        let graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&graph).expect("submit");
+
+        // Free with known epoch.
+        alloc.free(offset, 1024, Some(tv));
+        alloc.end_frame(&device, tv);
+
+        // Wait and flush to fire the FreeRangeToken.
+        device.wait_until(tv).expect("wait");
+        device.flush_deferred_deletions();
+
+        alloc.begin_frame(&device, 0).unwrap();
+        // Now the range should be back in the free list and reusable.
+        let v2 = alloc.alloc(&device, 1024, Some(4)).expect("alloc after reclaim");
+        assert_eq!(
+            v2.offset(),
+            offset,
+            "freed range should be reused after VramAllocator reclaim"
+        );
+    }
+
+    #[test]
+    fn bump_reset_token_fires_non_blockingly() {
+        // After end_frame issues a ResetToken, flush_deferred_deletions should
+        // fire it so begin_frame can reset without blocking wait_until.
+        let device = test_device();
+        let mut a = BumpResetAllocator::new(&device, small_config()).expect("create");
+
+        a.begin_frame(&device, 0).expect("begin 1");
+        let _v = a.alloc(&device, 512, Some(4)).expect("alloc");
+        let graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&graph).expect("submit");
+
+        a.end_frame(&device, tv);
+        // reset_ready is now false.
+        assert!(
+            !a.reset_ready.load(std::sync::atomic::Ordering::Acquire),
+            "reset_ready should be false after end_frame"
+        );
+
+        // Wait and flush to fire the ResetToken.
+        device.wait_until(tv).expect("wait");
+        device.flush_deferred_deletions();
+
+        // reset_ready should be true now (token fired).
+        assert!(
+            a.reset_ready.load(std::sync::atomic::Ordering::Acquire),
+            "reset_ready should be true after flush_deferred_deletions"
+        );
+
+        // begin_frame should not need to wait again (fast path).
+        a.begin_frame(&device, 0).expect("begin 2 should not block");
     }
 }

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -2412,7 +2412,7 @@ fn transient_allocator_smoke_all_strategies() {
         // Submit empty work to advance the timeline.
         let tv = ComputeEncoder::new().submit(&device).expect("submit");
         drop(view);
-        a.end_frame(tv);
+        a.end_frame(&device, tv);
         // Next frame: should not panic, and BumpReset should wait for tv internally.
         a.begin_frame(&device, 0).expect("begin frame 2");
         let _v2 = a.alloc(&device, 256, Some(4)).expect("alloc frame 2");
@@ -2453,7 +2453,7 @@ fn bump_reset_blocks_on_prev_epoch() {
     a.begin_frame(&device, 0).expect("begin");
     let _v = a.alloc(&device, 1024, Some(4)).expect("alloc");
     let tv = ComputeEncoder::new().submit(&device).expect("submit");
-    a.end_frame(tv);
+    a.end_frame(&device, tv);
 
     // begin_frame should wait for `tv` if it hasn't completed. After it returns,
     // gpu_progress must be at least tv.
@@ -2491,7 +2491,7 @@ fn epoch_regions_spills_when_active_full() {
     );
 
     let tv = ComputeEncoder::new().submit(&device).expect("submit");
-    a.end_frame(tv);
+    a.end_frame(&device, tv);
     // After end_frame all active should be retired.
     assert_eq!(a.retired_count(), after, "all active regions must retire");
     assert_eq!(a.empty_count(), 0);
@@ -2508,7 +2508,7 @@ fn epoch_regions_reclaims_after_gpu_catches_up() {
     a.begin_frame(&device, 0).expect("begin 1");
     let _v = a.alloc(&device, 2048, Some(4)).expect("alloc");
     let tv = ComputeEncoder::new().submit(&device).expect("submit");
-    a.end_frame(tv);
+    a.end_frame(&device, tv);
     assert!(a.retired_count() >= 1);
     assert_eq!(a.empty_count(), 0);
 
@@ -2538,7 +2538,7 @@ fn epoch_regions_respects_max_regions_cap() {
         a.begin_frame(&device, 0).expect("begin");
         let _v = a.alloc(&device, 1024, Some(4)).expect("alloc");
         let tv = ComputeEncoder::new().submit(&device).expect("submit");
-        a.end_frame(tv);
+        a.end_frame(&device, tv);
         device.wait_until(tv).expect("wait");
         assert!(
             a.region_count() <= cfg.max_regions,
@@ -2564,7 +2564,7 @@ fn transient_allocator_clear_resets_state() {
         a.begin_frame(&device, 0).expect("begin");
         let _v = a.alloc(&device, 1024, Some(4)).expect("alloc");
         let tv = ComputeEncoder::new().submit(&device).expect("submit");
-        a.end_frame(tv);
+        a.end_frame(&device, tv);
         device.wait_until(tv).expect("wait");
         a.clear();
         // After clear, used_this_frame should be zero and we can begin a new frame.
@@ -2598,14 +2598,14 @@ fn epoch_regions_deferred_end_frame_does_not_leak() {
         // On odd frames, simulate delayed end_frame arriving (from note_frame_presented).
         // On even frames, let it carry over.
         if i % 2 == 1 {
-            a.end_frame(tv);
+            a.end_frame(&device, tv);
             device.wait_until(tv).expect("wait");
         }
     }
 
     // Final end_frame so everything can be reclaimed.
     let tv = ComputeEncoder::new().submit(&device).expect("submit");
-    a.end_frame(tv);
+    a.end_frame(&device, tv);
     device.wait_until(tv).expect("wait");
 
     // All regions should be reclaimable. Region count must be bounded by max_regions.
@@ -2678,7 +2678,7 @@ fn epoch_regions_pending_promoted_to_retired_on_end_frame() {
     assert_eq!(a.active_count(), 1, "frame 2 should have one Active region");
 
     // Deferred end_frame for frame 1 arrives.
-    a.end_frame(tv1);
+    a.end_frame(&device, tv1);
     assert_eq!(
         a.pending_count(),
         0,


### PR DESCRIPTION
This commit improves the management of transient resources in the compute and surface modules. The `submit_compute` function now automatically resolves transient textures and buffers, deferring their lifetimes to the VramAllocator to ensure proper resource cleanup. Additionally, the `PlacementHeap` has been refactored to manage view lifetimes more efficiently, eliminating the need for direct view attachments. The `end_frame` method in the `TransientAllocator` has been updated to utilize the device for epoch-based resource cleanup, enhancing synchronization and memory management across frames. These changes streamline GPU resource handling and improve overall performance.

Fixes #150 
Fixes #153 