### PR TITLE
Implement FrameOrchestrator for managing pipelined frame submissions …

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [ComputeEncoder](./compute/encoder.md)
 - [Task Graph](./compute/task-graph.md)
 - [Device Timeline](./compute/timeline.md)
+- [Pipelined Frames](./compute/pipelined-frames.md)
 - [Compute to Surface](./compute/compute-to-surface.md)
 
 # Graphics Workflows

--- a/docs/src/compute/pipelined-frames.md
+++ b/docs/src/compute/pipelined-frames.md
@@ -1,0 +1,169 @@
+# Pipelined Frames
+
+Goldy's `FrameOrchestrator<T>` manages the lifecycle of multiple in-flight GPU frames so your CPU can record frame N+1 while the GPU executes frame N, without any manually written cleanup rings or deferred-timeline-patching code.
+
+## The problem it solves
+
+Every pipelined renderer needs the same bookkeeping:
+
+1. A ring of in-flight frame slots, each holding per-frame GPU resources.
+2. A pipeline-depth cap — block the CPU when the ring is full to prevent unbounded memory growth.
+3. Deferred retirement — pop completed slots from the front when `gpu_progress() >= epoch`.
+4. Surface-path timeline patching — the epoch is only known *after* `Frame::present()`, so the most recent slot must be stamped retroactively.
+
+Without shared infrastructure, every consumer reimplements this independently. `FrameOrchestrator` centralizes all of it.
+
+## Core API
+
+```rust
+use goldy::{FrameOrchestrator, FrameHandle};
+
+// max_depth: how many frames may be in-flight before begin_frame blocks
+let mut orch: FrameOrchestrator<MyCleanup> = FrameOrchestrator::new(&device, 3);
+```
+
+`T` is your per-frame payload type — whatever data you need to clean up when a slot retires (buffer views, textures, readback buffers, etc.).
+
+### Standalone (headless / render-to-texture) path
+
+```rust
+loop {
+    // 1. Open a new frame slot; retires completed older slots via your closure.
+    //    Blocks if max_depth frames are already in flight.
+    let handle = orch.begin_frame(|dev, retired| {
+        my_cleanup(dev, retired.timeline, retired.data)
+    })?;
+
+    // 2. Record compute work.
+    let mut graph = TaskGraph::new();
+    // ... add dispatches ...
+
+    // 3. Collect per-frame resources that should live until the GPU is done.
+    let cleanup = MyCleanup { /* views, buffers, etc. */ };
+
+    // 4. Submit & register the slot.  Returns the timeline value.
+    let tv = orch.end_frame_standalone(handle, graph, None, cleanup)?;
+}
+
+// Shutdown: drain all remaining slots.
+orch.drain_all(|dev, retired| my_cleanup(dev, retired.timeline, retired.data))?;
+```
+
+### Surface (swapchain) path
+
+```rust
+loop {
+    let frame = surface.begin()?;
+
+    let handle = orch.begin_frame(|dev, retired| {
+        my_cleanup(dev, retired.timeline, retired.data)
+    })?;
+
+    let mut graph = TaskGraph::new();
+    // ... write into frame.texture() ...
+
+    let cleanup = MyCleanup { /* ... */ };
+
+    // Submit compute into the frame bracket; timeline is unknown until present.
+    orch.end_frame_for_surface(handle, &graph, &frame, cleanup)?;
+
+    // Present; stamp the pending slot with the returned epoch.
+    let tv = frame.present()?;
+    orch.note_presented(tv);
+}
+
+orch.drain_all(|dev, retired| my_cleanup(dev, retired.timeline, retired.data))?;
+```
+
+`note_presented` fills in the `None` timeline on the most recent slot pushed by `end_frame_for_surface`. If it is never called (e.g. the window closes before present), `drain_all` falls back to the internal high-water timeline as a safe fence.
+
+## Mid-frame flush
+
+`flush()` submits the current graph and starts a fresh one, letting the GPU begin earlier phases while the CPU records later ones:
+
+```rust
+let handle = orch.begin_frame(|dev, retired| { /* ... */ })?;
+
+let mut graph = TaskGraph::new();
+let mut last_tv = None;
+
+// Coarse phase
+record_coarse(&mut graph);
+orch.flush(handle, &mut graph, None, &mut last_tv)?;
+
+// Fine phase — GPU executes coarse while CPU records this
+record_fine(&mut graph);
+
+let cleanup = MyCleanup { /* ... */ };
+let tv = orch.end_frame_standalone(handle, graph, last_tv, cleanup)?;
+```
+
+For surface frames pass `Some(&frame)` instead of `None`:
+
+```rust
+orch.flush(handle, &mut graph, Some(&frame), &mut last_tv)?;
+```
+
+### Transient resources across flush boundaries
+
+Each `flush()` call uses `Device::submit_pipelined` rather than `Device::submit`. The difference matters for graphs that contain transient buffers or textures:
+
+| Method | Transient heap behaviour |
+|---|---|
+| `Device::submit` | Blocks the CPU until the GPU finishes so the placement heap region is immediately reclaimable |
+| `Device::submit_pipelined` | Returns immediately; the placement heap region stays in flight and is reclaimed once `gpu_progress()` advances past the returned timeline |
+
+This means transient-buffer graphs can now be flushed mid-frame. Each flush boundary acquires its own placement heap region, so coarse-phase transients and fine-phase transients coexist without aliasing.
+
+## `Device::submit_pipelined`
+
+`submit_pipelined` is also available as a standalone method when you want non-blocking transient submit without the full orchestrator:
+
+```rust
+// Blocks until transients are reclaimable:
+let tv = device.submit(&graph)?;
+
+// Does not block — region stays in flight until tv retires:
+let tv = device.submit_pipelined(&graph)?;
+```
+
+Only use `submit_pipelined` when you have a mechanism (such as `FrameOrchestrator`, or your own tracking ring) to ensure you don't reuse the placement heap region before the GPU is done with it.
+
+## CPU/GPU overlap
+
+`FrameOrchestrator` enables two distinct layers of CPU/GPU overlap:
+
+**Frame-level** — `begin_frame` retires completed slots without blocking, so the CPU immediately starts recording frame N+1 while the GPU executes frame N. The depth cap (`max_depth`) prevents the CPU from running too far ahead.
+
+**Intra-frame** — `flush()` splits a single frame's command stream into multiple submissions. The GPU starts executing the first submission before the CPU finishes recording the last one.
+
+## Inspecting orchestrator state
+
+```rust
+orch.pending_frames();   // slots currently in the ring
+orch.max_depth();        // cap configured at construction
+orch.has_open_frame();   // true between begin_frame and end_frame_*
+```
+
+## Design notes
+
+### Retirement callback
+
+`begin_frame`, `reclaim`, and `drain_all` all accept a fallible closure `FnMut(&Device, RetiredFrame<T>) -> Result<(), E>`. The orchestrator converts errors into `GoldyError`. This keeps the orchestrator generic over your cleanup payload while allowing cleanup itself to fail.
+
+`RetiredFrame<T>` carries:
+
+```rust
+pub struct RetiredFrame<T> {
+    pub timeline: TimelineValue,  // epoch at which this frame's GPU work completed
+    pub data: T,                  // your per-frame payload
+}
+```
+
+### Surface path timeline is always deferred
+
+On the swapchain path the timeline value comes from `Frame::present`, which fires *after* `end_frame_for_surface`. The orchestrator holds the slot in a `timeline: None` state until `note_presented` arrives. The `EpochRegions` transient allocator documents the same invariant — `end_frame` may legally arrive after the next `begin_frame`.
+
+### Relationship to `TransientAllocator`
+
+`FrameOrchestrator` owns the frame-slot ring and retirement callbacks. `TransientAllocator` owns the per-frame bump region and advances its epoch via `begin_frame` / `end_frame`. They are independent: the orchestrator does not call into the allocator. Call `allocator.begin_frame()` before recording and `allocator.end_frame(tv)` in your retirement closure — or immediately after the standalone submit where `tv` is known synchronously.

