### PR TITLE
Add GoldyError for device management and enhance error handling

### DIFF
--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -334,6 +334,7 @@ impl Dx12Backend {
             free_dsv_offsets: Vec::new(),
             slang_compiler,
             staging_belts: HashMap::new(),
+            device_removed: std::sync::atomic::AtomicBool::new(false),
         };
 
         Ok(Self { state })
@@ -497,6 +498,12 @@ impl GpuBackend for Dx12Backend {
 
     fn is_device_valid(&self, device: DeviceHandle) -> bool {
         self.state.devices.contains_key(&device)
+    }
+
+    fn is_device_lost(&self, _device: DeviceHandle) -> bool {
+        self.state
+            .device_removed
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn create_buffer(
@@ -821,6 +828,18 @@ impl GpuBackend for Dx12Backend {
             .fence
             .clone();
         utils::wait_for_fence(&fence, value)?;
+        // Detect TDR: device removal signals all fences with u64::MAX.
+        let completed = unsafe { fence.GetCompletedValue() };
+        if completed == u64::MAX {
+            self.state
+                .device_removed
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            if let Some(ld) = self.state.devices.get(&device_handle) {
+                let reason = unsafe { ld.device.GetDeviceRemovedReason() };
+                anyhow::bail!("GPU device removed (TDR): {:?}", reason);
+            }
+            anyhow::bail!("GPU device removed (TDR)");
+        }
         if let Some(dev) = self.state.devices.get_mut(&device_handle) {
             dev.process_deletion_queue();
         }
@@ -842,6 +861,18 @@ impl GpuBackend for Dx12Backend {
             .clone();
         let ok = utils::wait_for_fence_timeout(&fence, value, timeout_ms)?;
         if ok {
+            // Detect TDR: device removal signals all fences with u64::MAX.
+            let completed = unsafe { fence.GetCompletedValue() };
+            if completed == u64::MAX {
+                self.state
+                    .device_removed
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                if let Some(ld) = self.state.devices.get(&device_handle) {
+                    let reason = unsafe { ld.device.GetDeviceRemovedReason() };
+                    anyhow::bail!("GPU device removed (TDR): {:?}", reason);
+                }
+                anyhow::bail!("GPU device removed (TDR)");
+            }
             if let Some(dev) = self.state.devices.get_mut(&device_handle) {
                 dev.process_deletion_queue();
             }

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -761,4 +761,8 @@ pub(super) struct Dx12State {
     pub slang_compiler: crate::slang::SlangCompiler,
     /// Per-device upload belts for `GpuCommand::WriteBuffer`.
     pub(super) staging_belts: HashMap<DeviceHandle, super::staging::StagingBelt>,
+    /// Set to `true` when a TDR / device-removal is detected (fence completed with `u64::MAX`
+    /// or `GetDeviceRemovedReason` returns a non-ok HRESULT).
+    /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.
+    pub device_removed: std::sync::atomic::AtomicBool,
 }

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -153,6 +153,12 @@ impl GpuBackend for MetalBackend {
         device::is_valid(&self.state, device)
     }
 
+    fn is_device_lost(&self, _device: DeviceHandle) -> bool {
+        self.state
+            .device_lost
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     fn create_buffer(
         &mut self,
         device: DeviceHandle,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -363,6 +363,16 @@ pub trait GpuBackend: Send + Sync {
     fn destroy_device(&mut self, device: DeviceHandle);
     fn is_device_valid(&self, device: DeviceHandle) -> bool;
 
+    /// Returns `true` if the device has been permanently lost (TDR, hardware hang, etc.).
+    ///
+    /// Backends set this flag atomically when they detect device loss so that
+    /// [`Device::is_device_lost`](crate::Device::is_device_lost) can be polled from the
+    /// render loop without acquiring any lock. The default returns `false` for
+    /// backends that have not yet wired up the flag.
+    fn is_device_lost(&self, _device: DeviceHandle) -> bool {
+        false
+    }
+
     // Buffer management
     fn create_buffer(
         &mut self,

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -255,6 +255,7 @@ impl VulkanBackend {
             compute_texture_staging_pool: HashMap::new(),
             staging_belts: HashMap::new(),
             timeline_cmd_buffers: HashMap::new(),
+            device_lost: std::sync::atomic::AtomicBool::new(false),
         };
 
         Ok(Self { state })
@@ -297,6 +298,12 @@ impl GpuBackend for VulkanBackend {
 
     fn is_device_valid(&self, device: DeviceHandle) -> bool {
         device::is_valid(&self.state, device)
+    }
+
+    fn is_device_lost(&self, _device: DeviceHandle) -> bool {
+        self.state
+            .device_lost
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn create_buffer(
@@ -1029,7 +1036,14 @@ impl GpuBackend for VulkanBackend {
         let wait = vk::SemaphoreWaitInfo::default()
             .semaphores(std::slice::from_ref(&sem))
             .values(std::slice::from_ref(&value));
-        unsafe { dev.wait_semaphores(&wait, u64::MAX) }.context("wait_semaphores failed")?;
+        if let Err(e) = unsafe { dev.wait_semaphores(&wait, u64::MAX) } {
+            if e == vk::Result::ERROR_DEVICE_LOST {
+                self.state
+                    .device_lost
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            return Err(anyhow::anyhow!("wait_semaphores: {:?}", e));
+        }
         compute::reap_timeline_cmd_buffers_up_to(&mut self.state, device_handle, value);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             let drained = ld.deletion_queue.drain_up_to(value);
@@ -1069,7 +1083,14 @@ impl GpuBackend for VulkanBackend {
                 Ok(true)
             }
             Err(vk::Result::TIMEOUT) => Ok(false),
-            Err(e) => Err(anyhow::anyhow!("wait_semaphores: {:?}", e)),
+            Err(e) => {
+                if e == vk::Result::ERROR_DEVICE_LOST {
+                    self.state
+                        .device_lost
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+                Err(anyhow::anyhow!("wait_semaphores: {:?}", e))
+            }
         }
     }
 

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -885,4 +885,7 @@ pub(super) struct VulkanState {
     /// Command buffers to free once the device timeline reaches the given value
     /// (one submit may register multiple buffers at the same timeline point).
     pub timeline_cmd_buffers: HashMap<u64, Vec<(DeviceHandle, vk::CommandBuffer)>>,
+    /// Set to `true` when any Vulkan call returns `VK_ERROR_DEVICE_LOST`.
+    /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.
+    pub device_lost: std::sync::atomic::AtomicBool,
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -25,6 +25,7 @@
 //! multi-queue support for parallel command submission if needed.
 
 use crate::backend::{self, AdapterInfo, DeviceHandle, GpuBackend};
+use crate::error::GoldyError;
 use crate::shader_library::ShaderLibrary;
 use crate::slang::{ShaderTarget, SlangCompiler, StructLayout};
 use crate::task_graph::TaskGraph;
@@ -566,16 +567,50 @@ impl Device {
         self.inner.high_water_timeline.load(Ordering::Relaxed)
     }
 
-    /// Block until the device timeline reaches at least `value`.
-    pub fn wait_until(&self, value: TimelineValue) -> Result<()> {
-        let mut backend = self.inner.backend.lock().unwrap();
-        backend.wait_until(self.inner.handle, value)
+    /// Returns `true` if the device has been permanently lost.
+    ///
+    /// After this returns `true`, all further submit / wait calls will fail with
+    /// [`GoldyError::DeviceLost`]. The device should be dropped and re-created.
+    pub fn is_device_lost(&self) -> bool {
+        self.inner
+            .backend
+            .lock()
+            .unwrap()
+            .is_device_lost(self.inner.handle)
     }
 
-    /// Like [`wait_until`](Self::wait_until) but returns `Ok(false)` on timeout.
-    pub fn wait_until_timeout(&self, value: TimelineValue, timeout_ms: u32) -> Result<bool> {
+    /// Map a backend [`anyhow::Error`] to the appropriate [`GoldyError`] variant.
+    fn classify(&self, e: anyhow::Error) -> GoldyError {
+        if self.is_device_lost() {
+            return GoldyError::DeviceLost;
+        }
+        GoldyError::Backend(e)
+    }
+
+    /// Block until the device timeline reaches at least `value`.
+    pub fn wait_until(&self, value: TimelineValue) -> Result<(), GoldyError> {
         let mut backend = self.inner.backend.lock().unwrap();
-        backend.wait_until_timeout(self.inner.handle, value, timeout_ms)
+        backend.wait_until(self.inner.handle, value).map_err(|e| {
+            drop(backend);
+            self.classify(e)
+        })
+    }
+
+    /// Like [`wait_until`](Self::wait_until) but returns `Err(`[`GoldyError::SubmitTimeout`]`)` on timeout.
+    pub fn wait_until_timeout(
+        &self,
+        value: TimelineValue,
+        timeout_ms: u32,
+    ) -> Result<(), GoldyError> {
+        let mut backend = self.inner.backend.lock().unwrap();
+        match backend.wait_until_timeout(self.inner.handle, value, timeout_ms) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(GoldyError::SubmitTimeout),
+            Err(e) => {
+                drop(backend);
+                Err(self.classify(e))
+            }
+        }
     }
 
     /// Number of bindless descriptor slots still available for allocation in
@@ -672,20 +707,29 @@ impl Device {
     /// by the device. The heap is lazily created on first use and reused across
     /// submissions — callers never need to manage transient buffer backing
     /// storage, view creation, or bindless index patching.
-    pub fn submit(&self, graph: &TaskGraph) -> Result<TimelineValue> {
+    pub fn submit(&self, graph: &TaskGraph) -> Result<TimelineValue, GoldyError> {
         if !graph.has_transient_resources() {
             let mut backend = self.inner.backend.lock().unwrap();
-            let tv = graph.submit_with_backend(self, backend.as_mut(), None, &HashMap::new())?;
+            let tv = graph
+                .submit_with_backend(self, backend.as_mut(), None, &HashMap::new())
+                .map_err(|e| {
+                    drop(backend);
+                    self.classify(e)
+                })?;
             self.inner
                 .high_water_timeline
                 .fetch_max(tv, Ordering::Relaxed);
             return Ok(tv);
         }
 
-        let (_tex_keepalive, tex_handles) = graph.allocate_transient_textures(self)?;
+        let (_tex_keepalive, tex_handles) = graph
+            .allocate_transient_textures(self)
+            .map_err(|e| self.classify(e))?;
 
         if graph.has_transient_buffers() {
-            let tv = self.submit_with_placement_heap(graph, &tex_handles)?;
+            let tv = self
+                .submit_with_placement_heap(graph, &tex_handles)
+                .map_err(|e| self.classify(e))?;
             self.inner
                 .high_water_timeline
                 .fetch_max(tv, Ordering::Relaxed);
@@ -693,7 +737,12 @@ impl Device {
         }
 
         let mut backend = self.inner.backend.lock().unwrap();
-        let tv = graph.submit_with_backend(self, backend.as_mut(), None, &tex_handles)?;
+        let tv = graph
+            .submit_with_backend(self, backend.as_mut(), None, &tex_handles)
+            .map_err(|e| {
+                drop(backend);
+                self.classify(e)
+            })?;
         self.inner
             .high_water_timeline
             .fetch_max(tv, Ordering::Relaxed);
@@ -800,7 +849,7 @@ impl Device {
     }
 
     /// Submit a task graph and block until it completes.
-    pub fn dispatch(&self, graph: &TaskGraph) -> Result<()> {
+    pub fn dispatch(&self, graph: &TaskGraph) -> Result<(), GoldyError> {
         let v = self.submit(graph)?;
         self.wait_until(v)
     }
@@ -1055,8 +1104,11 @@ impl Drop for DeviceInner {
         );
         // Wait for all submitted GPU work to complete. This covers any in-flight work not
         // covered by the placement-heap wait (e.g. non-transient submits held by callers).
+        // Skip the wait if the device is already lost: the hardware cannot make progress
+        // and backends handle per-object teardown ordering inside destroy_device.
         let high_water = self.high_water_timeline.load(Ordering::Relaxed);
-        if high_water > 0 {
+        let already_lost = self.backend.lock().unwrap().is_device_lost(self.handle);
+        if high_water > 0 && !already_lost {
             let mut backend = self.backend.lock().unwrap();
             let _ = backend.wait_until(self.handle, high_water);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+/// Typed error variants for the goldy public API.
+///
+/// Returned by [`Device::submit`], [`Device::dispatch`], [`Device::wait_until`],
+/// and [`Device::wait_until_timeout`] so callers can distinguish recoverable
+/// conditions (timeout) from permanent ones (device loss) without string-matching.
+#[derive(Debug, thiserror::Error)]
+pub enum GoldyError {
+    /// The GPU device has been lost and cannot process further commands.
+    ///
+    /// Any resources associated with this device are now invalid. The caller
+    /// should drop the [`Device`](crate::Device) and re-create from a new
+    /// [`Instance`](crate::Instance) if recovery is desired.
+    #[error("GPU device lost")]
+    DeviceLost,
+
+    /// The GPU or driver ran out of memory.
+    ///
+    /// The operation was not completed. The caller may attempt to free
+    /// resources and retry, or treat this as fatal.
+    #[error("GPU out of memory")]
+    OutOfMemory,
+
+    /// A fence or timeline wait exceeded the requested timeout.
+    ///
+    /// Returned by [`Device::wait_until_timeout`] when the GPU has not
+    /// reached the target [`TimelineValue`](crate::TimelineValue) within
+    /// the specified `timeout_ms`. The device itself is still healthy.
+    #[error("GPU submit timed out")]
+    SubmitTimeout,
+
+    /// An unexpected backend error that does not map to the typed variants above.
+    #[error(transparent)]
+    Backend(#[from] anyhow::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 /// Typed error variants for the goldy public API.
 ///
-/// Returned by [`Device::submit`], [`Device::dispatch`], [`Device::wait_until`],
-/// and [`Device::wait_until_timeout`] so callers can distinguish recoverable
+/// Returned by [`crate::Device::submit`], [`crate::Device::dispatch`], [`crate::Device::wait_until`],
+/// and [`crate::Device::wait_until_timeout`] so callers can distinguish recoverable
 /// conditions (timeout) from permanent ones (device loss) without string-matching.
 #[derive(Debug, thiserror::Error)]
 pub enum GoldyError {
@@ -22,7 +22,7 @@ pub enum GoldyError {
 
     /// A fence or timeline wait exceeded the requested timeout.
     ///
-    /// Returned by [`Device::wait_until_timeout`] when the GPU has not
+    /// Returned by [`crate::Device::wait_until_timeout`] when the GPU has not
     /// reached the target [`TimelineValue`](crate::TimelineValue) within
     /// the specified `timeout_ms`. The device itself is still healthy.
     #[error("GPU submit timed out")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod common_types;
 pub mod compute;
 pub mod device;
 pub mod encoder;
+pub mod error;
 pub mod examples;
 pub mod pipeline;
 pub mod render_target;
@@ -41,6 +42,7 @@ pub mod placement_heap;
 pub mod timeline;
 pub mod transient_allocator;
 pub mod vram_allocator;
+pub use error::GoldyError;
 pub use gpu_guard::GpuGuard;
 pub use vram_allocator::DeferredPayload;
 

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -13,6 +13,7 @@ use crate::buffer::{Buffer, BufferView};
 use crate::compute::ComputePipeline;
 use crate::device::Device;
 use crate::encoder::CommandEncoder;
+use crate::error::GoldyError;
 use crate::render_target::RenderTarget;
 use crate::texture::Texture;
 use crate::timeline::TimelineValue;
@@ -789,12 +790,12 @@ impl TaskGraph {
 
     /// Analyze the graph and submit all tasks with optimal barriers.
     /// Returns the device [`TimelineValue`] to pass to [`Device::wait_until`].
-    pub fn submit(&self, device: &Device) -> Result<TimelineValue> {
+    pub fn submit(&self, device: &Device) -> Result<TimelineValue, GoldyError> {
         device.submit(self)
     }
 
     /// Analyze the graph, submit, and block until complete.
-    pub fn dispatch(&self, device: &Device) -> Result<()> {
+    pub fn dispatch(&self, device: &Device) -> Result<(), GoldyError> {
         device.dispatch(self)
     }
 


### PR DESCRIPTION
This commit introduces a new `GoldyError` type to provide typed error variants for the Goldy API, allowing for better error handling in device management. The `Device` implementation is updated to include methods for checking if a device is lost and classifying errors. The `submit`, `dispatch`, and `wait_until` methods now return results with `GoldyError`, improving clarity on recoverable versus permanent errors. Additionally, backend implementations are updated to track device loss, enhancing overall robustness in GPU resource management.

Fixes #149 