--- a/docs/src/compute/task-graph.md
+++ b/docs/src/compute/task-graph.md
@@ -178,7 +178,9 @@ graph.node("render", &pipeline)
     .dispatch(wg_x, wg_y, 1);
 ```
 
-When transients are used, the graph **blocks until the GPU completes** so the staging heap can be freed. The scheduler uses wave-interval analysis to determine which transients can alias: if two transient buffers are never live in the same wave, they share the same backing memory.
+The scheduler uses wave-interval analysis to determine which transients can alias: if two transient buffers are never live in the same wave, they share the same backing memory.
+
+By default, `Device::submit` blocks the CPU until the GPU finishes so the placement heap region is immediately reclaimable. When the graph is submitted as part of a pipelined frame via `Device::submit_pipelined`, the CPU does **not** block — the region stays in flight until the returned `TimelineValue` advances. See [Pipelined Frames](./pipelined-frames.md) for the `FrameOrchestrator` API that manages this automatically.
 
 ## Per-resource barriers on Metal
 

--- a/docs/src/compute/timeline.md
+++ b/docs/src/compute/timeline.md
@@ -94,7 +94,21 @@ let result: Vec<f32> = buffer.read_data(0)?;
 
 ### Multi-frame pipelining
 
-Overlap CPU frame N+1 preparation with GPU frame N execution:
+For production renderers, use [`FrameOrchestrator`](./pipelined-frames.md). It manages the in-flight slot ring, depth cap, retirement callbacks, and surface-path timeline patching with no boilerplate:
+
+```rust
+let mut orch: FrameOrchestrator<MyCleanup> = FrameOrchestrator::new(&device, 3);
+
+loop {
+    let handle = orch.begin_frame(|dev, retired| my_cleanup(dev, retired))?;
+    // ... record and submit ...
+    orch.end_frame_standalone(handle, graph, None, cleanup)?;
+}
+
+orch.drain_all(|dev, retired| my_cleanup(dev, retired))?;
+```
+
+When you only need a one-off overlap without full frame management, the raw `TimelineValue` pattern works:
 
 ```rust
 let mut pending: Option<TimelineValue> = None;

--- a/docs/src/resources/pooling.md
+++ b/docs/src/resources/pooling.md
@@ -94,52 +94,6 @@ pool.remaining();        // bytes available
 pool.backing_buffer();   // reference to the underlying Buffer
 ```
 
-## BufferPoolRing
-
-`BufferPoolRing` is a fixed-size ring of `BufferPool`s for double- (or N-) buffered rendering. Each frame advances to the next slot, and the pool that was active N frames ago is safe to reset because its GPU work has completed.
-
-### Usage
-
-```rust
-use goldy::BufferPoolRing;
-
-let mut ring = BufferPoolRing::<2>::new(); // double-buffered
-
-// Each frame:
-ring.advance();
-ring.prepare(&device, needed_bytes)?;
-
-if ring.take_clear_flag() {
-    // New backing buffer was allocated — zero-fill it
-    let pool = ring.current_mut().unwrap();
-    pool.backing_buffer().clear(&device, 0, pool.capacity())?;
-}
-
-let pool = ring.current_mut().unwrap();
-let view = pool.alloc::<[f32; 4]>(256)?;
-```
-
-### How It Works
-
-1. **`advance()`** — rotates to the next pool slot (call once at frame start)
-2. **`prepare(device, size)`** — ensures the current slot has at least `size` bytes. Resets the pool if large enough, or allocates a new one if not. Sets a clear flag when a new allocation occurs.
-3. **`take_clear_flag()`** — returns `true` exactly once after `prepare` allocates a new backing buffer. Issue a `clear_buffer` for the backing when this fires.
-4. **`current_mut()`** / **`current()`** — access the current frame's pool
-
-### Bounded Prepare
-
-`prepare_bounded` adds an optional upper bound. If the current pool exceeds `max_size`, it is reallocated at `size`, enabling hysteresis-based shrinking:
-
-```rust
-ring.prepare_bounded(&device, needed_size, Some(max_size))?;
-```
-
-### Cleanup
-
-```rust
-ring.clear(); // drop all pools and reset state
-```
-
 ## TexturePool
 
 `TexturePool` caches released textures for reuse, avoiding repeated GPU allocation and deallocation. This is particularly valuable on DX12 where texture allocation involves descriptor heap management.
@@ -201,7 +155,7 @@ pool.clear(); // drop all pooled textures, free GPU memory
 | Scenario | Recommendation |
 |----------|---------------|
 | Many small storage buffers with similar lifetime | `BufferPool` — one allocation, many views |
-| Per-frame uniform/storage data that changes every frame | `BufferPoolRing` — ring-buffered pools, safe reset each frame |
+| Per-frame uniform/storage data that changes every frame | `BufferPool` reset inside a `FrameOrchestrator` retirement callback — epoch-safe, no manual ring |
 | Transient render targets or compute textures | `TexturePool` — acquire/release cycle avoids allocation churn |
 | Long-lived buffers (mesh data, static textures) | Individual `Buffer` / `Texture` — pooling adds no benefit |
 | Uniform buffer updated once at startup | Individual `Buffer` — no per-frame reuse needed |
@@ -225,19 +179,27 @@ let indices = pool.alloc_with_data(&index_data)?;
 
 ### Per-Frame Dynamic Data
 
-Use `BufferPoolRing` for data that changes every frame:
+For data that changes every frame, keep a `BufferPool` per frame slot and reset it in the `FrameOrchestrator` retirement callback — the orchestrator guarantees the GPU has finished before the callback fires:
 
 ```rust
-let mut ring = BufferPoolRing::<2>::new();
+struct FrameData {
+    pool: BufferPool,
+}
 
-// In the render loop:
-ring.advance();
-ring.prepare(&device, frame_data_size)?;
+let mut orch: FrameOrchestrator<FrameData> = FrameOrchestrator::new(&device, 3);
 
-let pool = ring.current_mut().unwrap();
-let uniforms = pool.alloc_with_data(&[camera_data])?;
-let instances = pool.alloc_with_data(&instance_transforms)?;
+// Each frame:
+let handle = orch.begin_frame(|_dev, retired| {
+    retired.data.pool.reset(); // safe: GPU epoch has passed
+    Ok(())
+})?;
+
+let mut frame_data = /* get or create pool for this slot */;
+let uniforms = frame_data.pool.alloc_with_data(&[camera_data])?;
+let instances = frame_data.pool.alloc_with_data(&instance_transforms)?;
 ```
+
+See [Pipelined Frames](../compute/pipelined-frames.md) for the full `FrameOrchestrator` API.
 
 ### Transient Compute Textures
 

--- a/docs/src/resources/transient-allocation.md
+++ b/docs/src/resources/transient-allocation.md
@@ -152,7 +152,7 @@ Possible future strategies:
 | Type | Scope | Lifecycle |
 |------|-------|-----------|
 | `BufferPool` | Manual sub-allocation from one buffer | Caller manages reset timing |
-| `BufferPoolRing` | N-deep ring of `BufferPool`s | Fixed rotation, no epoch awareness |
+| `FrameOrchestrator<T>` | Frame-slot ring with typed cleanup payloads | Epoch-aware, depth-capped, callback-driven |
 | `TexturePool` | Acquire/release cache for textures | Keyed recycling, no sub-allocation |
 | **`TransientAllocator`** | **Pluggable per-frame bump allocation** | **Epoch-aware, strategy-selectable** |
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -711,7 +711,7 @@ impl Device {
         if !graph.has_transient_resources() {
             let mut backend = self.inner.backend.lock().unwrap();
             let tv = graph
-                .submit_with_backend(self, backend.as_mut(), None, &HashMap::new())
+                .submit_with_backend(self, backend.as_mut(), None, &HashMap::new(), true)
                 .map_err(|e| {
                     drop(backend);
                     self.classify(e)
@@ -728,7 +728,7 @@ impl Device {
 
         if graph.has_transient_buffers() {
             let tv = self
-                .submit_with_placement_heap(graph, &tex_handles)
+                .submit_with_placement_heap(graph, &tex_handles, true)
                 .map_err(|e| self.classify(e))?;
             self.inner
                 .high_water_timeline
@@ -738,7 +738,58 @@ impl Device {
 
         let mut backend = self.inner.backend.lock().unwrap();
         let tv = graph
-            .submit_with_backend(self, backend.as_mut(), None, &tex_handles)
+            .submit_with_backend(self, backend.as_mut(), None, &tex_handles, true)
+            .map_err(|e| {
+                drop(backend);
+                self.classify(e)
+            })?;
+        self.inner
+            .high_water_timeline
+            .fetch_max(tv, Ordering::Relaxed);
+        Ok(tv)
+    }
+
+    /// Like [`Self::submit`] but does **not** block the CPU until transient-buffer or
+    /// transient-texture GPU work completes after the submission.
+    ///
+    /// Use this only when building a pipelined frame loop that records multiple
+    /// consecutive graphs (for example [`FrameOrchestrator::flush`](crate::FrameOrchestrator::flush)) or when the
+    /// caller tracks completion via [`TimelineValue`] / [`Self::gpu_progress`].
+    ///
+    /// [`Self::submit`] still waits on transient resources — that path remains the
+    /// safe default for one-shot submission.
+    pub fn submit_pipelined(&self, graph: &TaskGraph) -> Result<TimelineValue, GoldyError> {
+        if !graph.has_transient_resources() {
+            let mut backend = self.inner.backend.lock().unwrap();
+            let tv = graph
+                .submit_with_backend(self, backend.as_mut(), None, &HashMap::new(), false)
+                .map_err(|e| {
+                    drop(backend);
+                    self.classify(e)
+                })?;
+            self.inner
+                .high_water_timeline
+                .fetch_max(tv, Ordering::Relaxed);
+            return Ok(tv);
+        }
+
+        let (_tex_keepalive, tex_handles) = graph
+            .allocate_transient_textures(self)
+            .map_err(|e| self.classify(e))?;
+
+        if graph.has_transient_buffers() {
+            let tv = self
+                .submit_with_placement_heap(graph, &tex_handles, false)
+                .map_err(|e| self.classify(e))?;
+            self.inner
+                .high_water_timeline
+                .fetch_max(tv, Ordering::Relaxed);
+            return Ok(tv);
+        }
+
+        let mut backend = self.inner.backend.lock().unwrap();
+        let tv = graph
+            .submit_with_backend(self, backend.as_mut(), None, &tex_handles, false)
             .map_err(|e| {
                 drop(backend);
                 self.classify(e)
@@ -763,6 +814,7 @@ impl Device {
         &self,
         graph: &TaskGraph,
         tex_handles: &HashMap<u32, backend::TextureHandle>,
+        wait_for_transient_completion: bool,
     ) -> Result<TimelineValue> {
         let (total_size, base_align, layout) = graph.transient_heap_size_and_layout()?;
 
@@ -836,7 +888,13 @@ impl Device {
         drop(heap_guard);
 
         let mut backend = self.inner.backend.lock().unwrap();
-        let tv = resolved_graph.submit_with_backend(self, backend.as_mut(), None, tex_handles)?;
+        let tv = resolved_graph.submit_with_backend(
+            self,
+            backend.as_mut(),
+            None,
+            tex_handles,
+            wait_for_transient_completion,
+        )?;
         drop(backend);
 
         // Stamp the ring entry and immediately defer views to VramAllocator.

--- a/src/frame_orchestrator.rs
+++ b/src/frame_orchestrator.rs
@@ -81,6 +81,16 @@ impl<T> FrameOrchestrator<T> {
         self.open.is_some()
     }
 
+    /// Discard the currently open frame without pushing a cleanup slot.
+    ///
+    /// Call this when a `run_frame` error makes it impossible to call `end_frame_standalone` or
+    /// `end_frame_for_surface`. Leaves the ring intact so subsequent frames can begin normally.
+    pub fn abort_frame(&mut self, handle: FrameHandle) {
+        if self.open == Some(handle) {
+            self.open = None;
+        }
+    }
+
     /// Non-blocking drain of slots whose GPU timeline has completed, plus mandatory pops when the
     /// ring is deeper than [`Self::max_depth`]. Same ordering rules as a manual cleanup deque.
     pub fn reclaim<E, F>(&mut self, mut retire: F) -> Result<(), GoldyError>

--- a/src/frame_orchestrator.rs
+++ b/src/frame_orchestrator.rs
@@ -1,0 +1,278 @@
+//! Pipelined frame lifecycle: ring of in-flight frames, depth cap, and deferred retirement.
+//!
+//! [`FrameOrchestrator`] centralizes the pattern of pushing per-frame cleanup bundles keyed by
+//! [`TimelineValue`], including swapchain paths where the epoch arrives only after
+//! [`crate::surface::Frame::present`].
+
+use crate::device::Device;
+use crate::error::GoldyError;
+use crate::surface::Frame;
+use crate::task_graph::TaskGraph;
+use crate::timeline::TimelineValue;
+use anyhow::anyhow;
+use std::collections::VecDeque;
+
+/// Token returned from [`FrameOrchestrator::begin_frame`]; must be passed to
+/// [`FrameOrchestrator::flush`], [`FrameOrchestrator::end_frame_standalone`], or
+/// [`FrameOrchestrator::end_frame_for_surface`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FrameHandle(pub(crate) u64);
+
+/// A completed frame slot ready for application-specific cleanup.
+#[derive(Debug)]
+pub struct RetiredFrame<T> {
+    /// GPU timeline epoch used for pool / allocator retirement (may be `0` if unknown).
+    pub timeline: TimelineValue,
+    /// User payload supplied when the frame was closed.
+    pub data: T,
+}
+
+struct FrameSlot<T> {
+    timeline: Option<TimelineValue>,
+    data: T,
+}
+
+/// Owns an in-flight ring of per-frame cleanup slots and enforces a maximum pipelining depth.
+///
+/// Typical use:
+/// 1. [`Self::begin_frame`] (with retire closure)  
+/// 2. Record dispatch into one or more [`TaskGraph`]s; call [`Self::flush`] for mid-frame submits.  
+/// 3. [`Self::end_frame_standalone`] or [`Self::end_frame_for_surface`].  
+/// 4. For swapchain frames, [`Self::note_presented`] after [`Frame::present`].
+pub struct FrameOrchestrator<T> {
+    device: Device,
+    max_depth: usize,
+    ring: VecDeque<FrameSlot<T>>,
+    /// Monotonic id for the next [`FrameHandle`].
+    next_id: u64,
+    /// `Some` between [`Self::begin_frame`] and a matching end-frame call.
+    open: Option<FrameHandle>,
+}
+
+impl<T> FrameOrchestrator<T> {
+    /// Create an orchestrator. `max_depth` bounds how many frames may be in flight before the
+    /// next [`Self::begin_frame`] blocks or forces the oldest slot to retire (same role as
+    /// `max_regions` on pooled transient allocators).
+    pub fn new(device: &Device, max_depth: usize) -> Self {
+        Self {
+            device: device.clone(),
+            max_depth: max_depth.max(1),
+            ring: VecDeque::new(),
+            next_id: 1,
+            open: None,
+        }
+    }
+
+    /// Maximum number of in-flight frame slots (configured at construction).
+    #[inline]
+    pub fn max_depth(&self) -> usize {
+        self.max_depth
+    }
+
+    /// Current number of slots waiting on the GPU or a swapchain present timeline.
+    #[inline]
+    pub fn pending_frames(&self) -> usize {
+        self.ring.len()
+    }
+
+    /// `true` if [`Self::begin_frame`] was called and the frame was not yet ended.
+    #[inline]
+    pub fn has_open_frame(&self) -> bool {
+        self.open.is_some()
+    }
+
+    /// Non-blocking drain of slots whose GPU timeline has completed, plus mandatory pops when the
+    /// ring is deeper than [`Self::max_depth`]. Same ordering rules as a manual cleanup deque.
+    pub fn reclaim<E, F>(&mut self, mut retire: F) -> Result<(), GoldyError>
+    where
+        E: std::fmt::Display,
+        F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
+    {
+        self.drain_ring_with_retire(&mut retire)
+    }
+
+    /// Begin recording a new frame: reclaims completed slots, then returns a handle if there is
+    /// capacity (possibly after blocking on the oldest in-flight work).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoldyError`] if a frame is already open (missing end-frame call), or if
+    /// `retire` returns an error.
+    pub fn begin_frame<E, F>(&mut self, mut retire: F) -> Result<FrameHandle, GoldyError>
+    where
+        E: std::fmt::Display,
+        F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
+    {
+        if self.open.is_some() {
+            return Err(GoldyError::Backend(anyhow!(
+                "FrameOrchestrator::begin_frame: a frame is already open"
+            )));
+        }
+        self.drain_ring_with_retire(&mut retire)?;
+        let h = FrameHandle(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        self.open = Some(h);
+        Ok(h)
+    }
+
+    /// Mid-frame submit: dispatches the current graph and starts a fresh one.
+    ///
+    /// Uses [`Device::submit_pipelined`] on standalone paths so transient-buffer regions can overlap
+    /// CPU recording with GPU execution across flushes.
+    pub fn flush(
+        &mut self,
+        handle: FrameHandle,
+        graph: &mut TaskGraph,
+        surface_frame: Option<&Frame>,
+        last_timeline: &mut Option<TimelineValue>,
+    ) -> Result<(), GoldyError> {
+        self.expect_open(handle)?;
+        if graph.is_empty() {
+            return Ok(());
+        }
+        if let Some(frame) = surface_frame {
+            frame.submit_compute(graph).map_err(GoldyError::from)?;
+        } else {
+            let tv = self.device.submit_pipelined(graph)?;
+            *last_timeline = Some(tv);
+        }
+        *graph = TaskGraph::new();
+        Ok(())
+    }
+
+    /// End a standalone (headless / render-to-texture) frame: submit remaining work, push the
+    /// cleanup slot with a known timeline, clear the open handle.
+    ///
+    /// If `graph` is empty, `fallback_timeline` is used (e.g. the value from previous
+    /// [`Self::flush`] calls). If that is `None`, [`Device::gpu_progress`] is used.
+    pub fn end_frame_standalone(
+        &mut self,
+        handle: FrameHandle,
+        graph: TaskGraph,
+        fallback_timeline: Option<TimelineValue>,
+        cleanup: T,
+    ) -> Result<TimelineValue, GoldyError> {
+        self.expect_open(handle)?;
+        let tv = if graph.is_empty() {
+            fallback_timeline.unwrap_or_else(|| self.device.gpu_progress())
+        } else {
+            self.device.submit_pipelined(&graph)?
+        };
+        self.ring.push_back(FrameSlot {
+            timeline: Some(tv),
+            data: cleanup,
+        });
+        self.open = None;
+        Ok(tv)
+    }
+
+    /// End a surface frame: optionally submits compute, then pushes a slot whose timeline is
+    /// filled later via [`Self::note_presented`].
+    pub fn end_frame_for_surface(
+        &mut self,
+        handle: FrameHandle,
+        graph: &TaskGraph,
+        frame: &Frame,
+        cleanup: T,
+    ) -> Result<(), GoldyError> {
+        self.expect_open(handle)?;
+        if !graph.is_empty() {
+            frame.submit_compute(graph).map_err(GoldyError::from)?;
+        }
+        self.ring.push_back(FrameSlot {
+            timeline: None,
+            data: cleanup,
+        });
+        self.open = None;
+        Ok(())
+    }
+
+    /// After [`Frame::present`], stamp the most recent surface slot with the returned timeline.
+    pub fn note_presented(&mut self, tv: TimelineValue) {
+        if let Some(back) = self.ring.back_mut() {
+            if back.timeline.is_none() {
+                back.timeline = Some(tv);
+            }
+        }
+    }
+
+    /// Block until every pending slot has retired and invoke `retire` for each.
+    ///
+    /// Slots whose timeline is still unknown (`None`, i.e. surface path before
+    /// [`Self::note_presented`]) use [`Device::high_water_timeline`] as a completion fence —
+    /// callers draining mid-presentation should prefer [`Self::reclaim`] / presenting first.
+    pub fn drain_all<E, F>(&mut self, mut retire: F) -> Result<(), GoldyError>
+    where
+        E: std::fmt::Display,
+        F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
+    {
+        while let Some(slot) = self.ring.pop_front() {
+            let timeline = match slot.timeline {
+                Some(t) => t,
+                None => self
+                    .device
+                    .high_water_timeline()
+                    .max(self.device.gpu_progress()),
+            };
+            if self.device.gpu_progress() < timeline {
+                self.device.wait_until(timeline)?;
+            }
+            retire(
+                &self.device,
+                RetiredFrame {
+                    timeline,
+                    data: slot.data,
+                },
+            )
+            .map_err(|e| GoldyError::Backend(anyhow!("{e}")))?;
+        }
+        Ok(())
+    }
+
+    fn expect_open(&self, handle: FrameHandle) -> Result<(), GoldyError> {
+        match self.open {
+            Some(h) if h == handle => Ok(()),
+            Some(_) => Err(GoldyError::Backend(anyhow!(
+                "FrameOrchestrator: wrong FrameHandle for this frame"
+            ))),
+            None => Err(GoldyError::Backend(anyhow!(
+                "FrameOrchestrator: no open frame (call begin_frame first)"
+            ))),
+        }
+    }
+
+    fn drain_ring_with_retire<E, F>(&mut self, retire: &mut F) -> Result<(), GoldyError>
+    where
+        E: std::fmt::Display,
+        F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
+    {
+        let progress = self.device.gpu_progress();
+        while let Some(front) = self.ring.front() {
+            let done = match front.timeline {
+                Some(tv) => progress >= tv,
+                None => false,
+            };
+            let must_wait = !done && self.ring.len() >= self.max_depth;
+            if done || must_wait {
+                let slot = self.ring.pop_front().unwrap();
+                if let Some(tv) = slot.timeline {
+                    if self.device.gpu_progress() < tv && must_wait {
+                        self.device.wait_until(tv)?;
+                    }
+                }
+                let timeline = slot.timeline.unwrap_or(0);
+                retire(
+                    &self.device,
+                    RetiredFrame {
+                        timeline,
+                        data: slot.data,
+                    },
+                )
+                .map_err(|e| GoldyError::Backend(anyhow!("{e}")))?;
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod device;
 pub mod encoder;
 pub mod error;
 pub mod examples;
+pub mod frame_orchestrator;
 pub mod pipeline;
 pub mod render_target;
 pub mod sampler;
@@ -43,6 +44,7 @@ pub mod timeline;
 pub mod transient_allocator;
 pub mod vram_allocator;
 pub use error::GoldyError;
+pub use frame_orchestrator::{FrameHandle, FrameOrchestrator, RetiredFrame};
 pub use gpu_guard::GpuGuard;
 pub use vram_allocator::DeferredPayload;
 

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -91,8 +91,10 @@ impl TaskGraph {
     /// The backing memory is a single device buffer allocated for the duration of
     /// [`crate::Device::submit`]. Transients whose live ranges (in the compiled wave
     /// schedule) do not overlap may alias within that heap to reduce allocation size.
-    /// Graphs using transients **block until the submit completes** so the staging
-    /// heap can be freed.
+    /// Graphs using transients **block until the submit completes** when using
+    /// [`crate::Device::submit`] (so the CPU does not record overlapping standalone graphs that
+    /// reuse the same placement-heap protocol). For pipelined multi-submit frames, use
+    /// [`crate::Device::submit_pipelined`] or the surface path / [`crate::FrameOrchestrator`].
     pub fn transient_buffer(&mut self, size: u64) -> TransientId {
         self.transient_buffer_with_stride(size, 4)
     }
@@ -111,8 +113,9 @@ impl TaskGraph {
     /// Register a transient texture (same dimensions and format) for this graph.
     ///
     /// Non-overlapping wave lifetimes may alias onto one backing texture; see
-    /// [`Self::transient_buffer`] for scheduling behavior. Submits **wait until
-    /// completion** when transients are used.
+    /// [`Self::transient_buffer`] for scheduling behavior. [`crate::Device::submit`]
+    /// waits until completion when transients are used; use [`crate::Device::submit_pipelined`]
+    /// for overlapping submissions in a managed frame loop.
     pub fn transient_texture(
         &mut self,
         width: u32,
@@ -149,6 +152,7 @@ impl TaskGraph {
         backend: &mut dyn GpuBackend,
         transient_buffer_ranges: Option<&HashMap<u32, (BufferHandle, u64, u64)>>,
         transient_texture_handles: &HashMap<u32, TextureHandle>,
+        wait_for_transient_completion: bool,
     ) -> Result<TimelineValue> {
         if !self.transient_texture_specs.is_empty() {
             for s in &self.transient_texture_specs {
@@ -178,7 +182,7 @@ impl TaskGraph {
         }
 
         let tv = Self::submit_resolved_ir(device, backend, &ir)?;
-        if self.needs_transient_gpu_wait() {
+        if wait_for_transient_completion && self.needs_transient_gpu_wait() {
             backend.wait_until(device.inner.handle, tv)?;
         }
         Ok(tv)

--- a/tests/frame_orchestrator.rs
+++ b/tests/frame_orchestrator.rs
@@ -1,0 +1,31 @@
+//! Smoke tests for [`goldy::FrameOrchestrator`] and [`goldy::Device::submit_pipelined`].
+
+use goldy::{DeviceType, FrameOrchestrator, Instance, TaskGraph};
+
+#[test]
+fn orchestrator_double_begin_fails() {
+    let instance = Instance::new().expect("instance");
+    let device = instance.create_device(DeviceType::Cpu).expect("cpu device");
+
+    let mut orch: FrameOrchestrator<()> = FrameOrchestrator::new(&device, 3);
+    let h = orch
+        .begin_frame(|_d, _r| Ok::<_, std::convert::Infallible>(()))
+        .expect("begin");
+
+    assert!(orch
+        .begin_frame(|_d, _r| Ok::<_, std::convert::Infallible>(()))
+        .is_err());
+
+    orch.end_frame_standalone(h, TaskGraph::new(), None, ())
+        .expect("end");
+}
+
+#[test]
+fn orchestrator_reclaim_empty_is_ok() {
+    let instance = Instance::new().expect("instance");
+    let device = instance.create_device(DeviceType::Cpu).expect("cpu device");
+
+    let mut orch: FrameOrchestrator<()> = FrameOrchestrator::new(&device, 2);
+    orch.reclaim(|_d, _r| Ok::<_, std::convert::Infallible>(()))
+        .unwrap();
+}


### PR DESCRIPTION
…and enhance Device submission methods. This update introduces a new `FrameOrchestrator` struct to handle in-flight frames and their cleanup, allowing for non-blocking GPU submissions. The `Device` methods are modified to support pipelined submissions, improving performance in multi-submit scenarios. Additionally, tests are added to validate the functionality of the new orchestrator.