### PR TITLE
Backend submission optimizations, GPU profiling, and FrameStrategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "2.0"
 # Logging and instrumentation
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tracy-client = { version = "0.18", default-features = false, optional = true }
 
 # Utilities
 bitflags = "2.6"
@@ -97,6 +98,9 @@ update-screenshots = ["dep:image"]
 instrumentation = ["dep:tracing-subscriber"]
 # Interactive `examples/*.rs` (winit); avoids compiling winit for tests / lib-only builds
 examples = ["dep:winit"]
+# Tracy profiler integration — connect the Tracy GUI for live CPU/GPU timeline profiling.
+# Zero-cost when disabled; when enabled, only collects when a profiler connects (on-demand).
+tracy = ["dep:tracy-client", "tracy-client/enable", "tracy-client/ondemand", "tracy-client/broadcast", "tracy-client/system-tracing", "tracy-client/context-switch-tracing"]
 
 [[example]]
 name = "triangle"

--- a/docs/src/resources/transient-allocation.md
+++ b/docs/src/resources/transient-allocation.md
@@ -26,7 +26,6 @@ use goldy::{TransientAllocatorStrategy, TransientAllocatorConfig};
 let strategy = TransientAllocatorStrategy::EpochRegions;
 let mut allocator = strategy.create(&device, TransientAllocatorConfig {
     initial_size: 4 * 1024 * 1024,
-    expected_max: 64 * 1024 * 1024,
     min_region_size: 4 * 1024 * 1024,
     max_regions: 4,
     alignment: 256,
@@ -115,8 +114,7 @@ The closest CPU-side analogue is epoch-based reclamation (EBR), the same pattern
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `initial_size` | 64 KiB | Backing storage allocated on first frame |
-| `expected_max` | 16 MiB | Capacity hint for backends that pre-reserve virtual address range (e.g. Metal placement heaps) |
+| `initial_size` | 64 KiB | Backing storage allocated on first frame. The allocator grows reactively and auto-shrinks after warmup. |
 | `min_region_size` | 4 MiB | Minimum bytes per region for `EpochRegions`. Smaller = finer reclamation granularity, more regions. |
 | `max_regions` | 3 | Pipeline depth cap for `EpochRegions`. `BumpReset` ignores this. |
 | `alignment` | 256 | Sub-allocation alignment (must be power of two). 256 covers all known `minStorageBufferOffsetAlignment` values. |

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -9,9 +9,168 @@ use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, Dx12State};
 use super::{ComputePipelineHandle, DeviceHandle, RenderTargetHandle, ShaderHandle};
 use crate::backend::{GpuCommand, GraphCommand};
 use crate::timeline::TimelineValue;
+use crate::tracy_zone;
 use anyhow::{Context, Result};
 use windows::core::Interface;
 use windows::Win32::Graphics::Direct3D12::*;
+use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_UNKNOWN, DXGI_SAMPLE_DESC};
+
+#[derive(Debug)]
+struct Dx12GpuProfileResources {
+    heap: ID3D12QueryHeap,
+    readback: ID3D12Resource,
+    query_count: u32,
+    dispatch_labels: Vec<Option<&'static str>>,
+}
+
+fn dx12_collect_dispatch_labels(commands: &[GpuCommand]) -> (usize, Vec<Option<&'static str>>) {
+    let mut labels = Vec::new();
+    for c in commands {
+        match c {
+            GpuCommand::Dispatch { label, .. }
+            | GpuCommand::DispatchIndirect { label, .. }
+            | GpuCommand::DispatchBatch { label, .. } => {
+                labels.push(*label);
+            }
+            _ => {}
+        }
+    }
+    let n = labels.len();
+    (n, labels)
+}
+
+fn dx12_collect_dispatch_labels_graph(
+    commands: &[GraphCommand],
+) -> (usize, Vec<Option<&'static str>>) {
+    let mut labels = Vec::new();
+    for gc in commands {
+        if let GraphCommand::Compute(
+            GpuCommand::Dispatch { label, .. }
+            | GpuCommand::DispatchIndirect { label, .. }
+            | GpuCommand::DispatchBatch { label, .. },
+        ) = gc
+        {
+            labels.push(*label);
+        }
+    }
+    let n = labels.len();
+    (n, labels)
+}
+
+fn dx12_try_create_gpu_profile(
+    device: &ID3D12Device10,
+    dispatch_count: usize,
+    dispatch_labels: Vec<Option<&'static str>>,
+) -> Result<Option<Dx12GpuProfileResources>> {
+    if !crate::gpu_profiler::gpu_profile_enabled() {
+        return Ok(None);
+    }
+    debug_assert_eq!(dispatch_labels.len(), dispatch_count);
+    let query_count = 2u32.saturating_add((dispatch_count as u32).saturating_mul(2));
+
+    let heap_desc = D3D12_QUERY_HEAP_DESC {
+        Type: D3D12_QUERY_HEAP_TYPE_TIMESTAMP,
+        Count: query_count,
+        NodeMask: 0,
+    };
+    let mut heap_opt: Option<ID3D12QueryHeap> = None;
+    unsafe { device.CreateQueryHeap(&heap_desc, &mut heap_opt) }
+        .context("CreateQueryHeap for GOLDY_GPU_PROFILE")?;
+    let heap = heap_opt.context("CreateQueryHeap returned null")?;
+
+    let data_bytes = (query_count as u64).saturating_mul(8);
+    let aligned_width = data_bytes.max(256).next_multiple_of(256);
+
+    let buffer_desc = D3D12_RESOURCE_DESC {
+        Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+        Alignment: 0,
+        Width: aligned_width,
+        Height: 1,
+        DepthOrArraySize: 1,
+        MipLevels: 1,
+        Format: DXGI_FORMAT_UNKNOWN,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        Flags: D3D12_RESOURCE_FLAG_NONE,
+    };
+    let heap_props = D3D12_HEAP_PROPERTIES {
+        Type: D3D12_HEAP_TYPE_READBACK,
+        ..Default::default()
+    };
+    let mut readback_opt: Option<ID3D12Resource> = None;
+    unsafe {
+        device.CreateCommittedResource(
+            &heap_props,
+            D3D12_HEAP_FLAG_NONE,
+            &buffer_desc,
+            D3D12_RESOURCE_STATE_COPY_DEST,
+            None,
+            &mut readback_opt,
+        )
+    }
+    .context("CreateCommittedResource readback for GOLDY_GPU_PROFILE")?;
+    let readback = readback_opt.context("readback resource null")?;
+
+    Ok(Some(Dx12GpuProfileResources {
+        heap,
+        readback,
+        query_count,
+        dispatch_labels,
+    }))
+}
+
+fn dx12_decode_duration_ns(start: u64, end: u64, freq: u64) -> u64 {
+    if freq == 0 {
+        return 0;
+    }
+    let delta = end.wrapping_sub(start);
+    ((delta as f64 / freq as f64) * 1e9) as u64
+}
+
+fn dx12_finish_gpu_profile(
+    logical_device: &types::LogicalDevice,
+    fence_value: u64,
+    profile: Dx12GpuProfileResources,
+) -> Result<()> {
+    use crate::gpu_profiler::{self, DispatchGpuNs};
+    super::utils::wait_for_fence(&logical_device.fence, fence_value)?;
+
+    let freq = unsafe { logical_device.command_queue.GetTimestampFrequency() }
+        .context("GetTimestampFrequency")?;
+
+    let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
+    let no_read = D3D12_RANGE { Begin: 0, End: 0 };
+    unsafe { profile.readback.Map(0, Some(&no_read), Some(&mut mapped)) }
+        .context("Map gpu profile readback")?;
+
+    let vals: Vec<u64> = unsafe {
+        std::slice::from_raw_parts(mapped as *const u64, profile.query_count as usize).to_vec()
+    };
+
+    unsafe {
+        profile.readback.Unmap(0, None);
+    }
+
+    let cb_ns = dx12_decode_duration_ns(vals[0], vals[1], freq);
+    gpu_profiler::log_cb_timing("dx12", fence_value, cb_ns as f64 / 1_000_000.0);
+
+    let n = profile.dispatch_labels.len();
+    if n > 0 {
+        let mut dispatches = Vec::with_capacity(n);
+        for i in 0..n {
+            let si = 2 + 2 * i;
+            let ns = dx12_decode_duration_ns(vals[si], vals[si + 1], freq);
+            let label = profile.dispatch_labels[i].unwrap_or("dispatch");
+            dispatches.push(DispatchGpuNs { label, gpu_ns: ns });
+        }
+        gpu_profiler::log_dispatch_timings("dx12", fence_value, &dispatches);
+    }
+
+    Ok(())
+}
 
 /// Drain any pending debug-layer messages for this device into a single
 /// human-readable string. Returns `None` when the device has no
@@ -191,21 +350,41 @@ pub(super) fn submit(
     device_handle: DeviceHandle,
     commands: &[GpuCommand],
 ) -> Result<TimelineValue> {
-    let (allocator, fence_value, slot_idx) = {
+    let _tz = tracy_zone!("dx12.submit");
+    let (command_list, fence_value, slot_idx) = {
         let logical_device = state
             .devices
             .get_mut(&device_handle)
             .context("Invalid device handle")?;
 
-        // Find a free slot (allocator whose work has completed) or create a new one
         let fence = &logical_device.fence;
         let completed = unsafe { fence.GetCompletedValue() };
         let pool = &mut logical_device.compute_allocator_pool;
-        let slot_idx = pool.iter().position(|s| completed >= s.fence_value);
-        let (allocator, slot_idx) = if let Some(idx) = slot_idx {
+        // Skip retained slots — their allocator must not be reset until evict_retained is called.
+        let slot_idx = pool
+            .iter()
+            .position(|s| completed >= s.fence_value && !s.retained);
+        let (cmd_list, slot_idx) = if let Some(idx) = slot_idx {
             let slot = &mut pool[idx];
             unsafe { slot.allocator.Reset() }.context("Failed to reset command allocator")?;
-            (slot.allocator.clone(), idx)
+            let list = if let Some(ref existing) = slot.command_list {
+                unsafe { existing.Reset(&slot.allocator, None) }
+                    .context("Failed to reset command list")?;
+                existing.clone()
+            } else {
+                let new_list: ID3D12GraphicsCommandList = unsafe {
+                    logical_device.device.CreateCommandList(
+                        0,
+                        D3D12_COMMAND_LIST_TYPE_DIRECT,
+                        &slot.allocator,
+                        None,
+                    )
+                }
+                .context("Failed to create command list")?;
+                slot.command_list = Some(new_list.clone());
+                new_list
+            };
+            (list, idx)
         } else {
             let new_allocator: ID3D12CommandAllocator = unsafe {
                 logical_device
@@ -213,16 +392,26 @@ pub(super) fn submit(
                     .CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
             }
             .context("Failed to create command allocator")?;
+            let new_list: ID3D12GraphicsCommandList = unsafe {
+                logical_device.device.CreateCommandList(
+                    0,
+                    D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    &new_allocator,
+                    None,
+                )
+            }
+            .context("Failed to create command list")?;
             pool.push(ComputeAllocatorSlot {
-                allocator: new_allocator.clone(),
+                allocator: new_allocator,
                 fence_value: 0,
+                command_list: Some(new_list.clone()),
+                retained: false,
             });
-            unsafe { new_allocator.Reset() }.context("Failed to reset new command allocator")?;
-            (new_allocator, pool.len() - 1)
+            (new_list, pool.len() - 1)
         };
         let token = logical_device.fence_value;
         logical_device.fence_value += 1;
-        (allocator, token, slot_idx)
+        (cmd_list, token, slot_idx)
     };
 
     let (fence_clone, use_global_buffer_barriers) = {
@@ -232,107 +421,133 @@ pub(super) fn submit(
             .context("Invalid device handle")?;
         (dev.fence.clone(), dev.adapter_id == super::WARP_ADAPTER_ID)
     };
-    state
-        .staging_belts
-        .entry(device_handle)
-        .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-        .reclaim(&fence_clone)?;
+
+    // Detect host uploads up-front so we can skip the staging-belt reclaim and
+    // the WriteBuffer pre-pass when this submit has no host→GPU traffic.
+    let has_upload = commands.iter().any(|c| {
+        matches!(
+            c,
+            GpuCommand::WriteBuffer { .. }
+                | GpuCommand::WriteTexture { .. }
+                | GpuCommand::WriteTextureRegion { .. }
+        )
+    });
+    if has_upload {
+        state
+            .staging_belts
+            .entry(device_handle)
+            .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
+            .reclaim(&fence_clone)?;
+    }
 
     let mut belt_slices: Vec<(ID3D12Resource, u64)> = Vec::new();
 
-    // Create command list (allocator is owned, no borrow of state)
-    let command_list: ID3D12GraphicsCommandList = {
-        let logical_device = state
-            .devices
-            .get(&device_handle)
-            .context("Invalid device handle")?;
-        unsafe {
-            logical_device.device.CreateCommandList(
-                0,
-                D3D12_COMMAND_LIST_TYPE_DIRECT,
-                &allocator,
-                None,
-            )
-        }
-        .context("Failed to create command list")?
-    };
     let command_list7: ID3D12GraphicsCommandList7 = command_list
         .cast()
         .context("ID3D12GraphicsCommandList7 required")?;
 
     // Pre-pass: memcpy into staging belt chunks for DEVICE_LOCAL WriteBuffer uploads.
-    for command in commands {
-        if let GpuCommand::WriteBuffer {
-            buffer: buf_handle,
-            data,
-            ..
-        } = command
-        {
-            let buf = state
-                .buffers
-                .get(buf_handle)
-                .context("WriteBuffer pre-pass: invalid handle")?;
-            if buf.is_storage {
-                let buf_dev = buf.device_handle;
-                let ld = state
-                    .devices
-                    .get(&buf_dev)
-                    .context("WriteBuffer pre-pass: device missing")?;
-                let belt_entry = state.staging_belts.entry(buf_dev).or_insert_with(|| {
-                    staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                });
-                let (res, off) = belt_entry.write(ld, data)?;
-                belt_slices.push((res, off));
+    if has_upload {
+        for command in commands {
+            if let GpuCommand::WriteBuffer {
+                buffer: buf_handle,
+                data,
+                ..
+            } = command
+            {
+                let buf = state
+                    .buffers
+                    .get(buf_handle)
+                    .context("WriteBuffer pre-pass: invalid handle")?;
+                if buf.is_storage {
+                    let buf_dev = buf.device_handle;
+                    let ld = state
+                        .devices
+                        .get(&buf_dev)
+                        .context("WriteBuffer pre-pass: device missing")?;
+                    let belt_entry = state.staging_belts.entry(buf_dev).or_insert_with(|| {
+                        staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
+                    });
+                    let (res, off) = belt_entry.write(ld, data)?;
+                    belt_slices.push((res, off));
+                }
             }
         }
     }
 
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
-    for command in commands {
-        match command {
-            GpuCommand::WriteTexture {
-                texture,
-                data,
-                width,
-                height,
-            } => {
-                staged_texture_uploads.push(super::texture::stage_texture_upload_full(
-                    state, *texture, data, *width, *height,
-                )?);
+    if has_upload {
+        for command in commands {
+            match command {
+                GpuCommand::WriteTexture {
+                    texture,
+                    data,
+                    width,
+                    height,
+                } => {
+                    staged_texture_uploads.push(super::texture::stage_texture_upload_full(
+                        state, *texture, data, *width, *height,
+                    )?);
+                }
+                GpuCommand::WriteTextureRegion {
+                    texture,
+                    x,
+                    y,
+                    width,
+                    height,
+                    data,
+                } => {
+                    staged_texture_uploads.push(super::texture::stage_texture_upload_region(
+                        state, *texture, *x, *y, *width, *height, data,
+                    )?);
+                }
+                _ => {}
             }
-            GpuCommand::WriteTextureRegion {
-                texture,
-                x,
-                y,
-                width,
-                height,
-                data,
-            } => {
-                staged_texture_uploads.push(super::texture::stage_texture_upload_region(
-                    state, *texture, *x, *y, *width, *height, data,
-                )?);
-            }
-            _ => {}
         }
     }
 
-    {
-        let logical_device = state
+    let mut dx_dispatch_idx = 0u32;
+    let mut dx_gpu_profile = {
+        let logical_device_ref = state
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
 
+        let (dispatch_count, dispatch_labels) = dx12_collect_dispatch_labels(commands);
+        let dx_gpu_profile = match dx12_try_create_gpu_profile(
+            &logical_device_ref.device,
+            dispatch_count,
+            dispatch_labels,
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("GOLDY_GPU_PROFILE: DX12 timestamp heap creation failed: {e}");
+                None
+            }
+        };
+
         unsafe {
             command_list.SetDescriptorHeaps(&[
-                Some(logical_device.cbv_srv_uav_heap.clone()),
-                Some(logical_device.sampler_heap.clone()),
+                Some(logical_device_ref.cbv_srv_uav_heap.clone()),
+                Some(logical_device_ref.sampler_heap.clone()),
             ]);
         }
-    }
+
+        if let Some(ref prof) = dx_gpu_profile {
+            unsafe {
+                command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, 0);
+            }
+        }
+
+        dx_gpu_profile
+    };
 
     let mut belt_idx = 0usize;
     let mut texture_upload_idx = 0usize;
     let mut current_compute_pipeline: Option<super::ComputePipelineHandle> = None;
+
+    let pipelines = &state.compute_pipelines;
+    let bufs = &state.buffers;
 
     // Track which GPU sync scopes and access types have been used since the
     // last wave-boundary barrier. The ResourceBarrier handler uses these to
@@ -345,8 +560,9 @@ pub(super) fn submit(
     for command in commands {
         match command {
             GpuCommand::SetPipeline(handle) => {
+                let _tz = tracy_zone!("dx12.set_pipeline");
                 current_compute_pipeline = Some(*handle);
-                if let Some(pipeline_state) = state.compute_pipelines.get(handle) {
+                if let Some(pipeline_state) = pipelines.get(handle) {
                     unsafe {
                         command_list.SetComputeRootSignature(&pipeline_state.root_signature);
                         command_list.SetPipelineState(&pipeline_state.pipeline_state);
@@ -355,13 +571,12 @@ pub(super) fn submit(
             }
             GpuCommand::BindResources { buffers } => {
                 if crate::slang::layout_validation_enabled() {
-                    if let Some(pipeline) =
-                        current_compute_pipeline.and_then(|h| state.compute_pipelines.get(&h))
+                    if let Some(pipeline) = current_compute_pipeline.and_then(|h| pipelines.get(&h))
                     {
                         if !pipeline.binding_element_strides.is_empty() {
                             let actual: Vec<Option<u32>> = buffers
                                 .iter()
-                                .map(|h| state.buffers.get(h).and_then(|b| b.element_stride))
+                                .map(|h| bufs.get(h).and_then(|b| b.element_stride))
                                 .collect();
                             crate::backend::validate_binding_strides(
                                 &actual,
@@ -375,11 +590,7 @@ pub(super) fn submit(
                 shared::fill_bindless(
                     &mut layout,
                     buffers.iter().map(|h| {
-                        let offset = state
-                            .buffers
-                            .get(h)
-                            .and_then(|b| b.bindless_offset)
-                            .unwrap_or(0);
+                        let offset = bufs.get(h).and_then(|b| b.bindless_offset).unwrap_or(0);
                         tracing::trace!(
                             "Compute BindResources: buffer {} -> UAV offset {}",
                             h,
@@ -419,9 +630,7 @@ pub(super) fn submit(
             GpuCommand::BindResourcesTyped {
                 handles: typed_handles,
             } => {
-                if let Some(pipeline) =
-                    current_compute_pipeline.and_then(|h| state.compute_pipelines.get(&h))
-                {
+                if let Some(pipeline) = current_compute_pipeline.and_then(|h| pipelines.get(&h)) {
                     crate::backend::validate_typed_push_constants(
                         typed_handles,
                         &pipeline.push_constant_categories,
@@ -440,17 +649,37 @@ pub(super) fn submit(
                 }
             }
             GpuCommand::Dispatch {
+                label: _,
                 workgroups_x,
                 workgroups_y,
                 workgroups_z,
             } => {
+                let _tz = tracy_zone!("dx12.dispatch");
+                if let Some(ref prof) = dx_gpu_profile {
+                    let base = 2u32 + dx_dispatch_idx * 2;
+                    unsafe {
+                        command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base);
+                    }
+                }
                 unsafe {
                     command_list.Dispatch(*workgroups_x, *workgroups_y, *workgroups_z);
                 }
+                if let Some(ref prof) = dx_gpu_profile {
+                    let base = 2u32 + dx_dispatch_idx * 2;
+                    unsafe {
+                        command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base + 1);
+                    }
+                }
+                dx_dispatch_idx += 1;
                 pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
                 pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
             }
-            GpuCommand::DispatchIndirect { buffer, offset } => {
+            GpuCommand::DispatchIndirect {
+                buffer,
+                offset,
+                label: _,
+            } => {
+                let _tz = tracy_zone!("dx12.dispatch_indirect");
                 let logical_device = state
                     .devices
                     .get(&device_handle)
@@ -484,6 +713,13 @@ pub(super) fn submit(
                     unsafe { barriers::drop_buffer_barriers(&mut to_indirect) };
                 }
 
+                if let Some(ref prof) = dx_gpu_profile {
+                    let base = 2u32 + dx_dispatch_idx * 2;
+                    unsafe {
+                        command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base);
+                    }
+                }
+
                 unsafe {
                     command_list.ExecuteIndirect(
                         signature,
@@ -494,6 +730,14 @@ pub(super) fn submit(
                         0,
                     );
                 }
+
+                if let Some(ref prof) = dx_gpu_profile {
+                    let base = 2u32 + dx_dispatch_idx * 2;
+                    unsafe {
+                        command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base + 1);
+                    }
+                }
+                dx_dispatch_idx += 1;
 
                 if use_global_buffer_barriers {
                     let g = D3D12_GLOBAL_BARRIER {
@@ -517,7 +761,122 @@ pub(super) fn submit(
                 pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
                 pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
             }
+            GpuCommand::DispatchBatch {
+                label: _,
+                arg_data,
+                count,
+            } => {
+                let _tz = tracy_zone!("dx12.dispatch_batch");
+                let logical_device = state
+                    .devices
+                    .get(&device_handle)
+                    .context("DispatchBatch: invalid device")?;
+
+                if let Some(batch_sig) = logical_device.compute_batch_dispatch_signature.clone() {
+                    // Fast path: allocate an UPLOAD-heap buffer, copy arg_data into it,
+                    // then record a single ExecuteIndirect call.
+                    let buf_size = arg_data.len() as u64;
+                    let arg_buf_desc = D3D12_RESOURCE_DESC {
+                        Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+                        Alignment: 0,
+                        Width: buf_size,
+                        Height: 1,
+                        DepthOrArraySize: 1,
+                        MipLevels: 1,
+                        Format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN,
+                        SampleDesc: windows::Win32::Graphics::Dxgi::Common::DXGI_SAMPLE_DESC {
+                            Count: 1,
+                            Quality: 0,
+                        },
+                        Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                        Flags: D3D12_RESOURCE_FLAG_NONE,
+                    };
+                    let upload_heap = D3D12_HEAP_PROPERTIES {
+                        Type: D3D12_HEAP_TYPE_UPLOAD,
+                        ..Default::default()
+                    };
+                    let mut arg_resource: Option<ID3D12Resource> = None;
+                    unsafe {
+                        logical_device.device.CreateCommittedResource(
+                            &upload_heap,
+                            D3D12_HEAP_FLAG_NONE,
+                            &arg_buf_desc,
+                            D3D12_RESOURCE_STATE_GENERIC_READ,
+                            None,
+                            &mut arg_resource,
+                        )
+                    }
+                    .context("DispatchBatch: failed to create arg buffer")?;
+                    let arg_resource =
+                        arg_resource.context("DispatchBatch: arg_resource is None")?;
+
+                    // CPU-map, write arg data, unmap.
+                    let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
+                    let no_read = D3D12_RANGE { Begin: 0, End: 0 };
+                    unsafe {
+                        arg_resource
+                            .Map(0, Some(&no_read), Some(&mut mapped))
+                            .context("DispatchBatch: failed to map arg buffer")?;
+                        std::ptr::copy_nonoverlapping(
+                            arg_data.as_ptr(),
+                            mapped as *mut u8,
+                            arg_data.len(),
+                        );
+                        let written = D3D12_RANGE {
+                            Begin: 0,
+                            End: arg_data.len(),
+                        };
+                        arg_resource.Unmap(0, Some(&written));
+                    }
+
+                    // Record ExecuteIndirect.
+                    unsafe {
+                        command_list.ExecuteIndirect(&batch_sig, *count, &arg_resource, 0, None, 0);
+                    }
+
+                    // Defer destruction of arg_resource until the GPU is done.
+                    let fence_val = logical_device.fence_value.saturating_sub(1);
+                    let dev = state
+                        .devices
+                        .get_mut(&device_handle)
+                        .context("DispatchBatch: device gone")?;
+                    dev.deletion_queue.queue(
+                        fence_val,
+                        super::types::PendingDeletion::StandaloneResource(arg_resource),
+                    );
+                } else {
+                    // Fallback: iterate over entries and emit individual SetComputeRoot32BitConstants + Dispatch.
+                    use crate::backend::shared::{PushLayout, DISPATCH_BATCH_STRIDE};
+                    let stride = DISPATCH_BATCH_STRIDE;
+                    let push_size = std::mem::size_of::<PushLayout>();
+                    for i in 0..*count as usize {
+                        let base = i * stride;
+                        let layout_bytes = &arg_data[base..base + push_size];
+                        let wg_off = base + push_size;
+                        let wg_x =
+                            u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into().unwrap());
+                        let wg_y = u32::from_ne_bytes(
+                            arg_data[wg_off + 4..wg_off + 8].try_into().unwrap(),
+                        );
+                        let wg_z = u32::from_ne_bytes(
+                            arg_data[wg_off + 8..wg_off + 12].try_into().unwrap(),
+                        );
+                        unsafe {
+                            command_list.SetComputeRoot32BitConstants(
+                                0,
+                                (push_size / 4) as u32,
+                                layout_bytes.as_ptr() as *const _,
+                                0,
+                            );
+                            command_list.Dispatch(wg_x, wg_y, wg_z);
+                        }
+                    }
+                }
+                pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
+            }
             GpuCommand::Barrier => {
+                let _tz = tracy_zone!("dx12.barrier");
                 let sync_before = if pending_sync.0 != 0 {
                     pending_sync
                 } else {
@@ -545,6 +904,7 @@ pub(super) fn submit(
                 buffers: buf_handles,
                 textures: tex_handles,
             } => {
+                let _tz = tracy_zone!("dx12.resource_barrier");
                 let sync_before = if pending_sync.0 != 0 {
                     pending_sync
                 } else {
@@ -575,7 +935,7 @@ pub(super) fn submit(
                 } else {
                     let mut buf_barriers: Vec<D3D12_BUFFER_BARRIER> = buf_handles
                         .iter()
-                        .filter_map(|h| state.buffers.get(h))
+                        .filter_map(|h| bufs.get(h))
                         .map(|bs| {
                             barriers::buffer_barrier_full(
                                 &bs.resource,
@@ -632,6 +992,7 @@ pub(super) fn submit(
                 offset,
                 size,
             } => {
+                let _tz = tracy_zone!("dx12.clear_buffer");
                 let buf_state = state
                     .buffers
                     .get(buffer)
@@ -717,6 +1078,7 @@ pub(super) fn submit(
                 offset,
                 data,
             } => {
+                let _tz = tracy_zone!("dx12.write_buffer");
                 let buf_state = state
                     .buffers
                     .get(buf_handle)
@@ -746,7 +1108,7 @@ pub(super) fn submit(
                     belt_idx += 1;
                     let upload_src = belt_entry.0.clone();
                     let upload_off = belt_entry.1;
-                    let buf_state = state.buffers.get(buf_handle).unwrap();
+                    let buf_state = bufs.get(buf_handle).unwrap();
 
                     if use_global_buffer_barriers {
                         let pre = D3D12_GLOBAL_BARRIER {
@@ -790,6 +1152,7 @@ pub(super) fn submit(
                 }
             }
             GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {
+                let _tz = tracy_zone!("dx12.write_texture");
                 let upload = staged_texture_uploads
                     .get(texture_upload_idx)
                     .context("WriteTexture: staged upload missing (internal)")?;
@@ -797,9 +1160,107 @@ pub(super) fn submit(
                 super::texture::record_staged_texture_upload(
                     &command_list,
                     &command_list7,
-                    state,
+                    &mut state.textures,
                     upload,
                 )?;
+            }
+            GpuCommand::CopyTexture { src, dst } => {
+                let _tz = tracy_zone!("dx12.copy_texture");
+                let (src_res, src_layout) = {
+                    let ts = state
+                        .textures
+                        .get(src)
+                        .context("CopyTexture: src texture not found")?;
+                    (ts.resource.clone(), ts.last_layout)
+                };
+                let (dst_res, dst_layout) = {
+                    let ts = state
+                        .textures
+                        .get(dst)
+                        .context("CopyTexture: dst texture not found")?;
+                    (ts.resource.clone(), ts.last_layout)
+                };
+
+                let sync_before = if pending_sync.0 != 0 {
+                    pending_sync
+                } else {
+                    D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                };
+                let src_access_before = if src_layout
+                    == D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS
+                    || src_layout == D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS
+                {
+                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                } else {
+                    D3D12_BARRIER_ACCESS_SHADER_RESOURCE
+                };
+                let dst_access_before = if dst_layout
+                    == D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS
+                    || dst_layout == D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS
+                {
+                    D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                } else {
+                    D3D12_BARRIER_ACCESS_NO_ACCESS
+                };
+
+                let mut pre_barriers = vec![
+                    barriers::texture_barrier_full(
+                        &src_res,
+                        sync_before,
+                        D3D12_BARRIER_SYNC_COPY,
+                        src_access_before,
+                        D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                        src_layout,
+                        D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+                    ),
+                    barriers::texture_barrier_full(
+                        &dst_res,
+                        sync_before,
+                        D3D12_BARRIER_SYNC_COPY,
+                        dst_access_before,
+                        D3D12_BARRIER_ACCESS_COPY_DEST,
+                        dst_layout,
+                        D3D12_BARRIER_LAYOUT_COPY_DEST,
+                    ),
+                ];
+                unsafe { barriers::barrier_textures(&command_list7, &pre_barriers) };
+                unsafe { barriers::drop_texture_barriers(&mut pre_barriers) };
+
+                unsafe { command_list.CopyResource(&dst_res, &src_res) };
+
+                let post_layout = D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS;
+                let mut post_barriers = vec![
+                    barriers::texture_barrier_full(
+                        &src_res,
+                        D3D12_BARRIER_SYNC_COPY,
+                        D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                        D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                        D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+                        post_layout,
+                    ),
+                    barriers::texture_barrier_full(
+                        &dst_res,
+                        D3D12_BARRIER_SYNC_COPY,
+                        D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                        D3D12_BARRIER_ACCESS_COPY_DEST,
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                        D3D12_BARRIER_LAYOUT_COPY_DEST,
+                        post_layout,
+                    ),
+                ];
+                unsafe { barriers::barrier_textures(&command_list7, &post_barriers) };
+                unsafe { barriers::drop_texture_barriers(&mut post_barriers) };
+
+                if let Some(ts) = state.textures.get_mut(src) {
+                    ts.last_layout = post_layout;
+                }
+                if let Some(ts) = state.textures.get_mut(dst) {
+                    ts.last_layout = post_layout;
+                }
+
+                pending_sync = D3D12_BARRIER_SYNC(0);
+                pending_access = D3D12_BARRIER_ACCESS(0);
             }
         }
     }
@@ -825,6 +1286,20 @@ pub(super) fn submit(
     };
     unsafe { barriers::barrier_globals(&command_list7, &[tail]) };
 
+    if let Some(ref prof) = dx_gpu_profile {
+        unsafe {
+            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, 1);
+            command_list.ResolveQueryData(
+                &prof.heap,
+                D3D12_QUERY_TYPE_TIMESTAMP,
+                0,
+                prof.query_count,
+                &prof.readback,
+                0,
+            );
+        }
+    }
+
     // Close and execute
     if let Err(e) = unsafe { command_list.Close() } {
         let diag = state
@@ -842,19 +1317,27 @@ pub(super) fn submit(
     let cmd_list: ID3D12CommandList = command_list.cast().context("Failed to cast command list")?;
 
     let logical_device = state.devices.get(&device_handle).unwrap();
-    unsafe {
-        logical_device
-            .command_queue
-            .ExecuteCommandLists(&[Some(cmd_list)]);
+    {
+        let _tz = tracy_zone!("dx12.execute_and_signal");
+        unsafe {
+            logical_device
+                .command_queue
+                .ExecuteCommandLists(&[Some(cmd_list)]);
+        }
+
+        unsafe {
+            logical_device
+                .command_queue
+                .Signal(&logical_device.fence, fence_value)
+        }
+        .context("Failed to signal fence")?;
     }
 
-    // Signal fence with the token we reserved
-    unsafe {
-        logical_device
-            .command_queue
-            .Signal(&logical_device.fence, fence_value)
+    if let Some(prof) = dx_gpu_profile.take() {
+        if let Err(e) = dx12_finish_gpu_profile(logical_device, fence_value, prof) {
+            tracing::warn!("GOLDY_GPU_PROFILE: DX12 readback failed: {e}");
+        }
     }
-    .context("Failed to signal fence")?;
 
     // Update the slot's fence_value so we know when it can be reused
     if let Some(dev) = state.devices.get_mut(&device_handle) {
@@ -897,13 +1380,20 @@ pub(super) fn submit(
 /// everything into one `ID3D12GraphicsCommandList7` and performing a single
 /// `ExecuteCommandLists` + `Signal(fence)` at the end.
 #[allow(clippy::too_many_lines)]
+/// Core submit implementation.
+///
+/// When `retain_key` is `Some(k)`, the closed command list is stored in
+/// `LogicalDevice::retained_graph` keyed by `k` for future zero-cost re-execution
+/// via [`try_resubmit_retained`].  Any previously retained graph is evicted first.
 pub(super) fn submit_graph(
     state: &mut Dx12State,
     device_handle: DeviceHandle,
     commands: &[GraphCommand],
+    retain_key: Option<u64>,
 ) -> Result<TimelineValue> {
-    // --- Allocator + fence value reservation (same as `submit`) ---
-    let (allocator, fence_value, slot_idx) = {
+    let _tz = tracy_zone!("dx12.submit_graph");
+    // --- Allocator + command list + fence value reservation ---
+    let (command_list, fence_value, slot_idx) = {
         let logical_device = state
             .devices
             .get_mut(&device_handle)
@@ -912,11 +1402,31 @@ pub(super) fn submit_graph(
         let fence = &logical_device.fence;
         let completed = unsafe { fence.GetCompletedValue() };
         let pool = &mut logical_device.compute_allocator_pool;
-        let slot_idx = pool.iter().position(|s| completed >= s.fence_value);
-        let (allocator, slot_idx) = if let Some(idx) = slot_idx {
+        // Skip retained slots — their allocator must not be reset until evict_retained is called.
+        let slot_idx = pool
+            .iter()
+            .position(|s| completed >= s.fence_value && !s.retained);
+        let (cmd_list, slot_idx) = if let Some(idx) = slot_idx {
             let slot = &mut pool[idx];
             unsafe { slot.allocator.Reset() }.context("Failed to reset command allocator")?;
-            (slot.allocator.clone(), idx)
+            let list = if let Some(ref existing) = slot.command_list {
+                unsafe { existing.Reset(&slot.allocator, None) }
+                    .context("Failed to reset command list")?;
+                existing.clone()
+            } else {
+                let new_list: ID3D12GraphicsCommandList = unsafe {
+                    logical_device.device.CreateCommandList(
+                        0,
+                        D3D12_COMMAND_LIST_TYPE_DIRECT,
+                        &slot.allocator,
+                        None,
+                    )
+                }
+                .context("Failed to create command list")?;
+                slot.command_list = Some(new_list.clone());
+                new_list
+            };
+            (list, idx)
         } else {
             let new_allocator: ID3D12CommandAllocator = unsafe {
                 logical_device
@@ -924,16 +1434,26 @@ pub(super) fn submit_graph(
                     .CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
             }
             .context("Failed to create command allocator")?;
+            let new_list: ID3D12GraphicsCommandList = unsafe {
+                logical_device.device.CreateCommandList(
+                    0,
+                    D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    &new_allocator,
+                    None,
+                )
+            }
+            .context("Failed to create command list")?;
             pool.push(ComputeAllocatorSlot {
-                allocator: new_allocator.clone(),
+                allocator: new_allocator,
                 fence_value: 0,
+                command_list: Some(new_list.clone()),
+                retained: false,
             });
-            unsafe { new_allocator.Reset() }.context("Failed to reset new command allocator")?;
-            (new_allocator, pool.len() - 1)
+            (new_list, pool.len() - 1)
         };
         let token = logical_device.fence_value;
         logical_device.fence_value += 1;
-        (allocator, token, slot_idx)
+        (cmd_list, token, slot_idx)
     };
 
     // --- Staging belt reclaim ---
@@ -944,106 +1464,133 @@ pub(super) fn submit_graph(
             .context("Invalid device handle")?;
         (dev.fence.clone(), dev.adapter_id == super::WARP_ADAPTER_ID)
     };
-    state
-        .staging_belts
-        .entry(device_handle)
-        .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-        .reclaim(&fence_clone)?;
+
+    // Detect host uploads up-front; skip belt reclaim and pre-pass when none.
+    let has_upload = commands.iter().any(|c| {
+        matches!(
+            c,
+            GraphCommand::Compute(
+                GpuCommand::WriteBuffer { .. }
+                    | GpuCommand::WriteTexture { .. }
+                    | GpuCommand::WriteTextureRegion { .. }
+            )
+        )
+    });
+    if has_upload {
+        state
+            .staging_belts
+            .entry(device_handle)
+            .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
+            .reclaim(&fence_clone)?;
+    }
 
     // --- Pre-pass: stage WriteBuffer data for compute segments ---
     let mut belt_slices: Vec<(ID3D12Resource, u64)> = Vec::new();
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
 
-    for graph_cmd in commands {
-        if let GraphCommand::Compute(gpu_cmd) = graph_cmd {
-            match gpu_cmd {
-                GpuCommand::WriteBuffer {
-                    buffer: buf_handle,
-                    data,
-                    ..
-                } => {
-                    let buf = state
-                        .buffers
-                        .get(buf_handle)
-                        .context("WriteBuffer pre-pass: invalid handle")?;
-                    if buf.is_storage {
-                        let buf_dev = buf.device_handle;
-                        let ld = state
-                            .devices
-                            .get(&buf_dev)
-                            .context("WriteBuffer pre-pass: device missing")?;
-                        let belt_entry = state.staging_belts.entry(buf_dev).or_insert_with(|| {
-                            staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                        });
-                        let (res, off) = belt_entry.write(ld, data)?;
-                        belt_slices.push((res, off));
+    if has_upload {
+        for graph_cmd in commands {
+            if let GraphCommand::Compute(gpu_cmd) = graph_cmd {
+                match gpu_cmd {
+                    GpuCommand::WriteBuffer {
+                        buffer: buf_handle,
+                        data,
+                        ..
+                    } => {
+                        let buf = state
+                            .buffers
+                            .get(buf_handle)
+                            .context("WriteBuffer pre-pass: invalid handle")?;
+                        if buf.is_storage {
+                            let buf_dev = buf.device_handle;
+                            let ld = state
+                                .devices
+                                .get(&buf_dev)
+                                .context("WriteBuffer pre-pass: device missing")?;
+                            let belt_entry =
+                                state.staging_belts.entry(buf_dev).or_insert_with(|| {
+                                    staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
+                                });
+                            let (res, off) = belt_entry.write(ld, data)?;
+                            belt_slices.push((res, off));
+                        }
                     }
+                    GpuCommand::WriteTexture {
+                        texture,
+                        data,
+                        width,
+                        height,
+                    } => {
+                        staged_texture_uploads.push(super::texture::stage_texture_upload_full(
+                            state, *texture, data, *width, *height,
+                        )?);
+                    }
+                    GpuCommand::WriteTextureRegion {
+                        texture,
+                        x,
+                        y,
+                        width,
+                        height,
+                        data,
+                    } => {
+                        staged_texture_uploads.push(super::texture::stage_texture_upload_region(
+                            state, *texture, *x, *y, *width, *height, data,
+                        )?);
+                    }
+                    _ => {}
                 }
-                GpuCommand::WriteTexture {
-                    texture,
-                    data,
-                    width,
-                    height,
-                } => {
-                    staged_texture_uploads.push(super::texture::stage_texture_upload_full(
-                        state, *texture, data, *width, *height,
-                    )?);
-                }
-                GpuCommand::WriteTextureRegion {
-                    texture,
-                    x,
-                    y,
-                    width,
-                    height,
-                    data,
-                } => {
-                    staged_texture_uploads.push(super::texture::stage_texture_upload_region(
-                        state, *texture, *x, *y, *width, *height, data,
-                    )?);
-                }
-                _ => {}
             }
         }
     }
 
-    // --- Create command list ---
-    let command_list: ID3D12GraphicsCommandList = {
-        let logical_device = state
-            .devices
-            .get(&device_handle)
-            .context("Invalid device handle")?;
-        unsafe {
-            logical_device.device.CreateCommandList(
-                0,
-                D3D12_COMMAND_LIST_TYPE_DIRECT,
-                &allocator,
-                None,
-            )
-        }
-        .context("Failed to create command list")?
-    };
     let command_list7: ID3D12GraphicsCommandList7 = command_list
         .cast()
         .context("ID3D12GraphicsCommandList7 required")?;
 
-    {
-        let logical_device = state
+    let mut dx_dispatch_idx = 0u32;
+    let mut dx_gpu_profile = {
+        let logical_device_ref = state
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
+
+        let (dispatch_count, dispatch_labels) = dx12_collect_dispatch_labels_graph(commands);
+        let dx_gpu_profile = match dx12_try_create_gpu_profile(
+            &logical_device_ref.device,
+            dispatch_count,
+            dispatch_labels,
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("GOLDY_GPU_PROFILE: DX12 timestamp heap creation failed: {e}");
+                None
+            }
+        };
+
         unsafe {
             command_list.SetDescriptorHeaps(&[
-                Some(logical_device.cbv_srv_uav_heap.clone()),
-                Some(logical_device.sampler_heap.clone()),
+                Some(logical_device_ref.cbv_srv_uav_heap.clone()),
+                Some(logical_device_ref.sampler_heap.clone()),
             ]);
         }
-    }
+
+        if let Some(ref prof) = dx_gpu_profile {
+            unsafe {
+                command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, 0);
+            }
+        }
+
+        dx_gpu_profile
+    };
 
     // --- Walk GraphCommands ---
     let mut belt_idx = 0usize;
     let mut texture_upload_idx = 0usize;
     let mut current_compute_pipeline: Option<super::ComputePipelineHandle> = None;
     let mut rendered_targets: Vec<RenderTargetHandle> = Vec::new();
+
+    let pipelines = &state.compute_pipelines;
+    let bufs = &state.buffers;
 
     let mut pending_sync = D3D12_BARRIER_SYNC(0);
     let mut pending_access = D3D12_BARRIER_ACCESS(0);
@@ -1052,8 +1599,9 @@ pub(super) fn submit_graph(
         match graph_cmd {
             GraphCommand::Compute(gpu_cmd) => match gpu_cmd {
                 GpuCommand::SetPipeline(handle) => {
+                    let _tz = tracy_zone!("dx12.set_pipeline");
                     current_compute_pipeline = Some(*handle);
-                    if let Some(pipeline_state) = state.compute_pipelines.get(handle) {
+                    if let Some(pipeline_state) = pipelines.get(handle) {
                         unsafe {
                             command_list.SetComputeRootSignature(&pipeline_state.root_signature);
                             command_list.SetPipelineState(&pipeline_state.pipeline_state);
@@ -1064,13 +1612,9 @@ pub(super) fn submit_graph(
                     let mut layout = types::PushLayout::default();
                     shared::fill_bindless(
                         &mut layout,
-                        buffers.iter().map(|h| {
-                            state
-                                .buffers
-                                .get(h)
-                                .and_then(|b| b.bindless_offset)
-                                .unwrap_or(0)
-                        }),
+                        buffers
+                            .iter()
+                            .map(|h| bufs.get(h).and_then(|b| b.bindless_offset).unwrap_or(0)),
                     );
                     unsafe {
                         command_list.SetComputeRoot32BitConstants(
@@ -1099,8 +1643,7 @@ pub(super) fn submit_graph(
                 GpuCommand::BindResourcesTyped {
                     handles: typed_handles,
                 } => {
-                    if let Some(pipeline) =
-                        current_compute_pipeline.and_then(|h| state.compute_pipelines.get(&h))
+                    if let Some(pipeline) = current_compute_pipeline.and_then(|h| pipelines.get(&h))
                     {
                         crate::backend::validate_typed_push_constants(
                             typed_handles,
@@ -1120,17 +1663,37 @@ pub(super) fn submit_graph(
                     }
                 }
                 GpuCommand::Dispatch {
+                    label: _,
                     workgroups_x,
                     workgroups_y,
                     workgroups_z,
                 } => {
+                    let _tz = tracy_zone!("dx12.dispatch");
+                    if let Some(ref prof) = dx_gpu_profile {
+                        let base = 2u32 + dx_dispatch_idx * 2;
+                        unsafe {
+                            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base);
+                        }
+                    }
                     unsafe {
                         command_list.Dispatch(*workgroups_x, *workgroups_y, *workgroups_z);
                     }
+                    if let Some(ref prof) = dx_gpu_profile {
+                        let base = 2u32 + dx_dispatch_idx * 2;
+                        unsafe {
+                            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base + 1);
+                        }
+                    }
+                    dx_dispatch_idx += 1;
                     pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
                     pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
                 }
-                GpuCommand::DispatchIndirect { buffer, offset } => {
+                GpuCommand::DispatchIndirect {
+                    buffer,
+                    offset,
+                    label: _,
+                } => {
+                    let _tz = tracy_zone!("dx12.dispatch_indirect");
                     let logical_device = state
                         .devices
                         .get(&device_handle)
@@ -1164,6 +1727,13 @@ pub(super) fn submit_graph(
                         unsafe { barriers::drop_buffer_barriers(&mut to_indirect) };
                     }
 
+                    if let Some(ref prof) = dx_gpu_profile {
+                        let base = 2u32 + dx_dispatch_idx * 2;
+                        unsafe {
+                            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base);
+                        }
+                    }
+
                     unsafe {
                         command_list.ExecuteIndirect(
                             signature,
@@ -1174,6 +1744,14 @@ pub(super) fn submit_graph(
                             0,
                         );
                     }
+
+                    if let Some(ref prof) = dx_gpu_profile {
+                        let base = 2u32 + dx_dispatch_idx * 2;
+                        unsafe {
+                            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, base + 1);
+                        }
+                    }
+                    dx_dispatch_idx += 1;
 
                     if use_global_buffer_barriers {
                         let g = D3D12_GLOBAL_BARRIER {
@@ -1197,7 +1775,128 @@ pub(super) fn submit_graph(
                     pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
                     pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
                 }
+                GpuCommand::DispatchBatch {
+                    label: _,
+                    arg_data,
+                    count,
+                } => {
+                    let _tz = tracy_zone!("dx12.dispatch_batch");
+                    let logical_device = state
+                        .devices
+                        .get(&device_handle)
+                        .context("DispatchBatch(graph): invalid device")?;
+
+                    if let Some(batch_sig) = logical_device.compute_batch_dispatch_signature.clone()
+                    {
+                        let buf_size = arg_data.len() as u64;
+                        let arg_buf_desc = D3D12_RESOURCE_DESC {
+                            Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+                            Alignment: 0,
+                            Width: buf_size,
+                            Height: 1,
+                            DepthOrArraySize: 1,
+                            MipLevels: 1,
+                            Format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN,
+                            SampleDesc: windows::Win32::Graphics::Dxgi::Common::DXGI_SAMPLE_DESC {
+                                Count: 1,
+                                Quality: 0,
+                            },
+                            Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                            Flags: D3D12_RESOURCE_FLAG_NONE,
+                        };
+                        let upload_heap = D3D12_HEAP_PROPERTIES {
+                            Type: D3D12_HEAP_TYPE_UPLOAD,
+                            ..Default::default()
+                        };
+                        let mut arg_resource: Option<ID3D12Resource> = None;
+                        unsafe {
+                            logical_device.device.CreateCommittedResource(
+                                &upload_heap,
+                                D3D12_HEAP_FLAG_NONE,
+                                &arg_buf_desc,
+                                D3D12_RESOURCE_STATE_GENERIC_READ,
+                                None,
+                                &mut arg_resource,
+                            )
+                        }
+                        .context("DispatchBatch(graph): failed to create arg buffer")?;
+                        let arg_resource =
+                            arg_resource.context("DispatchBatch(graph): arg_resource is None")?;
+                        let mut mapped: *mut std::ffi::c_void = std::ptr::null_mut();
+                        let no_read = D3D12_RANGE { Begin: 0, End: 0 };
+                        unsafe {
+                            arg_resource
+                                .Map(0, Some(&no_read), Some(&mut mapped))
+                                .context("DispatchBatch(graph): map failed")?;
+                            std::ptr::copy_nonoverlapping(
+                                arg_data.as_ptr(),
+                                mapped as *mut u8,
+                                arg_data.len(),
+                            );
+                            let written = D3D12_RANGE {
+                                Begin: 0,
+                                End: arg_data.len(),
+                            };
+                            arg_resource.Unmap(0, Some(&written));
+                        }
+                        unsafe {
+                            command_list.ExecuteIndirect(
+                                &batch_sig,
+                                *count,
+                                &arg_resource,
+                                0,
+                                None,
+                                0,
+                            );
+                        }
+                        let fence_val = {
+                            let dev = state
+                                .devices
+                                .get(&device_handle)
+                                .context("DispatchBatch(graph): device gone")?;
+                            dev.fence_value.saturating_sub(1)
+                        };
+                        let dev = state
+                            .devices
+                            .get_mut(&device_handle)
+                            .context("DispatchBatch(graph): device gone")?;
+                        dev.deletion_queue.queue(
+                            fence_val,
+                            super::types::PendingDeletion::StandaloneResource(arg_resource),
+                        );
+                    } else {
+                        use crate::backend::shared::{PushLayout, DISPATCH_BATCH_STRIDE};
+                        let stride = DISPATCH_BATCH_STRIDE;
+                        let push_size = std::mem::size_of::<PushLayout>();
+                        for i in 0..*count as usize {
+                            let base = i * stride;
+                            let layout_bytes = &arg_data[base..base + push_size];
+                            let wg_off = base + push_size;
+                            let wg_x = u32::from_ne_bytes(
+                                arg_data[wg_off..wg_off + 4].try_into().unwrap(),
+                            );
+                            let wg_y = u32::from_ne_bytes(
+                                arg_data[wg_off + 4..wg_off + 8].try_into().unwrap(),
+                            );
+                            let wg_z = u32::from_ne_bytes(
+                                arg_data[wg_off + 8..wg_off + 12].try_into().unwrap(),
+                            );
+                            unsafe {
+                                command_list.SetComputeRoot32BitConstants(
+                                    0,
+                                    (push_size / 4) as u32,
+                                    layout_bytes.as_ptr() as *const _,
+                                    0,
+                                );
+                                command_list.Dispatch(wg_x, wg_y, wg_z);
+                            }
+                        }
+                    }
+                    pending_sync.0 |= D3D12_BARRIER_SYNC_COMPUTE_SHADING.0;
+                    pending_access.0 |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS.0;
+                }
                 GpuCommand::Barrier => {
+                    let _tz = tracy_zone!("dx12.barrier");
                     let sync_before = if pending_sync.0 != 0 {
                         pending_sync
                     } else {
@@ -1225,6 +1924,7 @@ pub(super) fn submit_graph(
                     buffers: buf_handles,
                     textures: tex_handles,
                 } => {
+                    let _tz = tracy_zone!("dx12.resource_barrier");
                     let sync_before = if pending_sync.0 != 0 {
                         pending_sync
                     } else {
@@ -1251,7 +1951,7 @@ pub(super) fn submit_graph(
                     } else {
                         let mut buf_barriers: Vec<D3D12_BUFFER_BARRIER> = buf_handles
                             .iter()
-                            .filter_map(|h| state.buffers.get(h))
+                            .filter_map(|h| bufs.get(h))
                             .map(|bs| {
                                 barriers::buffer_barrier_full(
                                     &bs.resource,
@@ -1308,6 +2008,7 @@ pub(super) fn submit_graph(
                     offset,
                     size,
                 } => {
+                    let _tz = tracy_zone!("dx12.clear_buffer");
                     let buf_state = state
                         .buffers
                         .get(buffer)
@@ -1388,6 +2089,7 @@ pub(super) fn submit_graph(
                     offset,
                     data,
                 } => {
+                    let _tz = tracy_zone!("dx12.write_buffer");
                     let buf_state = state
                         .buffers
                         .get(buf_handle)
@@ -1416,7 +2118,7 @@ pub(super) fn submit_graph(
                         belt_idx += 1;
                         let upload_src = belt_entry.0.clone();
                         let upload_off = belt_entry.1;
-                        let buf_state = state.buffers.get(buf_handle).unwrap();
+                        let buf_state = bufs.get(buf_handle).unwrap();
 
                         if use_global_buffer_barriers {
                             let pre = D3D12_GLOBAL_BARRIER {
@@ -1460,6 +2162,7 @@ pub(super) fn submit_graph(
                     }
                 }
                 GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {
+                    let _tz = tracy_zone!("dx12.write_texture");
                     let upload = staged_texture_uploads
                         .get(texture_upload_idx)
                         .context("WriteTexture: staged upload missing (internal)")?;
@@ -1467,15 +2170,114 @@ pub(super) fn submit_graph(
                     super::texture::record_staged_texture_upload(
                         &command_list,
                         &command_list7,
-                        state,
+                        &mut state.textures,
                         upload,
                     )?;
+                }
+                GpuCommand::CopyTexture { src, dst } => {
+                    let _tz = tracy_zone!("dx12.copy_texture");
+                    let (src_res, src_layout) = {
+                        let ts = state
+                            .textures
+                            .get(src)
+                            .context("CopyTexture: src texture not found")?;
+                        (ts.resource.clone(), ts.last_layout)
+                    };
+                    let (dst_res, dst_layout) = {
+                        let ts = state
+                            .textures
+                            .get(dst)
+                            .context("CopyTexture: dst texture not found")?;
+                        (ts.resource.clone(), ts.last_layout)
+                    };
+
+                    let sync_before = if pending_sync.0 != 0 {
+                        pending_sync
+                    } else {
+                        D3D12_BARRIER_SYNC_COMPUTE_SHADING
+                    };
+                    let src_access_before = if src_layout
+                        == D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS
+                        || src_layout == D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS
+                    {
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                    } else {
+                        D3D12_BARRIER_ACCESS_SHADER_RESOURCE
+                    };
+                    let dst_access_before = if dst_layout
+                        == D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS
+                        || dst_layout == D3D12_BARRIER_LAYOUT_UNORDERED_ACCESS
+                    {
+                        D3D12_BARRIER_ACCESS_UNORDERED_ACCESS
+                    } else {
+                        D3D12_BARRIER_ACCESS_NO_ACCESS
+                    };
+
+                    let mut pre_barriers = vec![
+                        barriers::texture_barrier_full(
+                            &src_res,
+                            sync_before,
+                            D3D12_BARRIER_SYNC_COPY,
+                            src_access_before,
+                            D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                            src_layout,
+                            D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+                        ),
+                        barriers::texture_barrier_full(
+                            &dst_res,
+                            sync_before,
+                            D3D12_BARRIER_SYNC_COPY,
+                            dst_access_before,
+                            D3D12_BARRIER_ACCESS_COPY_DEST,
+                            dst_layout,
+                            D3D12_BARRIER_LAYOUT_COPY_DEST,
+                        ),
+                    ];
+                    unsafe { barriers::barrier_textures(&command_list7, &pre_barriers) };
+                    unsafe { barriers::drop_texture_barriers(&mut pre_barriers) };
+
+                    unsafe { command_list.CopyResource(&dst_res, &src_res) };
+
+                    let post_layout = D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS;
+                    let mut post_barriers = vec![
+                        barriers::texture_barrier_full(
+                            &src_res,
+                            D3D12_BARRIER_SYNC_COPY,
+                            D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                            D3D12_BARRIER_ACCESS_COPY_SOURCE,
+                            D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                            D3D12_BARRIER_LAYOUT_COPY_SOURCE,
+                            post_layout,
+                        ),
+                        barriers::texture_barrier_full(
+                            &dst_res,
+                            D3D12_BARRIER_SYNC_COPY,
+                            D3D12_BARRIER_SYNC_COMPUTE_SHADING,
+                            D3D12_BARRIER_ACCESS_COPY_DEST,
+                            D3D12_BARRIER_ACCESS_UNORDERED_ACCESS,
+                            D3D12_BARRIER_LAYOUT_COPY_DEST,
+                            post_layout,
+                        ),
+                    ];
+                    unsafe { barriers::barrier_textures(&command_list7, &post_barriers) };
+                    unsafe { barriers::drop_texture_barriers(&mut post_barriers) };
+
+                    if let Some(ts) = state.textures.get_mut(src) {
+                        ts.last_layout = post_layout;
+                    }
+                    if let Some(ts) = state.textures.get_mut(dst) {
+                        ts.last_layout = post_layout;
+                    }
+
+                    pending_sync = D3D12_BARRIER_SYNC(0);
+                    pending_access = D3D12_BARRIER_ACCESS(0);
                 }
             },
             GraphCommand::Render {
                 target,
                 commands: render_cmds,
             } => {
+                let _tz = tracy_zone!("dx12.render_pass");
                 // Flush compute/copy writes before the render pass
                 let compute_to_render = D3D12_GLOBAL_BARRIER {
                     SyncBefore: D3D12_BARRIER_SYNC(
@@ -1544,6 +2346,20 @@ pub(super) fn submit_graph(
     };
     unsafe { barriers::barrier_globals(&command_list7, &[tail]) };
 
+    if let Some(ref prof) = dx_gpu_profile {
+        unsafe {
+            command_list.EndQuery(&prof.heap, D3D12_QUERY_TYPE_TIMESTAMP, 1);
+            command_list.ResolveQueryData(
+                &prof.heap,
+                D3D12_QUERY_TYPE_TIMESTAMP,
+                0,
+                prof.query_count,
+                &prof.readback,
+                0,
+            );
+        }
+    }
+
     // --- Close + execute + signal ---
     if let Err(e) = unsafe { command_list.Close() } {
         let diag = state
@@ -1561,22 +2377,53 @@ pub(super) fn submit_graph(
     let cmd_list: ID3D12CommandList = command_list.cast().context("Failed to cast command list")?;
 
     let logical_device = state.devices.get(&device_handle).unwrap();
-    unsafe {
-        logical_device
-            .command_queue
-            .ExecuteCommandLists(&[Some(cmd_list)]);
+    {
+        let _tz = tracy_zone!("dx12.execute_and_signal");
+        unsafe {
+            logical_device
+                .command_queue
+                .ExecuteCommandLists(&[Some(cmd_list)]);
+        }
+
+        unsafe {
+            logical_device
+                .command_queue
+                .Signal(&logical_device.fence, fence_value)
+        }
+        .context("Failed to signal fence")?;
     }
 
-    unsafe {
-        logical_device
-            .command_queue
-            .Signal(&logical_device.fence, fence_value)
+    if let Some(prof) = dx_gpu_profile.take() {
+        if let Err(e) = dx12_finish_gpu_profile(logical_device, fence_value, prof) {
+            tracing::warn!("GOLDY_GPU_PROFILE: DX12 readback failed: {e}");
+        }
     }
-    .context("Failed to signal fence")?;
 
     if let Some(dev) = state.devices.get_mut(&device_handle) {
         if let Some(slot) = dev.compute_allocator_pool.get_mut(slot_idx) {
             slot.fence_value = fence_value;
+        }
+        // If the caller wants to retain this command list, store it for future re-execution.
+        if let Some(key) = retain_key {
+            // Evict any previously retained graph (mark its slot as available).
+            if let Some(old) = dev.retained_graph.take() {
+                if let Some(old_slot) = dev.compute_allocator_pool.get_mut(old.slot_idx) {
+                    old_slot.retained = false;
+                }
+            }
+            // Store the just-closed command list.  Cloning a COM interface is cheap (AddRef).
+            if let Some(cl) = dev
+                .compute_allocator_pool
+                .get(slot_idx)
+                .and_then(|s| s.command_list.clone())
+            {
+                dev.compute_allocator_pool[slot_idx].retained = true;
+                dev.retained_graph = Some(types::RetainedGraph {
+                    fingerprint: key,
+                    command_list: cl,
+                    slot_idx,
+                });
+            }
         }
         dev.process_deletion_queue();
     }
@@ -1607,6 +2454,80 @@ pub(super) fn submit_graph(
     }
 
     Ok(fence_value)
+}
+
+/// Re-execute a previously retained command list without re-recording.
+///
+/// Calls `ExecuteCommandLists` on the closed list stored by a prior
+/// `submit_graph(..., Some(key))` call, then signals the device fence.
+/// Returns `Ok(Some(tv))` on success, `Ok(None)` if no retained list matches `key`.
+pub(super) fn try_resubmit_retained(
+    state: &mut Dx12State,
+    device_handle: DeviceHandle,
+    key: u64,
+) -> Result<Option<TimelineValue>> {
+    let retained = {
+        let dev = state
+            .devices
+            .get(&device_handle)
+            .context("Invalid device handle")?;
+        match dev.retained_graph.as_ref() {
+            Some(r) if r.fingerprint == key => Some((r.command_list.clone(), r.slot_idx)),
+            _ => None,
+        }
+    };
+
+    let Some((command_list, slot_idx)) = retained else {
+        return Ok(None);
+    };
+
+    let fence_value = {
+        let dev = state
+            .devices
+            .get_mut(&device_handle)
+            .context("Invalid device handle")?;
+        let token = dev.fence_value;
+        dev.fence_value += 1;
+        token
+    };
+
+    let cmd_list: ID3D12CommandList = command_list
+        .cast()
+        .context("Failed to cast retained command list")?;
+
+    let dev = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?;
+    {
+        let _tz = tracy_zone!("dx12.resubmit_retained");
+        unsafe {
+            dev.command_queue.ExecuteCommandLists(&[Some(cmd_list)]);
+        }
+        unsafe { dev.command_queue.Signal(&dev.fence, fence_value) }
+            .context("Failed to signal fence after retained resubmit")?;
+    }
+
+    if let Some(dev) = state.devices.get_mut(&device_handle) {
+        // Update the retained slot's fence_value so the GPU timeline stays accurate.
+        if let Some(slot) = dev.compute_allocator_pool.get_mut(slot_idx) {
+            slot.fence_value = fence_value;
+        }
+        dev.process_deletion_queue();
+    }
+
+    Ok(Some(fence_value))
+}
+
+/// Drop the retained command list for `key`, marking its pool slot as reusable.
+pub(super) fn evict_retained(state: &mut Dx12State, device_handle: DeviceHandle) {
+    if let Some(dev) = state.devices.get_mut(&device_handle) {
+        if let Some(old) = dev.retained_graph.take() {
+            if let Some(slot) = dev.compute_allocator_pool.get_mut(old.slot_idx) {
+                slot.retained = false;
+            }
+        }
+    }
 }
 
 /// Check if the fence for the given token has signaled.

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -250,6 +250,54 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
         sig
     };
 
+    // Command signature for batched dispatch: push-constants + dispatch per entry.
+    // Requires the bindless root signature so that INDIRECT_ARGUMENT_TYPE_CONSTANT
+    // can reference root parameter 0.
+    let compute_batch_dispatch_signature = if let Some(ref root_sig) = bindless_root_signature {
+        use crate::backend::shared::TOTAL_PUSH_BYTES;
+        let arg_descs = [
+            D3D12_INDIRECT_ARGUMENT_DESC {
+                Type: D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT,
+                Anonymous: D3D12_INDIRECT_ARGUMENT_DESC_0 {
+                    Constant: D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
+                        RootParameterIndex: 0,
+                        DestOffsetIn32BitValues: 0,
+                        Num32BitValuesToSet: (TOTAL_PUSH_BYTES / 4) as u32,
+                    },
+                },
+            },
+            D3D12_INDIRECT_ARGUMENT_DESC {
+                Type: D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH,
+                Anonymous: unsafe { std::mem::zeroed() },
+            },
+        ];
+        let stride = (TOTAL_PUSH_BYTES + 3 * 4) as u32; // PushLayout + [wg_x, wg_y, wg_z]
+        let cmd_sig_desc = D3D12_COMMAND_SIGNATURE_DESC {
+            ByteStride: stride,
+            NumArgumentDescs: arg_descs.len() as u32,
+            pArgumentDescs: arg_descs.as_ptr(),
+            NodeMask: 0,
+        };
+        let mut sig: Option<ID3D12CommandSignature> = None;
+        let result = unsafe {
+            device.CreateCommandSignature(
+                &cmd_sig_desc,
+                root_sig, // must match all pipelines using this signature
+                &mut sig,
+            )
+        };
+        if let Err(e) = result {
+            tracing::warn!("Failed to create batch dispatch command signature: {e}; DispatchBatch will use per-dispatch fallback");
+            None
+        } else {
+            tracing::debug!("Created batch dispatch command signature (stride={stride}B)");
+            sig
+        }
+    } else {
+        tracing::warn!("No bindless root signature; DispatchBatch batch path unavailable");
+        None
+    };
+
     // Zero-filled UPLOAD-heap buffer used as the source for CopyBufferRegion clears.
     // UPLOAD heaps are zero-initialized by the D3D12 runtime; no explicit memset needed.
     // Size matches UPLOAD_CHUNK_SIZE in buffer.rs so any single chunk fits in one copy.
@@ -300,6 +348,8 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
     let compute_allocator_pool = vec![types::ComputeAllocatorSlot {
         allocator: compute_initial_allocator,
         fence_value: 0,
+        command_list: None,
+        retained: false,
     }];
 
     let resource_registry = types::ResourceRegistry::new();
@@ -341,8 +391,10 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             },
             bindless_root_signature,
             compute_dispatch_indirect_signature,
+            compute_batch_dispatch_signature,
             resource_registry,
             zero_buffer,
+            retained_graph: None,
             deletion_queue: super::types::DeletionQueue::new(),
             graphics_pso_blobs,
             compute_pso_blobs,

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -893,7 +893,28 @@ impl GpuBackend for Dx12Backend {
         device: DeviceHandle,
         commands: &[GraphCommand],
     ) -> Result<crate::timeline::TimelineValue> {
-        compute::submit_graph(&mut self.state, device, commands)
+        compute::submit_graph(&mut self.state, device, commands, None)
+    }
+
+    fn submit_graph_and_retain(
+        &mut self,
+        device: DeviceHandle,
+        commands: &[GraphCommand],
+        key: u64,
+    ) -> Result<crate::timeline::TimelineValue> {
+        compute::submit_graph(&mut self.state, device, commands, Some(key))
+    }
+
+    fn try_resubmit_retained(
+        &mut self,
+        device: DeviceHandle,
+        key: u64,
+    ) -> Result<Option<crate::timeline::TimelineValue>> {
+        compute::try_resubmit_retained(&mut self.state, device, key)
+    }
+
+    fn evict_retained(&mut self, device: DeviceHandle, _key: u64) {
+        compute::evict_retained(&mut self.state, device);
     }
 
     fn record_gpu_work(&mut self, frame: &FrameToken, commands: &[GpuCommand]) -> Result<()> {

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -527,12 +527,11 @@ pub(super) fn stage_texture_upload_region(
 pub(super) fn record_staged_texture_upload(
     command_list: &ID3D12GraphicsCommandList,
     command_list7: &ID3D12GraphicsCommandList7,
-    state: &mut Dx12State,
+    textures: &mut std::collections::HashMap<TextureHandle, TextureState>,
     upload: &StagedTextureUpload,
 ) -> Result<()> {
     let after_layout = D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_SHADER_RESOURCE;
-    let texture = state
-        .textures
+    let texture = textures
         .get(&upload.texture_handle)
         .context("record_staged_texture_upload: invalid texture")?;
     let layout_before = upload.layout_before;
@@ -591,7 +590,7 @@ pub(super) fn record_staged_texture_upload(
     unsafe { barriers::barrier_textures(command_list7, &b_to_shader) };
     unsafe { barriers::drop_texture_barriers(&mut b_to_shader) };
 
-    if let Some(tex) = state.textures.get_mut(&upload.texture_handle) {
+    if let Some(tex) = textures.get_mut(&upload.texture_handle) {
         tex.last_layout = after_layout;
     }
     Ok(())

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -319,6 +319,26 @@ pub(crate) struct ComputeAllocatorSlot {
     pub allocator: Direct3D12::ID3D12CommandAllocator,
     /// Fence value when this slot was last used (for reuse detection)
     pub fence_value: u64,
+    /// Reusable command list (created on first use, then reset with allocator).
+    pub command_list: Option<Direct3D12::ID3D12GraphicsCommandList>,
+    /// When `true`, this slot holds a retained command list that must not be reset
+    /// until the caller explicitly releases it via `evict_retained`.
+    pub retained: bool,
+}
+
+/// A retained (closed but not reset) command list available for re-execution.
+///
+/// DX12 allows re-executing a closed command list via `ExecuteCommandLists`
+/// without calling `Reset`, as long as the backing allocator is not reset first.
+/// This enables zero-recording-cost re-submission for static scenes.
+pub(crate) struct RetainedGraph {
+    /// Scene fingerprint that uniquely identifies this command list's content.
+    pub fingerprint: u64,
+    /// The closed (but not reset) command list.  Cloned from the pool slot so both
+    /// the pool and this struct hold a reference-counted pointer to the same COM object.
+    pub command_list: Direct3D12::ID3D12GraphicsCommandList,
+    /// Index into `LogicalDevice::compute_allocator_pool` for the backing allocator slot.
+    pub slot_idx: usize,
 }
 
 /// Resource pending deferred deletion.
@@ -353,6 +373,10 @@ pub(crate) enum PendingDeletion {
         texture_handle: TextureHandle,
         resource: Direct3D12::ID3D12Resource,
     },
+    /// An ad-hoc GPU resource (e.g. a DispatchBatch argument buffer) that is not
+    /// tracked in any resource map.  Dropping it releases the COM reference and
+    /// frees the GPU memory once the fence is met.
+    StandaloneResource(Direct3D12::ID3D12Resource),
 }
 
 /// Deferred deletion queue for a DX12 device.
@@ -409,13 +433,20 @@ pub(crate) struct LogicalDevice {
     pub tile_heap_pool: Option<super::tiles::TileHeapPool>,
     /// Shared root signature for all bindless pipelines (graphics and compute)
     pub bindless_root_signature: Option<Direct3D12::ID3D12RootSignature>,
-    /// Command signature for indirect compute dispatch (ExecuteIndirect)
+    /// Command signature for indirect compute dispatch (ExecuteIndirect, dispatch-only)
     pub compute_dispatch_indirect_signature: Option<Direct3D12::ID3D12CommandSignature>,
+    /// Command signature for batched dispatch: sets push constants then dispatches.
+    /// Each argument entry contains `[PushLayout (TOTAL_PUSH_BYTES)] [wg_x] [wg_y] [wg_z]`.
+    /// Requires the shared `bindless_root_signature` to be non-None.
+    pub compute_batch_dispatch_signature: Option<Direct3D12::ID3D12CommandSignature>,
     /// Registry tracking resource offsets in descriptor heaps
     pub resource_registry: ResourceRegistry,
     /// Pool of command allocators for non-blocking compute submission.
     /// Slots can be reused when fence signals completion.
     pub compute_allocator_pool: Vec<ComputeAllocatorSlot>,
+    /// A single retained command list for zero-recording-cost re-submission.
+    /// `None` until a `submit_graph_and_retain` call stores a closed CL here.
+    pub retained_graph: Option<RetainedGraph>,
     /// Device-lifetime zero-filled UPLOAD-heap buffer used as the source for
     /// `CopyBufferRegion` clears. One buffer per device; clears of any size are
     /// handled by chunking `CopyBufferRegion` calls. Using a copy instead of
@@ -520,6 +551,9 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             resource,
         } => {
             ld.resource_registry.unregister_texture(texture_handle);
+            drop(resource);
+        }
+        PendingDeletion::StandaloneResource(resource) => {
             drop(resource);
         }
     }

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -6,6 +6,7 @@ use super::types::RESOURCE_SLOT_BUFFER;
 use super::types::{ComputePipelineState, MetalState, PushLayout};
 use crate::slang::parse_numthreads;
 use crate::slang::SlangStage;
+use crate::tracy_zone;
 
 /// Fallback workgroup size used when a compute shader's `[numthreads]` annotation
 /// cannot be parsed. Matches the Metal/Slang default used elsewhere in the codebase.
@@ -103,11 +104,14 @@ pub(super) fn destroy(state: &mut MetalState, pipeline_handle: ComputePipelineHa
 
 /// Begin a fresh compute encoder on the command buffer with heap and argument buffer bindings.
 ///
-/// Calls `use_resource` on every buffer and texture so Metal's hazard tracking
-/// can detect cross-encoder dependencies (e.g. compute→blit→compute). `use_heap`
-/// alone provides residency but NOT hazard tracking — without per-resource
+/// Calls `useResources:count:usage:` (batch form) on all device-owned buffers and textures
+/// so Metal's hazard tracking can detect cross-encoder dependencies (e.g. compute→blit→compute).
+/// `use_heap` alone provides residency but NOT hazard tracking — without per-resource
 /// declarations, Metal GPU Validation rejects dispatches that touch heap-resident
 /// resources via argument buffers.
+///
+/// Using the batched form reduces Objective-C msg_send overhead from O(N) per encoder open
+/// to O(1) regardless of how many resources the device owns.
 pub(super) fn begin_compute_encoder<'a>(
     command_buffer: &'a mtl::CommandBufferRef,
     state: &MetalState,
@@ -117,24 +121,43 @@ pub(super) fn begin_compute_encoder<'a>(
     let encoder = command_buffer.new_compute_command_encoder();
     logical_device.heap_allocator.use_heaps_for_compute(encoder);
     logical_device.texture_heap.use_heaps_for_compute(encoder);
+
+    // Collect resource refs by usage tier then call use_resources once per tier,
+    // replacing one ObjC msg_send per resource with at most three total.
+    // Safety: BufferRef/TextureRef are subclasses of Resource in the Metal ObjC
+    // hierarchy, so transmuting the reference type is sound (same pointer, same layout).
+    let mut rw_refs: Vec<&mtl::ResourceRef> = Vec::new();
+    let mut ro_refs: Vec<&mtl::ResourceRef> = Vec::new();
     for buf_state in state.buffers.values() {
         if buf_state.device_handle == device_handle {
-            encoder.use_resource(
-                &buf_state.buffer,
-                mtl::MTLResourceUsage::Read | mtl::MTLResourceUsage::Write,
-            );
+            let buf_ref: &mtl::BufferRef = &buf_state.buffer;
+            rw_refs.push(unsafe {
+                std::mem::transmute::<&mtl::BufferRef, &mtl::ResourceRef>(buf_ref)
+            });
         }
     }
     for tex_state in state.textures.values() {
         if tex_state.device_handle == device_handle {
-            let usage = if tex_state.is_storage_image {
-                mtl::MTLResourceUsage::Read | mtl::MTLResourceUsage::Write
+            let tex_ref: &mtl::TextureRef = &tex_state.texture;
+            let res_ref =
+                unsafe { std::mem::transmute::<&mtl::TextureRef, &mtl::ResourceRef>(tex_ref) };
+            if tex_state.is_storage_image {
+                rw_refs.push(res_ref);
             } else {
-                mtl::MTLResourceUsage::Read
-            };
-            encoder.use_resource(&tex_state.texture, usage);
+                ro_refs.push(res_ref);
+            }
         }
     }
+    if !rw_refs.is_empty() {
+        encoder.use_resources(
+            &rw_refs,
+            mtl::MTLResourceUsage::Read | mtl::MTLResourceUsage::Write,
+        );
+    }
+    if !ro_refs.is_empty() {
+        encoder.use_resources(&ro_refs, mtl::MTLResourceUsage::Read);
+    }
+
     encoder.set_buffer(0, Some(&logical_device.argument_buffer), 0);
     encoder
 }
@@ -187,6 +210,15 @@ pub(super) fn record_commands_to_buffer(
     // the memcpy result when the command buffer is later committed.
     let mut has_recorded_gpu_work = false;
 
+    // Tracks which buffer/texture handles have been touched in the current blit
+    // encoder session. Metal does not guarantee ordering between two blit ops on
+    // the same resource within one encoder (e.g. fill_buffer → copy_from_buffer on
+    // the same buffer). We end+reopen the encoder only when the incoming command
+    // targets a handle already touched in this session; distinct-handle blit ops
+    // share the encoder and avoid the per-command encoder-open overhead.
+    let mut blit_touched_bufs: Vec<super::BufferHandle> = Vec::new();
+    let mut blit_touched_texs: Vec<super::TextureHandle> = Vec::new();
+
     macro_rules! end_compute {
         () => {
             if let Some(enc) = guard.compute.take() {
@@ -206,6 +238,8 @@ pub(super) fn record_commands_to_buffer(
     macro_rules! ensure_compute {
         () => {
             end_blit!();
+            blit_touched_bufs.clear();
+            blit_touched_texs.clear();
             if guard.compute.is_none() {
                 let enc =
                     begin_compute_encoder(command_buffer, state, logical_device, device_handle);
@@ -218,18 +252,37 @@ pub(super) fn record_commands_to_buffer(
         };
     }
 
-    macro_rules! ensure_blit {
+    /// Open a new blit encoder, clearing both touched-handle sets.
+    macro_rules! open_blit {
         () => {
             end_compute!();
-            // End any active blit encoder before opening a new one. Metal does not
-            // guarantee ordering between commands within the same blit encoder (e.g.
-            // fill_buffer and copy_from_buffer targeting the same buffer may execute
-            // in any order). Ending and reopening creates a new encoder boundary which
-            // Metal serializes, so each ClearBuffer/WriteBuffer command executes in
-            // strictly program order relative to every other blit command.
             end_blit!();
             guard.blit = Some(command_buffer.new_blit_command_encoder());
+            blit_touched_bufs.clear();
+            blit_touched_texs.clear();
             has_recorded_gpu_work = true;
+        };
+    }
+
+    /// Ensure a blit encoder is open, splitting only if `$buf` (a BufferHandle)
+    /// has already been written in the current encoder session.
+    macro_rules! ensure_blit_buf {
+        ($handle:expr) => {
+            if guard.blit.is_none() || blit_touched_bufs.contains(&$handle) {
+                open_blit!();
+            }
+            blit_touched_bufs.push($handle);
+        };
+    }
+
+    /// Ensure a blit encoder is open, splitting only if `$tex` (a TextureHandle)
+    /// has already been written in the current encoder session.
+    macro_rules! ensure_blit_tex {
+        ($handle:expr) => {
+            if guard.blit.is_none() || blit_touched_texs.contains(&$handle) {
+                open_blit!();
+            }
+            blit_touched_texs.push($handle);
         };
     }
 
@@ -250,7 +303,7 @@ pub(super) fn record_commands_to_buffer(
                     *size
                 };
                 if clear_size > 0 {
-                    ensure_blit!();
+                    ensure_blit_buf!(*buffer);
                     let range = mtl::NSRange::new(*offset, clear_size);
                     guard.blit.unwrap().fill_buffer(&buf_state.buffer, range, 0);
                 }
@@ -301,7 +354,7 @@ pub(super) fn record_commands_to_buffer(
                     }
                 }
 
-                ensure_blit!();
+                ensure_blit_buf!(*buf_handle);
                 let staging = logical_device.device.new_buffer_with_data(
                     data.as_ptr() as *const _,
                     data.len() as u64,
@@ -342,7 +395,7 @@ pub(super) fn record_commands_to_buffer(
                 if expected == 0 {
                     continue;
                 }
-                ensure_blit!();
+                ensure_blit_tex!(*tex_handle);
                 let staging = logical_device.device.new_buffer_with_data(
                     data.as_ptr() as *const _,
                     data.len() as u64,
@@ -393,7 +446,7 @@ pub(super) fn record_commands_to_buffer(
                 if expected == 0 {
                     continue;
                 }
-                ensure_blit!();
+                ensure_blit_tex!(*tex_handle);
                 let staging = logical_device.device.new_buffer_with_data(
                     data.as_ptr() as *const _,
                     data.len() as u64,
@@ -508,6 +561,7 @@ pub(super) fn record_commands_to_buffer(
                     );
             }
             GpuCommand::Dispatch {
+                label: _,
                 workgroups_x,
                 workgroups_y,
                 workgroups_z,
@@ -530,7 +584,61 @@ pub(super) fn record_commands_to_buffer(
                         .dispatch_thread_groups(threadgroups, threads_per_group);
                 }
             }
-            GpuCommand::DispatchIndirect { buffer, offset } => {
+            GpuCommand::DispatchBatch {
+                label: _,
+                arg_data,
+                count,
+            } => {
+                ensure_compute!();
+                if let Some(pipeline) = current_pipeline {
+                    let push_size = std::mem::size_of::<PushLayout>();
+                    let stride = shared::DISPATCH_BATCH_STRIDE;
+                    let entry_count = *count as usize;
+                    let needed = entry_count
+                        .checked_mul(stride)
+                        .context("DispatchBatch: stride overflow")?;
+                    anyhow::ensure!(
+                        arg_data.len() >= needed,
+                        "DispatchBatch: arg_data len {} < {} entries × stride {}",
+                        arg_data.len(),
+                        entry_count,
+                        stride,
+                    );
+                    let threads_per_group = MTLSize {
+                        width: pipeline.workgroup_size[0] as u64,
+                        height: pipeline.workgroup_size[1] as u64,
+                        depth: pipeline.workgroup_size[2] as u64,
+                    };
+                    let enc = guard
+                        .compute
+                        .expect("encoder must be set after ensure_compute!()");
+                    for i in 0..entry_count {
+                        let base = i * stride;
+                        let layout_slice = &arg_data[base..base + push_size];
+                        enc.set_bytes(
+                            RESOURCE_SLOT_BUFFER,
+                            layout_slice.len() as u64,
+                            layout_slice.as_ptr() as *const _,
+                        );
+                        let wg_off = base + push_size;
+                        let wg_x = u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into()?);
+                        let wg_y = u32::from_ne_bytes(arg_data[wg_off + 4..wg_off + 8].try_into()?);
+                        let wg_z =
+                            u32::from_ne_bytes(arg_data[wg_off + 8..wg_off + 12].try_into()?);
+                        let threadgroups = MTLSize {
+                            width: wg_x as u64,
+                            height: wg_y as u64,
+                            depth: wg_z as u64,
+                        };
+                        enc.dispatch_thread_groups(threadgroups, threads_per_group);
+                    }
+                }
+            }
+            GpuCommand::DispatchIndirect {
+                label: _,
+                buffer,
+                offset,
+            } => {
                 ensure_compute!();
                 let buf_state = state
                     .buffers
@@ -546,6 +654,35 @@ pub(super) fn record_commands_to_buffer(
                     .compute
                     .expect("encoder must be set after ensure_compute!()")
                     .dispatch_thread_groups_indirect(&buf_state.buffer, *offset, threads_per_group);
+            }
+            GpuCommand::CopyTexture { src, dst } => {
+                ensure_blit_tex!(*src);
+                ensure_blit_tex!(*dst);
+                let src_state = state
+                    .textures
+                    .get(src)
+                    .context("CopyTexture: src texture not found")?;
+                let dst_state = state
+                    .textures
+                    .get(dst)
+                    .context("CopyTexture: dst texture not found")?;
+                let w = src_state.width as u64;
+                let h = src_state.height as u64;
+                guard.blit.unwrap().copy_from_texture(
+                    &src_state.texture,
+                    0,
+                    0,
+                    MTLOrigin { x: 0, y: 0, z: 0 },
+                    MTLSize {
+                        width: w,
+                        height: h,
+                        depth: 1,
+                    },
+                    &dst_state.texture,
+                    0,
+                    0,
+                    MTLOrigin { x: 0, y: 0, z: 0 },
+                );
             }
             GpuCommand::Barrier => {
                 if let Some(enc) = guard.compute {
@@ -600,6 +737,7 @@ pub(super) fn submit(
     device_handle: DeviceHandle,
     commands: &[GpuCommand],
 ) -> Result<TimelineValue> {
+    let _tz = tracy_zone!("mtl.submit");
     if state.device_lost.load(Ordering::Relaxed) {
         anyhow::bail!("GPU device is lost (earlier wait timed out); refusing to submit new work");
     }
@@ -650,6 +788,14 @@ pub(super) fn submit(
                 description
             );
         }
+        // Capture per-command-buffer GPU timestamps. `GPUStartTime` / `GPUEndTime`
+        // are only valid after completion, which is guaranteed here.
+        if crate::gpu_profiler::gpu_profile_enabled() {
+            let gpu_start: f64 = unsafe { objc::msg_send![cb, GPUStartTime] };
+            let gpu_end: f64 = unsafe { objc::msg_send![cb, GPUEndTime] };
+            let ms = (gpu_end - gpu_start) * 1000.0;
+            crate::gpu_profiler::log_cb_timing("metal", signal_value, ms);
+        }
         waiter.signal(signal_value);
     })
     .copy();
@@ -683,6 +829,7 @@ pub(super) fn submit_graph(
     device_handle: DeviceHandle,
     commands: &[super::super::GraphCommand],
 ) -> Result<TimelineValue> {
+    let _tz = tracy_zone!("mtl.submit_graph");
     use super::super::GraphCommand;
 
     if state.device_lost.load(Ordering::Relaxed) {
@@ -784,6 +931,14 @@ pub(super) fn submit_graph(
                 status,
                 description
             );
+        }
+        // Capture per-command-buffer GPU timestamps. `GPUStartTime` / `GPUEndTime`
+        // are only valid after completion, which is guaranteed here.
+        if crate::gpu_profiler::gpu_profile_enabled() {
+            let gpu_start: f64 = unsafe { objc::msg_send![cb, GPUStartTime] };
+            let gpu_end: f64 = unsafe { objc::msg_send![cb, GPUEndTime] };
+            let ms = (gpu_end - gpu_start) * 1000.0;
+            crate::gpu_profiler::log_cb_timing("metal", signal_value, ms);
         }
         waiter.signal(signal_value);
     })

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -1828,6 +1828,7 @@ mod tests {
                 buffers: vec![buffer1, buffer2],
             },
             GpuCommand::Dispatch {
+                label: None,
                 workgroups_x: 8,
                 workgroups_y: 8,
                 workgroups_z: 1,
@@ -1860,6 +1861,7 @@ mod tests {
         let commands = vec![
             GraphCommand::Compute(GpuCommand::SetPipeline(0)),
             GraphCommand::Compute(GpuCommand::Dispatch {
+                label: None,
                 workgroups_x: 1,
                 workgroups_y: 1,
                 workgroups_z: 1,
@@ -1870,6 +1872,7 @@ mod tests {
             },
             GraphCommand::Compute(GpuCommand::SetPipeline(0)),
             GraphCommand::Compute(GpuCommand::Dispatch {
+                label: None,
                 workgroups_x: 1,
                 workgroups_y: 1,
                 workgroups_z: 1,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -33,12 +33,8 @@ pub mod mock;
 #[cfg(all(feature = "metal", target_os = "macos"))]
 pub mod metal;
 
-/// Shared primitives reused across Vulkan, DX12, and Metal backends.
-#[cfg(any(
-    feature = "vulkan",
-    all(feature = "dx12", target_os = "windows"),
-    all(feature = "metal", target_os = "macos")
-))]
+/// Shared primitives reused across Vulkan, DX12, and Metal backends, and by
+/// task-graph command emission (e.g. `DispatchBatch` argument packing).
 pub(crate) mod shared;
 
 use crate::types::{
@@ -283,12 +279,18 @@ pub enum GpuCommand {
     BindResourcesTyped { handles: Vec<BindlessHandle> },
     /// Dispatch compute workgroups.
     Dispatch {
+        /// Debug label from [`crate::task_graph::TaskGraph::node`] when emitted by the analyzer.
+        label: Option<&'static str>,
         workgroups_x: u32,
         workgroups_y: u32,
         workgroups_z: u32,
     },
     /// Indirect dispatch: workgroup counts read from buffer at offset (3× u32: x, y, z).
-    DispatchIndirect { buffer: BufferHandle, offset: u64 },
+    DispatchIndirect {
+        label: Option<&'static str>,
+        buffer: BufferHandle,
+        offset: u64,
+    },
     /// Fill a buffer region with zeros. Batched into the same command stream as dispatches.
     ClearBuffer {
         buffer: BufferHandle,
@@ -322,6 +324,29 @@ pub enum GpuCommand {
         width: u32,
         height: u32,
         data: Arc<[u8]>,
+    },
+    /// Copy the entire contents of `src` texture into `dst`.
+    ///
+    /// Both textures must have compatible formats and identical dimensions.
+    /// The backend inserts appropriate layout transitions and memory barriers.
+    CopyTexture {
+        src: TextureHandle,
+        dst: TextureHandle,
+    },
+    /// Batched indirect dispatch: multiple consecutive dispatches sharing the same pipeline.
+    ///
+    /// Each entry packs `[PushLayout bytes | wg_x u32 | wg_y u32 | wg_z u32]` into
+    /// `arg_data` (`DISPATCH_BATCH_STRIDE` bytes per entry).  The backend records a
+    /// single `ExecuteIndirect` on DX12 or iterates on Vulkan/Metal.
+    ///
+    /// Only emitted by `emit_commands` when consecutive same-pipeline dispatches
+    /// are detected within a wave.  Falls back to individual `Dispatch` commands
+    /// if no grouping is possible.
+    DispatchBatch {
+        label: Option<&'static str>,
+        /// Pre-filled argument data: `count` entries of `DISPATCH_BATCH_STRIDE` bytes each.
+        arg_data: Arc<[u8]>,
+        count: u32,
     },
     /// Memory barrier between compute dispatches.
     /// Ensures all prior shader writes are visible to subsequent reads.
@@ -714,6 +739,44 @@ pub trait GpuBackend: Send + Sync {
         }
         Ok(last_tv)
     }
+
+    /// Submit commands and retain the closed command list for potential reuse on the next
+    /// cache-hit frame.
+    ///
+    /// When `key` matches the key passed on the previous call AND the GPU resources
+    /// referenced by those commands have stable bindless handles, callers may call
+    /// [`Self::try_resubmit_retained`] instead of re-recording.
+    ///
+    /// The DX12 backend implements this by keeping the closed `ID3D12GraphicsCommandList`
+    /// alive (without `Reset`) and re-executing it via `ExecuteCommandLists`.  Other
+    /// backends default to a normal [`Self::submit_graph`] (safe fallback, no caching).
+    fn submit_graph_and_retain(
+        &mut self,
+        device: DeviceHandle,
+        commands: &[GraphCommand],
+        key: u64,
+    ) -> Result<crate::timeline::TimelineValue> {
+        let _ = key;
+        self.submit_graph(device, commands)
+    }
+
+    /// Re-execute a previously retained command list without re-recording.
+    ///
+    /// Returns `Ok(Some(tv))` if the retained list for `key` was found and resubmitted.
+    /// Returns `Ok(None)` if no matching retained list exists (caller should fall back to
+    /// a full [`Self::submit_graph_and_retain`]).  Returns `Err` on a backend error.
+    fn try_resubmit_retained(
+        &mut self,
+        device: DeviceHandle,
+        key: u64,
+    ) -> Result<Option<crate::timeline::TimelineValue>> {
+        let _ = (device, key);
+        Ok(None)
+    }
+
+    /// Drop the retained command list associated with `key`, marking its allocator slot
+    /// as available for re-use.  No-op if no retained list exists.
+    fn evict_retained(&mut self, _device: DeviceHandle, _key: u64) {}
 
     /// Acquire the next swapchain image and begin a frame bracket.
     fn begin_frame(&mut self, surface: SurfaceHandle) -> Result<(FrameToken, TextureHandle)>;

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -4,6 +4,16 @@
 //! `pub(super)` so that sibling modules (`vulkan/`, `dx12/`, `metal/`) can
 //! re-export them locally without leaking internal details to crate consumers.
 //!
+//! When only the mock backend is enabled, most items here are unused except
+//! push-layout helpers consumed by task-graph `DispatchBatch` emission.
+#![cfg_attr(
+    not(any(
+        feature = "vulkan",
+        all(feature = "dx12", target_os = "windows"),
+        all(feature = "metal", target_os = "macos"),
+    )),
+    allow(dead_code)
+)]
 
 use crate::slang::OwnedLayoutCheck;
 use crate::types::{
@@ -28,6 +38,10 @@ pub const MAX_BINDLESS_SLOTS: usize = 16;
 pub const MAX_USER_SLOTS: usize = 8;
 /// Total size of [`PushLayout`] in bytes (must match the Slang `PushLayout` struct).
 pub const TOTAL_PUSH_BYTES: usize = 128;
+/// Byte stride of one entry in a `DispatchBatch` argument buffer.
+///
+/// Layout per entry: `[PushLayout (TOTAL_PUSH_BYTES)] [wg_x u32] [wg_y u32] [wg_z u32]`
+pub const DISPATCH_BATCH_STRIDE: usize = TOTAL_PUSH_BYTES + 3 * 4;
 
 /// Packed 128-byte push-constant / root-constant / `set_bytes` layout shared by
 /// all three GPU backends.
@@ -241,8 +255,9 @@ impl<K: PartialOrd + Copy, V> DeferredQueue<K, V> {
     /// Drain all entries whose key is `<= threshold`, returning them as an
     /// owned `Vec`. Entries with keys above `threshold` are kept in the queue.
     pub fn drain_up_to(&mut self, threshold: K) -> Vec<V> {
-        // Partition in-place: move eligible entries to a temporary vec and
-        // put the rest back, avoiding a full allocation on every call.
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
         let mut i = 0;
         let mut eligible: Vec<V> = Vec::new();
         while i < self.pending.len() {

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -5,10 +5,177 @@ use super::staging;
 use super::types::{ComputePipelineState, LogicalDevice, PushLayout};
 use super::{ComputePipelineHandle, DeviceHandle, RenderTargetHandle, SurfaceHandle};
 use crate::backend::{GpuCommand, GraphCommand};
+use crate::gpu_profiler::{self, DispatchGpuNs};
 use crate::timeline::TimelineValue;
+use crate::tracy_zone;
 use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+
+/// Acquire a command buffer: recycle from the free-list or allocate a fresh one.
+fn acquire_cmd_buffer(ld: &mut LogicalDevice) -> Result<vk::CommandBuffer> {
+    if let Some(cb) = ld.free_cmd_buffers.pop() {
+        return Ok(cb);
+    }
+    let alloc_info = vk::CommandBufferAllocateInfo::default()
+        .command_pool(ld.command_pool)
+        .level(vk::CommandBufferLevel::PRIMARY)
+        .command_buffer_count(1);
+    let cbs = unsafe { ld.device.allocate_command_buffers(&alloc_info) }
+        .context("Failed to allocate command buffer")?;
+    Ok(cbs[0])
+}
+
+#[derive(Debug)]
+struct VulkanGpuProfilePool {
+    pool: vk::QueryPool,
+    query_count: u32,
+    dispatch_labels: Vec<Option<&'static str>>,
+    period_ns: f32,
+    valid_bits: u32,
+}
+
+fn collect_dispatch_labels_compute(commands: &[GpuCommand]) -> (usize, Vec<Option<&'static str>>) {
+    let mut labels = Vec::new();
+    for c in commands {
+        match c {
+            GpuCommand::Dispatch { label, .. }
+            | GpuCommand::DispatchIndirect { label, .. }
+            | GpuCommand::DispatchBatch { label, .. } => {
+                labels.push(*label);
+            }
+            _ => {}
+        }
+    }
+    let n = labels.len();
+    (n, labels)
+}
+
+fn collect_dispatch_labels_graph(commands: &[GraphCommand]) -> (usize, Vec<Option<&'static str>>) {
+    let mut labels = Vec::new();
+    for gc in commands {
+        if let GraphCommand::Compute(
+            GpuCommand::Dispatch { label, .. }
+            | GpuCommand::DispatchIndirect { label, .. }
+            | GpuCommand::DispatchBatch { label, .. },
+        ) = gc
+        {
+            labels.push(*label);
+        }
+    }
+    let n = labels.len();
+    (n, labels)
+}
+
+unsafe fn create_vulkan_gpu_profile_pool(
+    ld: &LogicalDevice,
+    defer_present: bool,
+    dispatch_count: usize,
+    dispatch_labels: Vec<Option<&'static str>>,
+) -> Result<Option<VulkanGpuProfilePool>> {
+    if defer_present
+        || !gpu_profiler::gpu_profile_enabled()
+        || !ld.vk_timestamp_compute_and_graphics
+    {
+        return Ok(None);
+    }
+    debug_assert_eq!(dispatch_labels.len(), dispatch_count);
+    let query_count = 2u32.saturating_add((dispatch_count as u32).saturating_mul(2));
+    let pool = ld.device.create_query_pool(
+        &vk::QueryPoolCreateInfo::default()
+            .query_type(vk::QueryType::TIMESTAMP)
+            .query_count(query_count),
+        None,
+    )?;
+    Ok(Some(VulkanGpuProfilePool {
+        pool,
+        query_count,
+        dispatch_labels,
+        period_ns: ld.vk_timestamp_period_ns,
+        valid_bits: 64,
+    }))
+}
+
+fn vulkan_decode_duration_ns(start: u64, end: u64, valid_bits: u32, period_ns: f32) -> u64 {
+    let mask = if valid_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << valid_bits) - 1
+    };
+    let a = start & mask;
+    let b = end & mask;
+    let delta = b.wrapping_sub(a);
+    let ns_f = (delta as f64) * f64::from(period_ns);
+    if ns_f <= 0.0 {
+        0
+    } else if ns_f >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        ns_f as u64
+    }
+}
+
+unsafe fn vulkan_finish_gpu_profile(
+    state: &mut super::types::VulkanState,
+    device_handle: DeviceHandle,
+    device: &ash::Device,
+    timeline_sem: vk::Semaphore,
+    signal_value: TimelineValue,
+    cmd: vk::CommandBuffer,
+    profile: VulkanGpuProfilePool,
+) -> Result<()> {
+    let wait = vk::SemaphoreWaitInfo::default()
+        .semaphores(std::slice::from_ref(&timeline_sem))
+        .values(std::slice::from_ref(&signal_value));
+    if let Err(e) = device.wait_semaphores(&wait, u64::MAX) {
+        unsafe {
+            device.destroy_query_pool(profile.pool, None);
+        }
+        if e == vk::Result::ERROR_DEVICE_LOST {
+            state.device_lost.store(true, Ordering::Relaxed);
+        }
+        return Err(anyhow::anyhow!("wait_semaphores (gpu profiling): {:?}", e));
+    }
+
+    let mut raw = vec![0u64; profile.query_count as usize];
+    if let Err(e) = device.get_query_pool_results(
+        profile.pool,
+        0,
+        &mut raw,
+        vk::QueryResultFlags::WAIT | vk::QueryResultFlags::TYPE_64,
+    ) {
+        unsafe {
+            device.destroy_query_pool(profile.pool, None);
+        }
+        return Err(anyhow::anyhow!("get_query_pool_results: {:?}", e));
+    }
+
+    let cb_ns = vulkan_decode_duration_ns(raw[0], raw[1], profile.valid_bits, profile.period_ns);
+    gpu_profiler::log_cb_timing("vulkan", signal_value, cb_ns as f64 / 1_000_000.0);
+
+    let n = profile.dispatch_labels.len();
+    if n > 0 {
+        let mut dispatches = Vec::with_capacity(n);
+        for i in 0..n {
+            let si = 2 + 2 * i;
+            let ns = vulkan_decode_duration_ns(
+                raw[si],
+                raw[si + 1],
+                profile.valid_bits,
+                profile.period_ns,
+            );
+            let label = profile.dispatch_labels[i].unwrap_or("dispatch");
+            dispatches.push(DispatchGpuNs { label, gpu_ns: ns });
+        }
+        gpu_profiler::log_dispatch_timings("vulkan", signal_value, &dispatches);
+    }
+
+    device.destroy_query_pool(profile.pool, None);
+    reap_timeline_cmd_buffers_up_to(state, device_handle, signal_value);
+    let _ = cmd;
+    Ok(())
+}
 
 /// Reap fences that have already signaled from the compute fence pool.
 ///
@@ -157,6 +324,14 @@ pub(super) fn submit(
     commands: &[GpuCommand],
     defer_to_present_for_surface: Option<SurfaceHandle>,
 ) -> Result<TimelineValue> {
+    let _tz = tracy_zone!("vk.submit");
+    // Detect WriteBuffer up-front so we can skip all the staging-belt /
+    // fence-pool maintenance when this submit has no host→GPU uploads.
+    // The next WriteBuffer-bearing submit will reclaim/reap any debris.
+    let has_write_buffer = commands
+        .iter()
+        .any(|c| matches!(c, GpuCommand::WriteBuffer { .. }));
+
     // Reap any previously-submitted fences that have already signaled. Keeps
     // the pool bounded when callers (ekrano) don't wait on every intermediate submit.
     // Belt before reap: need live VkFence handles to poll completion.
@@ -164,74 +339,79 @@ pub(super) fn submit(
     // For timeline-keyed staging chunks (standalone-submit path) we also need the
     // current device timeline counter so `reclaim` knows which chunks are safe to
     // recycle without reaching into `compute_fence_pool`.
-    let completed_timeline = state
-        .devices
-        .get(&device_handle)
-        .map(|ld| unsafe {
-            ld.device
-                .get_semaphore_counter_value(ld.timeline_semaphore)
-                .unwrap_or(0)
-        })
-        .unwrap_or(0);
+    if has_write_buffer {
+        let _rz = tracy_zone!("vk.submit.belt_reclaim");
+        let completed_timeline = state
+            .devices
+            .get(&device_handle)
+            .map(|ld| unsafe {
+                ld.device
+                    .get_semaphore_counter_value(ld.timeline_semaphore)
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
 
-    for belt in state.staging_belts.values_mut() {
-        belt.reclaim(
-            &state.compute_fence_pool,
-            &state.devices,
-            completed_timeline,
-        )?;
+        for belt in state.staging_belts.values_mut() {
+            belt.reclaim(
+                &state.compute_fence_pool,
+                &state.devices,
+                completed_timeline,
+            )?;
+        }
+        reap_signaled_fences(state);
     }
-    reap_signaled_fences(state);
 
     // Belt slices for DEVICE_LOCAL WriteBuffer copies (same iteration order as command loop).
     let mut belt_slices: Vec<(vk::Buffer, u64)> = Vec::new();
 
     // Pre-pass: stage CPU data for WriteBuffer commands (needs mutable buffer
     // access before we borrow state immutably for the command loop).
-    for command in commands {
-        if let GpuCommand::WriteBuffer {
-            buffer: buf_handle,
-            offset,
-            data,
-        } = command
-        {
-            let buf = state
-                .buffers
-                .get(buf_handle)
-                .context("WriteBuffer: invalid buffer handle")?;
-            if let Some(base) = buf.host_mapped {
-                let p = base as *mut u8;
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        data.as_ptr(),
-                        p.add(*offset as usize),
-                        data.len(),
-                    );
+    if has_write_buffer {
+        for command in commands {
+            if let GpuCommand::WriteBuffer {
+                buffer: buf_handle,
+                offset,
+                data,
+            } = command
+            {
+                let buf = state
+                    .buffers
+                    .get(buf_handle)
+                    .context("WriteBuffer: invalid buffer handle")?;
+                if let Some(base) = buf.host_mapped {
+                    let p = base as *mut u8;
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            data.as_ptr(),
+                            p.add(*offset as usize),
+                            data.len(),
+                        );
+                    }
+                } else if !buf.is_storage {
+                    let dev = state
+                        .devices
+                        .get(&buf.device_handle)
+                        .context("WriteBuffer: device invalid")?;
+                    unsafe {
+                        let ptr = dev
+                            .map_memory2(buf.memory, *offset, data.len() as u64)
+                            .context("WriteBuffer: map failed")?;
+                        std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
+                        dev.unmap_memory2(buf.memory)
+                            .context("WriteBuffer: unmap failed")?;
+                    }
+                } else {
+                    let buf_device = buf.device_handle;
+                    let dev = state
+                        .devices
+                        .get(&buf_device)
+                        .context("WriteBuffer: device invalid")?;
+                    let belt_entry = state.staging_belts.entry(buf_device).or_insert_with(|| {
+                        staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
+                    });
+                    let (stg_buf, stg_off) = belt_entry.write(&state.instance, dev, data)?;
+                    belt_slices.push((stg_buf, stg_off));
                 }
-            } else if !buf.is_storage {
-                let dev = state
-                    .devices
-                    .get(&buf.device_handle)
-                    .context("WriteBuffer: device invalid")?;
-                unsafe {
-                    let ptr = dev
-                        .map_memory2(buf.memory, *offset, data.len() as u64)
-                        .context("WriteBuffer: map failed")?;
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
-                    dev.unmap_memory2(buf.memory)
-                        .context("WriteBuffer: unmap failed")?;
-                }
-            } else {
-                let buf_device = buf.device_handle;
-                let dev = state
-                    .devices
-                    .get(&buf_device)
-                    .context("WriteBuffer: device invalid")?;
-                let belt_entry = state.staging_belts.entry(buf_device).or_insert_with(|| {
-                    staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                });
-                let (stg_buf, stg_off) = belt_entry.write(&state.instance, dev, data)?;
-                belt_slices.push((stg_buf, stg_off));
             }
         }
     }
@@ -317,55 +497,93 @@ pub(super) fn submit(
         }
     }
 
+    let (dispatch_count, dispatch_labels) = collect_dispatch_labels_compute(commands);
+    let vk_gpu_profile = unsafe {
+        let ld = state
+            .devices
+            .get(&device_handle)
+            .context("Invalid device handle")?;
+        create_vulkan_gpu_profile_pool(
+            ld,
+            defer_to_present_for_surface.is_some(),
+            dispatch_count,
+            dispatch_labels,
+        )?
+    };
+
+    let mut vk_gpu_profile = vk_gpu_profile;
+
+    let cmd = {
+        let ld = state
+            .devices
+            .get_mut(&device_handle)
+            .context("Invalid device handle")?;
+        let cb = acquire_cmd_buffer(ld)?;
+        let begin_info = vk::CommandBufferBeginInfo::default()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+        if let Err(e) = unsafe { ld.device.begin_command_buffer(cb, &begin_info) } {
+            ld.free_cmd_buffers.push(cb);
+            return Err(anyhow::anyhow!("Failed to begin command buffer: {:?}", e));
+        }
+        cb
+    };
+
     let (cmd, belt_idx, _texture_upload_idx) = {
         let logical_device = state
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
 
-        // Allocate command buffer
-        let alloc_info = vk::CommandBufferAllocateInfo::default()
-            .command_pool(logical_device.command_pool)
-            .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1);
-
-        let cmd_buffers = unsafe { logical_device.device.allocate_command_buffers(&alloc_info) }
-            .context("Failed to allocate command buffer")?;
-        let cmd = cmd_buffers[0];
-
-        // Begin command buffer
-        let begin_info = vk::CommandBufferBeginInfo::default()
-            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
-
-        if let Err(e) = unsafe { logical_device.device.begin_command_buffer(cmd, &begin_info) } {
-            unsafe {
-                logical_device
-                    .device
-                    .free_command_buffers(logical_device.command_pool, &[cmd]);
-            }
-            return Err(anyhow::anyhow!("Failed to begin command buffer: {:?}", e));
-        }
-
-        // Cross-submission memory barrier: ensure writes from prior queue
-        // visible to this submission's operations.  Vulkan guarantees execution
-        // ordering for same-queue submissions but NOT memory visibility.
+        // Cross-submission acquire: make prior submit's writes visible to this
+        // CB's reads. Same-queue execution ordering is guaranteed by Vulkan but
+        // memory visibility is not.
         unsafe {
             let acquire = vk::MemoryBarrier2::default()
                 .src_stage_mask(
-                    vk::PipelineStageFlags2::TRANSFER | vk::PipelineStageFlags2::COMPUTE_SHADER,
+                    vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::TRANSFER,
                 )
-                .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE | vk::AccessFlags2::SHADER_WRITE)
+                .src_access_mask(vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE)
                 .dst_stage_mask(
-                    vk::PipelineStageFlags2::TRANSFER | vk::PipelineStageFlags2::COMPUTE_SHADER,
+                    vk::PipelineStageFlags2::COMPUTE_SHADER
+                        | vk::PipelineStageFlags2::TRANSFER
+                        | vk::PipelineStageFlags2::DRAW_INDIRECT,
                 )
                 .dst_access_mask(
-                    vk::AccessFlags2::TRANSFER_READ
-                        | vk::AccessFlags2::TRANSFER_WRITE
-                        | vk::AccessFlags2::SHADER_READ
-                        | vk::AccessFlags2::SHADER_WRITE,
+                    vk::AccessFlags2::SHADER_READ
+                        | vk::AccessFlags2::TRANSFER_READ
+                        | vk::AccessFlags2::INDIRECT_COMMAND_READ,
                 );
             let dep = vk::DependencyInfo::default().memory_barriers(std::slice::from_ref(&acquire));
             logical_device.device.cmd_pipeline_barrier2(cmd, &dep);
+
+            if let (Some(bindless_set), Some(bindless_layout)) = (
+                logical_device.bindless_descriptor_set,
+                logical_device.bindless_pipeline_layout,
+            ) {
+                logical_device.device.cmd_bind_descriptor_sets(
+                    cmd,
+                    vk::PipelineBindPoint::COMPUTE,
+                    bindless_layout,
+                    0,
+                    std::slice::from_ref(&bindless_set),
+                    &[],
+                );
+            }
+        }
+
+        let mut vk_dispatch_idx = 0usize;
+        if let Some(ref prof) = vk_gpu_profile {
+            unsafe {
+                logical_device
+                    .device
+                    .cmd_reset_query_pool(cmd, prof.pool, 0, prof.query_count);
+                logical_device.device.cmd_write_timestamp2(
+                    cmd,
+                    vk::PipelineStageFlags2::TOP_OF_PIPE,
+                    prof.pool,
+                    0,
+                );
+            }
         }
 
         // Track current pipeline for resource slot binding
@@ -377,6 +595,7 @@ pub(super) fn submit(
         for command in commands {
             match command {
                 GpuCommand::SetPipeline(handle) => {
+                    let _tz = tracy_zone!("vk.set_pipeline");
                     if let Some(pipeline_state) = compute_pipelines.get(handle) {
                         unsafe {
                             logical_device.device.cmd_bind_pipeline(
@@ -384,20 +603,6 @@ pub(super) fn submit(
                                 vk::PipelineBindPoint::COMPUTE,
                                 pipeline_state.pipeline,
                             );
-
-                            if let (Some(bindless_set), Some(bindless_layout)) = (
-                                logical_device.bindless_descriptor_set,
-                                logical_device.bindless_pipeline_layout,
-                            ) {
-                                logical_device.device.cmd_bind_descriptor_sets(
-                                    cmd,
-                                    vk::PipelineBindPoint::COMPUTE,
-                                    bindless_layout,
-                                    0,
-                                    std::slice::from_ref(&bindless_set),
-                                    &[],
-                                );
-                            }
                         }
                         current_pipeline = Some(*handle);
                     }
@@ -481,67 +686,209 @@ pub(super) fn submit(
                     }
                 }
                 GpuCommand::Dispatch {
+                    label: _label,
                     workgroups_x,
                     workgroups_y,
                     workgroups_z,
-                } => unsafe {
-                    let mem_barrier = vk::MemoryBarrier2::default()
-                        .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
-                        .src_access_mask(vk::AccessFlags2::SHADER_WRITE)
-                        .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
-                        .dst_access_mask(
-                            vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch");
+                    unsafe {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::TOP_OF_PIPE,
+                                prof.pool,
+                                base,
+                            );
+                        }
+                        logical_device.device.cmd_dispatch(
+                            cmd,
+                            *workgroups_x,
+                            *workgroups_y,
+                            *workgroups_z,
                         );
-                    let dep_info = vk::DependencyInfo::default()
-                        .memory_barriers(std::slice::from_ref(&mem_barrier));
-                    logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
-
-                    logical_device.device.cmd_dispatch(
-                        cmd,
-                        *workgroups_x,
-                        *workgroups_y,
-                        *workgroups_z,
-                    );
-                },
-                GpuCommand::DispatchIndirect { buffer, offset } => {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                                prof.pool,
+                                base + 1,
+                            );
+                        }
+                        vk_dispatch_idx += 1;
+                    }
+                }
+                GpuCommand::DispatchBatch {
+                    label: _,
+                    arg_data,
+                    count,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch_batch");
+                    let push_size = std::mem::size_of::<crate::backend::shared::PushLayout>();
+                    let stride = crate::backend::shared::DISPATCH_BATCH_STRIDE;
+                    let pipeline_layout = current_pipeline
+                        .and_then(|h| compute_pipelines.get(&h))
+                        .map(|p| p.layout);
+                    for i in 0..*count as usize {
+                        let base = i * stride;
+                        let layout_bytes = &arg_data[base..base + push_size];
+                        let wg_off = base + push_size;
+                        let wg_x =
+                            u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into().unwrap());
+                        let wg_y = u32::from_ne_bytes(
+                            arg_data[wg_off + 4..wg_off + 8].try_into().unwrap(),
+                        );
+                        let wg_z = u32::from_ne_bytes(
+                            arg_data[wg_off + 8..wg_off + 12].try_into().unwrap(),
+                        );
+                        unsafe {
+                            if let Some(layout) = pipeline_layout {
+                                logical_device.device.cmd_push_constants(
+                                    cmd,
+                                    layout,
+                                    vk::ShaderStageFlags::ALL,
+                                    0,
+                                    layout_bytes,
+                                );
+                            }
+                            logical_device.device.cmd_dispatch(cmd, wg_x, wg_y, wg_z);
+                        }
+                        vk_dispatch_idx += 1;
+                    }
+                }
+                GpuCommand::DispatchIndirect {
+                    label: _label,
+                    buffer,
+                    offset,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch_indirect");
                     let buf_state = buffers
                         .get(buffer)
                         .context("DispatchIndirect: invalid buffer handle")?;
                     unsafe {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::TOP_OF_PIPE,
+                                prof.pool,
+                                base,
+                            );
+                        }
+                        logical_device
+                            .device
+                            .cmd_dispatch_indirect(cmd, buf_state.buffer, *offset);
+
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                                prof.pool,
+                                base + 1,
+                            );
+                        }
+                    }
+                    vk_dispatch_idx += 1;
+                }
+                GpuCommand::Barrier => {
+                    let _tz = tracy_zone!("vk.barrier");
+                    unsafe {
                         let mem_barrier = vk::MemoryBarrier2::default()
                             .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
                             .src_access_mask(vk::AccessFlags2::SHADER_WRITE)
-                            .dst_stage_mask(
-                                vk::PipelineStageFlags2::COMPUTE_SHADER
-                                    | vk::PipelineStageFlags2::DRAW_INDIRECT,
-                            )
+                            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
                             .dst_access_mask(
-                                vk::AccessFlags2::SHADER_READ
-                                    | vk::AccessFlags2::SHADER_WRITE
-                                    | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
                             );
                         let dep_info = vk::DependencyInfo::default()
                             .memory_barriers(std::slice::from_ref(&mem_barrier));
                         logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
-
-                        logical_device
-                            .device
-                            .cmd_dispatch_indirect(cmd, buf_state.buffer, *offset);
                     }
                 }
-                GpuCommand::Barrier => {
-                    // No-op: Vulkan already emits pipeline barriers before each dispatch.
-                }
-                GpuCommand::ResourceBarrier { .. } => {
-                    // Falls back to global barrier behavior. Vulkan already inserts a
-                    // compute→compute pipeline barrier before each dispatch, so this
-                    // is a no-op. Per-resource VkBufferMemoryBarrier is a future optimization.
+                GpuCommand::ResourceBarrier {
+                    buffers: buf_handles,
+                    textures: tex_handles,
+                } => {
+                    let _tz = tracy_zone!("vk.resource_barrier");
+                    unsafe {
+                        // The graph scheduler emits ResourceBarrier between any pair
+                        // of dependent nodes (WriteBuffer→Dispatch, Dispatch→Dispatch,
+                        // Dispatch→DispatchIndirect, ClearBuffer→Dispatch).  We don't
+                        // track per-buffer prior access, so use the union of all
+                        // possible src/dst stages and access masks.
+                        let buf_barriers: Vec<vk::BufferMemoryBarrier2> = buf_handles
+                            .iter()
+                            .filter_map(|h| buffers.get(h))
+                            .map(|bs| {
+                                vk::BufferMemoryBarrier2::default()
+                                    .src_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::TRANSFER,
+                                    )
+                                    .src_access_mask(
+                                        vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::TRANSFER_WRITE,
+                                    )
+                                    .dst_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::DRAW_INDIRECT,
+                                    )
+                                    .dst_access_mask(
+                                        vk::AccessFlags2::SHADER_READ
+                                            | vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                    )
+                                    .buffer(bs.buffer)
+                                    .offset(0)
+                                    .size(vk::WHOLE_SIZE)
+                            })
+                            .collect();
+                        // Textures: we don't track per-image Vulkan layout in TextureState,
+                        // so use a global memory barrier for the texture portion. No layout
+                        // transition needed — just execution + memory dependency.
+                        let tex_mem: Option<vk::MemoryBarrier2> = if !tex_handles.is_empty() {
+                            Some(
+                                vk::MemoryBarrier2::default()
+                                    .src_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::TRANSFER,
+                                    )
+                                    .src_access_mask(
+                                        vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::TRANSFER_WRITE,
+                                    )
+                                    .dst_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::DRAW_INDIRECT,
+                                    )
+                                    .dst_access_mask(
+                                        vk::AccessFlags2::SHADER_READ
+                                            | vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                    ),
+                            )
+                        } else {
+                            None
+                        };
+                        let dep_info = if let Some(ref mb) = tex_mem {
+                            vk::DependencyInfo::default()
+                                .buffer_memory_barriers(&buf_barriers)
+                                .memory_barriers(std::slice::from_ref(mb))
+                        } else {
+                            vk::DependencyInfo::default().buffer_memory_barriers(&buf_barriers)
+                        };
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
+                    }
                 }
                 GpuCommand::ClearBuffer {
                     buffer,
                     offset,
                     size,
                 } => {
+                    let _tz = tracy_zone!("vk.clear_buffer");
                     let buf_state = buffers
                         .get(buffer)
                         .context("ClearBuffer: invalid buffer handle")?;
@@ -578,6 +925,7 @@ pub(super) fn submit(
                     offset,
                     data,
                 } => {
+                    let _tz = tracy_zone!("vk.write_buffer");
                     let buf_state = buffers
                         .get(buf_handle)
                         .context("WriteBuffer: invalid buffer handle")?;
@@ -615,6 +963,7 @@ pub(super) fn submit(
                     }
                 }
                 GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {
+                    let _tz = tracy_zone!("vk.write_texture");
                     let scratch = texture_upload_scratch
                         .get(texture_upload_idx)
                         .context("WriteTexture: scratch missing (internal)")?;
@@ -626,6 +975,87 @@ pub(super) fn submit(
                         scratch,
                     )?;
                 }
+                GpuCommand::CopyTexture { src, dst } => {
+                    let _tz = tracy_zone!("vk.copy_texture");
+                    let (src_image, width, height) = {
+                        let ts = state
+                            .textures
+                            .get(src)
+                            .context("CopyTexture: src texture not found")?;
+                        (ts.image, ts.width, ts.height)
+                    };
+                    let dst_image = state
+                        .textures
+                        .get(dst)
+                        .context("CopyTexture: dst texture not found")?
+                        .image;
+
+                    unsafe {
+                        // Barrier: ensure compute writes to src are visible; dst may be
+                        // written by compute, so also synchronise its prior writes.
+                        let mem_barrier = vk::MemoryBarrier2::default()
+                            .src_stage_mask(
+                                vk::PipelineStageFlags2::COMPUTE_SHADER
+                                    | vk::PipelineStageFlags2::TRANSFER,
+                            )
+                            .src_access_mask(
+                                vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE,
+                            )
+                            .dst_stage_mask(vk::PipelineStageFlags2::TRANSFER)
+                            .dst_access_mask(
+                                vk::AccessFlags2::TRANSFER_READ | vk::AccessFlags2::TRANSFER_WRITE,
+                            );
+                        let dep_info = vk::DependencyInfo::default()
+                            .memory_barriers(std::slice::from_ref(&mem_barrier));
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
+
+                        // Both UAV textures are in GENERAL layout — copy is valid.
+                        let region = vk::ImageCopy {
+                            src_subresource: vk::ImageSubresourceLayers {
+                                aspect_mask: vk::ImageAspectFlags::COLOR,
+                                mip_level: 0,
+                                base_array_layer: 0,
+                                layer_count: 1,
+                            },
+                            src_offset: vk::Offset3D::default(),
+                            dst_subresource: vk::ImageSubresourceLayers {
+                                aspect_mask: vk::ImageAspectFlags::COLOR,
+                                mip_level: 0,
+                                base_array_layer: 0,
+                                layer_count: 1,
+                            },
+                            dst_offset: vk::Offset3D::default(),
+                            extent: vk::Extent3D {
+                                width,
+                                height,
+                                depth: 1,
+                            },
+                        };
+                        logical_device.device.cmd_copy_image(
+                            cmd,
+                            src_image,
+                            vk::ImageLayout::GENERAL,
+                            dst_image,
+                            vk::ImageLayout::GENERAL,
+                            std::slice::from_ref(&region),
+                        );
+
+                        // Barrier: make copy writes visible to subsequent compute/transfer.
+                        let mem_barrier2 = vk::MemoryBarrier2::default()
+                            .src_stage_mask(vk::PipelineStageFlags2::TRANSFER)
+                            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                            .dst_stage_mask(
+                                vk::PipelineStageFlags2::COMPUTE_SHADER
+                                    | vk::PipelineStageFlags2::ALL_COMMANDS,
+                            )
+                            .dst_access_mask(
+                                vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
+                            );
+                        let dep_info2 = vk::DependencyInfo::default()
+                            .memory_barriers(std::slice::from_ref(&mem_barrier2));
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info2);
+                    }
+                }
             }
         }
 
@@ -635,22 +1065,39 @@ pub(super) fn submit(
             "WriteTexture commands mismatch texture scratch pre-pass"
         );
 
-        // Release barrier: flush compute/transfer writes so they are available to
-        // subsequent queue submissions (e.g. the present-barrier layout transition
-        // in the surface present path).  Same-queue ordering guarantees execution
-        // order but NOT memory visibility across submits; this barrier closes the
-        // gap by making all writes from this command buffer available before the
-        // submit completes.
+        // Release barrier: make this CB's writes available to subsequent submits.
         unsafe {
             let release = vk::MemoryBarrier2::default()
                 .src_stage_mask(
                     vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::TRANSFER,
                 )
                 .src_access_mask(vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE)
-                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-                .dst_access_mask(vk::AccessFlags2::MEMORY_READ | vk::AccessFlags2::MEMORY_WRITE);
+                .dst_stage_mask(
+                    vk::PipelineStageFlags2::COMPUTE_SHADER
+                        | vk::PipelineStageFlags2::TRANSFER
+                        | vk::PipelineStageFlags2::DRAW_INDIRECT
+                        | vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+                )
+                .dst_access_mask(
+                    vk::AccessFlags2::SHADER_READ
+                        | vk::AccessFlags2::SHADER_WRITE
+                        | vk::AccessFlags2::TRANSFER_READ
+                        | vk::AccessFlags2::INDIRECT_COMMAND_READ
+                        | vk::AccessFlags2::COLOR_ATTACHMENT_READ,
+                );
             let dep = vk::DependencyInfo::default().memory_barriers(std::slice::from_ref(&release));
             logical_device.device.cmd_pipeline_barrier2(cmd, &dep);
+        }
+
+        if let Some(ref prof) = vk_gpu_profile {
+            unsafe {
+                logical_device.device.cmd_write_timestamp2(
+                    cmd,
+                    vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                    prof.pool,
+                    1,
+                );
+            }
         }
 
         // End command buffer
@@ -712,17 +1159,26 @@ pub(super) fn submit(
         .command_buffer_infos(std::slice::from_ref(&cmd_info))
         .signal_semaphore_infos(std::slice::from_ref(&signal_info));
 
-    if let Err(e) = unsafe {
-        submit_device_core.device.queue_submit2(
-            submit_device_core.queue,
-            std::slice::from_ref(&submit_info2),
-            vk::Fence::null(),
-        )
-    } {
+    let queue_submit_result = {
+        let _tz = tracy_zone!("vk.queue_submit2");
+        unsafe {
+            submit_device_core.device.queue_submit2(
+                submit_device_core.queue,
+                std::slice::from_ref(&submit_info2),
+                vk::Fence::null(),
+            )
+        }
+    };
+    if let Err(e) = queue_submit_result {
         unsafe {
             submit_device_core
                 .device
                 .free_command_buffers(submit_device_core.command_pool, &[cmd]);
+            if let Some(prof) = vk_gpu_profile.take() {
+                submit_device_core
+                    .device
+                    .destroy_query_pool(prof.pool, None);
+            }
         }
         return Err(anyhow::anyhow!(
             "Failed to queue_submit2 command buffer: {:?}",
@@ -762,6 +1218,27 @@ pub(super) fn submit(
         "WriteBuffer DEVICE_LOCAL count must match belt pre-pass"
     );
 
+    if let Some(prof) = vk_gpu_profile {
+        let (device_clone, timeline_sem) = {
+            let ld = state
+                .devices
+                .get(&device_handle)
+                .context("Invalid device handle")?;
+            (ld.device.clone(), ld.timeline_semaphore)
+        };
+        unsafe {
+            vulkan_finish_gpu_profile(
+                state,
+                device_handle,
+                &device_clone,
+                timeline_sem,
+                signal_value,
+                cmd,
+                prof,
+            )?;
+        }
+    }
+
     if let Some(ld) = state.devices.get_mut(&device_handle) {
         ld.process_deletion_queue_up_to_gpu_progress();
     }
@@ -779,170 +1256,254 @@ pub(super) fn submit_graph(
     device_handle: DeviceHandle,
     commands: &[GraphCommand],
 ) -> Result<TimelineValue> {
-    // --- Same housekeeping as `submit` ---
-    let completed_timeline = state
-        .devices
-        .get(&device_handle)
-        .map(|ld| unsafe {
-            ld.device
-                .get_semaphore_counter_value(ld.timeline_semaphore)
-                .unwrap_or(0)
-        })
-        .unwrap_or(0);
+    submit_graph_impl(state, device_handle, commands, None)
+}
 
-    for belt in state.staging_belts.values_mut() {
-        belt.reclaim(
-            &state.compute_fence_pool,
-            &state.devices,
-            completed_timeline,
-        )?;
+/// Inner implementation shared by `submit_graph` and `submit_graph_and_retain`.
+///
+/// When `retain_key` is `Some(key)`:
+/// - the CB is recorded without `ONE_TIME_SUBMIT` (driver keeps it executable)
+/// - after a successful submit the CB is stored in `LogicalDevice::retained_compute_cb`
+///   rather than `timeline_cmd_buffers` (so it is not freed by the normal reap cycle)
+/// - any WriteBuffer / WriteTexture commands cause a fallback to normal (non-retained) submit
+///
+/// When `retain_key` is `None` (normal path):
+/// - the CB is recorded with `ONE_TIME_SUBMIT`
+/// - after submit it is stored in `timeline_cmd_buffers` and freed once the GPU retires it
+fn submit_graph_impl(
+    state: &mut super::types::VulkanState,
+    device_handle: DeviceHandle,
+    commands: &[GraphCommand],
+    retain_key: Option<u64>,
+) -> Result<TimelineValue> {
+    let _tz = tracy_zone!("vk.submit_graph");
+    // --- Same housekeeping as `submit` ---
+    // Skip belt reclaim + fence reap when there's no host upload in this submit;
+    // the next upload-bearing submit will pick up any signaled fences.
+    let has_upload = commands.iter().any(|c| {
+        matches!(
+            c,
+            GraphCommand::Compute(
+                GpuCommand::WriteBuffer { .. }
+                    | GpuCommand::WriteTexture { .. }
+                    | GpuCommand::WriteTextureRegion { .. }
+            )
+        )
+    });
+    if has_upload {
+        let _rz = tracy_zone!("vk.submit_graph.belt_reclaim");
+        let completed_timeline = state
+            .devices
+            .get(&device_handle)
+            .map(|ld| unsafe {
+                ld.device
+                    .get_semaphore_counter_value(ld.timeline_semaphore)
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
+
+        for belt in state.staging_belts.values_mut() {
+            belt.reclaim(
+                &state.compute_fence_pool,
+                &state.devices,
+                completed_timeline,
+            )?;
+        }
+        reap_signaled_fences(state);
     }
-    reap_signaled_fences(state);
 
     // --- Pre-pass: stage CPU data for WriteBuffer in compute segments ---
     let mut belt_slices: Vec<(vk::Buffer, u64)> = Vec::new();
     let mut texture_upload_scratch: Vec<super::texture::ComputeTextureScratch> = Vec::new();
 
-    for graph_cmd in commands {
-        if let GraphCommand::Compute(gpu_cmd) = graph_cmd {
-            match gpu_cmd {
-                GpuCommand::WriteBuffer {
-                    buffer: buf_handle,
-                    offset,
-                    data,
-                } => {
-                    let buf = state
-                        .buffers
-                        .get(buf_handle)
-                        .context("WriteBuffer: invalid buffer handle")?;
-                    if let Some(base) = buf.host_mapped {
-                        let p = base as *mut u8;
-                        unsafe {
-                            std::ptr::copy_nonoverlapping(
-                                data.as_ptr(),
-                                p.add(*offset as usize),
-                                data.len(),
-                            );
+    if has_upload {
+        for graph_cmd in commands {
+            if let GraphCommand::Compute(gpu_cmd) = graph_cmd {
+                match gpu_cmd {
+                    GpuCommand::WriteBuffer {
+                        buffer: buf_handle,
+                        offset,
+                        data,
+                    } => {
+                        let buf = state
+                            .buffers
+                            .get(buf_handle)
+                            .context("WriteBuffer: invalid buffer handle")?;
+                        if let Some(base) = buf.host_mapped {
+                            let p = base as *mut u8;
+                            unsafe {
+                                std::ptr::copy_nonoverlapping(
+                                    data.as_ptr(),
+                                    p.add(*offset as usize),
+                                    data.len(),
+                                );
+                            }
+                        } else if !buf.is_storage {
+                            let dev = state
+                                .devices
+                                .get(&buf.device_handle)
+                                .context("WriteBuffer: device invalid")?;
+                            unsafe {
+                                let ptr = dev
+                                    .map_memory2(buf.memory, *offset, data.len() as u64)
+                                    .context("WriteBuffer: map failed")?;
+                                std::ptr::copy_nonoverlapping(
+                                    data.as_ptr(),
+                                    ptr as *mut u8,
+                                    data.len(),
+                                );
+                                dev.unmap_memory2(buf.memory)
+                                    .context("WriteBuffer: unmap failed")?;
+                            }
+                        } else {
+                            let buf_device = buf.device_handle;
+                            let dev = state
+                                .devices
+                                .get(&buf_device)
+                                .context("WriteBuffer: device invalid")?;
+                            let belt_entry =
+                                state.staging_belts.entry(buf_device).or_insert_with(|| {
+                                    staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
+                                });
+                            let (stg_buf, stg_off) =
+                                belt_entry.write(&state.instance, dev, data)?;
+                            belt_slices.push((stg_buf, stg_off));
                         }
-                    } else if !buf.is_storage {
-                        let dev = state
-                            .devices
-                            .get(&buf.device_handle)
-                            .context("WriteBuffer: device invalid")?;
-                        unsafe {
-                            let ptr = dev
-                                .map_memory2(buf.memory, *offset, data.len() as u64)
-                                .context("WriteBuffer: map failed")?;
-                            std::ptr::copy_nonoverlapping(
-                                data.as_ptr(),
-                                ptr as *mut u8,
-                                data.len(),
-                            );
-                            dev.unmap_memory2(buf.memory)
-                                .context("WriteBuffer: unmap failed")?;
-                        }
-                    } else {
-                        let buf_device = buf.device_handle;
-                        let dev = state
-                            .devices
-                            .get(&buf_device)
-                            .context("WriteBuffer: device invalid")?;
-                        let belt_entry =
-                            state.staging_belts.entry(buf_device).or_insert_with(|| {
-                                staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                            });
-                        let (stg_buf, stg_off) = belt_entry.write(&state.instance, dev, data)?;
-                        belt_slices.push((stg_buf, stg_off));
                     }
-                }
-                GpuCommand::WriteTexture {
-                    texture,
-                    data,
-                    width,
-                    height,
-                } => {
-                    texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
-                        &state.instance,
-                        &state.devices,
-                        &state.textures,
-                        *texture,
+                    GpuCommand::WriteTexture {
+                        texture,
                         data,
-                        0,
-                        0,
-                        *width,
-                        *height,
-                    )?);
-                }
-                GpuCommand::WriteTextureRegion {
-                    texture,
-                    x,
-                    y,
-                    width,
-                    height,
-                    data,
-                } => {
-                    texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
-                        &state.instance,
-                        &state.devices,
-                        &state.textures,
-                        *texture,
+                        width,
+                        height,
+                    } => {
+                        texture_upload_scratch.push(
+                            super::texture::allocate_compute_texture_staging(
+                                &state.instance,
+                                &state.devices,
+                                &state.textures,
+                                *texture,
+                                data,
+                                0,
+                                0,
+                                *width,
+                                *height,
+                            )?,
+                        );
+                    }
+                    GpuCommand::WriteTextureRegion {
+                        texture,
+                        x,
+                        y,
+                        width,
+                        height,
                         data,
-                        *x,
-                        *y,
-                        *width,
-                        *height,
-                    )?);
+                    } => {
+                        texture_upload_scratch.push(
+                            super::texture::allocate_compute_texture_staging(
+                                &state.instance,
+                                &state.devices,
+                                &state.textures,
+                                *texture,
+                                data,
+                                *x,
+                                *y,
+                                *width,
+                                *height,
+                            )?,
+                        );
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
     }
 
-    // --- Allocate single command buffer ---
+    // --- Acquire and begin command buffer ---
+    let cmd = {
+        let ld = state
+            .devices
+            .get_mut(&device_handle)
+            .context("Invalid device handle")?;
+        let cb = acquire_cmd_buffer(ld)?;
+        // Use ONE_TIME_SUBMIT for normal submits (driver hint for optimization).
+        // When retaining, omit the flag so the CB stays executable after GPU completion
+        // and can be resubmitted on the next frame.
+        let flags = if retain_key.is_none() {
+            vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT
+        } else {
+            vk::CommandBufferUsageFlags::empty()
+        };
+        let begin_info = vk::CommandBufferBeginInfo::default().flags(flags);
+        if let Err(e) = unsafe { ld.device.begin_command_buffer(cb, &begin_info) } {
+            ld.free_cmd_buffers.push(cb);
+            return Err(anyhow::anyhow!("Failed to begin command buffer: {:?}", e));
+        }
+        cb
+    };
+
     let logical_device = state
         .devices
         .get(&device_handle)
         .context("Invalid device handle")?;
 
-    let alloc_info = vk::CommandBufferAllocateInfo::default()
-        .command_pool(logical_device.command_pool)
-        .level(vk::CommandBufferLevel::PRIMARY)
-        .command_buffer_count(1);
+    let (dispatch_count_graph, dispatch_labels_graph) = collect_dispatch_labels_graph(commands);
+    let mut vk_gpu_profile = unsafe {
+        create_vulkan_gpu_profile_pool(
+            logical_device,
+            false,
+            dispatch_count_graph,
+            dispatch_labels_graph,
+        )?
+    };
 
-    let cmd_buffers = unsafe { logical_device.device.allocate_command_buffers(&alloc_info) }
-        .context("Failed to allocate command buffer")?;
-    let cmd = cmd_buffers[0];
-
-    let begin_info =
-        vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
-
-    if let Err(e) = unsafe { logical_device.device.begin_command_buffer(cmd, &begin_info) } {
-        unsafe {
-            logical_device
-                .device
-                .free_command_buffers(logical_device.command_pool, &[cmd]);
-        }
-        return Err(anyhow::anyhow!("Failed to begin command buffer: {:?}", e));
-    }
-
-    // Cross-submission acquire barrier
+    // Cross-submission acquire: make prior submit's writes visible.
     unsafe {
         let acquire = vk::MemoryBarrier2::default()
             .src_stage_mask(
-                vk::PipelineStageFlags2::TRANSFER | vk::PipelineStageFlags2::COMPUTE_SHADER,
+                vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::TRANSFER,
             )
-            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE | vk::AccessFlags2::SHADER_WRITE)
+            .src_access_mask(vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE)
             .dst_stage_mask(
-                vk::PipelineStageFlags2::TRANSFER | vk::PipelineStageFlags2::COMPUTE_SHADER,
+                vk::PipelineStageFlags2::COMPUTE_SHADER
+                    | vk::PipelineStageFlags2::TRANSFER
+                    | vk::PipelineStageFlags2::DRAW_INDIRECT,
             )
             .dst_access_mask(
-                vk::AccessFlags2::TRANSFER_READ
-                    | vk::AccessFlags2::TRANSFER_WRITE
-                    | vk::AccessFlags2::SHADER_READ
-                    | vk::AccessFlags2::SHADER_WRITE,
+                vk::AccessFlags2::SHADER_READ
+                    | vk::AccessFlags2::TRANSFER_READ
+                    | vk::AccessFlags2::INDIRECT_COMMAND_READ,
             );
         let dep = vk::DependencyInfo::default().memory_barriers(std::slice::from_ref(&acquire));
         logical_device.device.cmd_pipeline_barrier2(cmd, &dep);
+
+        if let (Some(bindless_set), Some(bindless_layout)) = (
+            logical_device.bindless_descriptor_set,
+            logical_device.bindless_pipeline_layout,
+        ) {
+            logical_device.device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                bindless_layout,
+                0,
+                std::slice::from_ref(&bindless_set),
+                &[],
+            );
+        }
+    }
+
+    let mut vk_dispatch_idx = 0usize;
+    if let Some(ref prof) = vk_gpu_profile {
+        unsafe {
+            logical_device
+                .device
+                .cmd_reset_query_pool(cmd, prof.pool, 0, prof.query_count);
+            logical_device.device.cmd_write_timestamp2(
+                cmd,
+                vk::PipelineStageFlags2::TOP_OF_PIPE,
+                prof.pool,
+                0,
+            );
+        }
     }
 
     // --- Walk GraphCommands (inline to satisfy the borrow checker) ---
@@ -957,6 +1518,7 @@ pub(super) fn submit_graph(
         match graph_cmd {
             GraphCommand::Compute(gpu_cmd) => match gpu_cmd {
                 GpuCommand::SetPipeline(handle) => {
+                    let _tz = tracy_zone!("vk.set_pipeline");
                     if let Some(pipeline_state) = compute_pipelines.get(handle) {
                         unsafe {
                             logical_device.device.cmd_bind_pipeline(
@@ -964,19 +1526,6 @@ pub(super) fn submit_graph(
                                 vk::PipelineBindPoint::COMPUTE,
                                 pipeline_state.pipeline,
                             );
-                            if let (Some(bindless_set), Some(bindless_layout)) = (
-                                logical_device.bindless_descriptor_set,
-                                logical_device.bindless_pipeline_layout,
-                            ) {
-                                logical_device.device.cmd_bind_descriptor_sets(
-                                    cmd,
-                                    vk::PipelineBindPoint::COMPUTE,
-                                    bindless_layout,
-                                    0,
-                                    std::slice::from_ref(&bindless_set),
-                                    &[],
-                                );
-                            }
                         }
                         current_compute_pipeline = Some(*handle);
                     }
@@ -1050,59 +1599,209 @@ pub(super) fn submit_graph(
                     }
                 }
                 GpuCommand::Dispatch {
+                    label: _label,
                     workgroups_x,
                     workgroups_y,
                     workgroups_z,
-                } => unsafe {
-                    let mem_barrier = vk::MemoryBarrier2::default()
-                        .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
-                        .src_access_mask(vk::AccessFlags2::SHADER_WRITE)
-                        .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
-                        .dst_access_mask(
-                            vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch");
+                    unsafe {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::TOP_OF_PIPE,
+                                prof.pool,
+                                base,
+                            );
+                        }
+                        logical_device.device.cmd_dispatch(
+                            cmd,
+                            *workgroups_x,
+                            *workgroups_y,
+                            *workgroups_z,
                         );
-                    let dep_info = vk::DependencyInfo::default()
-                        .memory_barriers(std::slice::from_ref(&mem_barrier));
-                    logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
-                    logical_device.device.cmd_dispatch(
-                        cmd,
-                        *workgroups_x,
-                        *workgroups_y,
-                        *workgroups_z,
-                    );
-                },
-                GpuCommand::DispatchIndirect { buffer, offset } => {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                                prof.pool,
+                                base + 1,
+                            );
+                        }
+                        vk_dispatch_idx += 1;
+                    }
+                }
+                GpuCommand::DispatchBatch {
+                    label: _,
+                    arg_data,
+                    count,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch_batch");
+                    let push_size = std::mem::size_of::<crate::backend::shared::PushLayout>();
+                    let stride = crate::backend::shared::DISPATCH_BATCH_STRIDE;
+                    let pipeline_layout = current_compute_pipeline
+                        .and_then(|h| compute_pipelines.get(&h))
+                        .map(|p| p.layout);
+                    for i in 0..*count as usize {
+                        let base = i * stride;
+                        let layout_bytes = &arg_data[base..base + push_size];
+                        let wg_off = base + push_size;
+                        let wg_x =
+                            u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into().unwrap());
+                        let wg_y = u32::from_ne_bytes(
+                            arg_data[wg_off + 4..wg_off + 8].try_into().unwrap(),
+                        );
+                        let wg_z = u32::from_ne_bytes(
+                            arg_data[wg_off + 8..wg_off + 12].try_into().unwrap(),
+                        );
+                        unsafe {
+                            if let Some(layout) = pipeline_layout {
+                                logical_device.device.cmd_push_constants(
+                                    cmd,
+                                    layout,
+                                    vk::ShaderStageFlags::ALL,
+                                    0,
+                                    layout_bytes,
+                                );
+                            }
+                            logical_device.device.cmd_dispatch(cmd, wg_x, wg_y, wg_z);
+                        }
+                        vk_dispatch_idx += 1;
+                    }
+                }
+                GpuCommand::DispatchIndirect {
+                    label: _label,
+                    buffer,
+                    offset,
+                } => {
+                    let _tz = tracy_zone!("vk.dispatch_indirect");
                     let buf_state = buffers
                         .get(buffer)
                         .context("DispatchIndirect: invalid buffer handle")?;
                     unsafe {
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::TOP_OF_PIPE,
+                                prof.pool,
+                                base,
+                            );
+                        }
+                        logical_device
+                            .device
+                            .cmd_dispatch_indirect(cmd, buf_state.buffer, *offset);
+
+                        if let Some(ref prof) = vk_gpu_profile {
+                            let base = 2u32 + (vk_dispatch_idx as u32) * 2;
+                            logical_device.device.cmd_write_timestamp2(
+                                cmd,
+                                vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                                prof.pool,
+                                base + 1,
+                            );
+                        }
+                    }
+                    vk_dispatch_idx += 1;
+                }
+                GpuCommand::Barrier => {
+                    let _tz = tracy_zone!("vk.barrier");
+                    unsafe {
                         let mem_barrier = vk::MemoryBarrier2::default()
                             .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
                             .src_access_mask(vk::AccessFlags2::SHADER_WRITE)
-                            .dst_stage_mask(
-                                vk::PipelineStageFlags2::COMPUTE_SHADER
-                                    | vk::PipelineStageFlags2::DRAW_INDIRECT,
-                            )
+                            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
                             .dst_access_mask(
-                                vk::AccessFlags2::SHADER_READ
-                                    | vk::AccessFlags2::SHADER_WRITE
-                                    | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
                             );
                         let dep_info = vk::DependencyInfo::default()
                             .memory_barriers(std::slice::from_ref(&mem_barrier));
                         logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
-                        logical_device
-                            .device
-                            .cmd_dispatch_indirect(cmd, buf_state.buffer, *offset);
                     }
                 }
-                GpuCommand::Barrier => {}
-                GpuCommand::ResourceBarrier { .. } => {}
+                GpuCommand::ResourceBarrier {
+                    buffers: buf_handles,
+                    textures: tex_handles,
+                } => {
+                    let _tz = tracy_zone!("vk.resource_barrier");
+                    unsafe {
+                        // The graph scheduler emits ResourceBarrier between any pair
+                        // of dependent nodes (WriteBuffer→Dispatch, Dispatch→Dispatch,
+                        // Dispatch→DispatchIndirect, ClearBuffer→Dispatch).  We don't
+                        // track per-buffer prior access, so use the union of all
+                        // possible src/dst stages and access masks.
+                        let buf_barriers: Vec<vk::BufferMemoryBarrier2> = buf_handles
+                            .iter()
+                            .filter_map(|h| buffers.get(h))
+                            .map(|bs| {
+                                vk::BufferMemoryBarrier2::default()
+                                    .src_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::TRANSFER,
+                                    )
+                                    .src_access_mask(
+                                        vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::TRANSFER_WRITE,
+                                    )
+                                    .dst_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::DRAW_INDIRECT,
+                                    )
+                                    .dst_access_mask(
+                                        vk::AccessFlags2::SHADER_READ
+                                            | vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                    )
+                                    .buffer(bs.buffer)
+                                    .offset(0)
+                                    .size(vk::WHOLE_SIZE)
+                            })
+                            .collect();
+                        // Textures: we don't track per-image Vulkan layout in TextureState,
+                        // so use a global memory barrier for the texture portion. No layout
+                        // transition needed — just execution + memory dependency.
+                        let tex_mem: Option<vk::MemoryBarrier2> = if !tex_handles.is_empty() {
+                            Some(
+                                vk::MemoryBarrier2::default()
+                                    .src_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::TRANSFER,
+                                    )
+                                    .src_access_mask(
+                                        vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::TRANSFER_WRITE,
+                                    )
+                                    .dst_stage_mask(
+                                        vk::PipelineStageFlags2::COMPUTE_SHADER
+                                            | vk::PipelineStageFlags2::DRAW_INDIRECT,
+                                    )
+                                    .dst_access_mask(
+                                        vk::AccessFlags2::SHADER_READ
+                                            | vk::AccessFlags2::SHADER_WRITE
+                                            | vk::AccessFlags2::INDIRECT_COMMAND_READ,
+                                    ),
+                            )
+                        } else {
+                            None
+                        };
+                        let dep_info = if let Some(ref mb) = tex_mem {
+                            vk::DependencyInfo::default()
+                                .buffer_memory_barriers(&buf_barriers)
+                                .memory_barriers(std::slice::from_ref(mb))
+                        } else {
+                            vk::DependencyInfo::default().buffer_memory_barriers(&buf_barriers)
+                        };
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
+                    }
+                }
                 GpuCommand::ClearBuffer {
                     buffer,
                     offset,
                     size,
                 } => {
+                    let _tz = tracy_zone!("vk.clear_buffer");
                     let buf_state = buffers
                         .get(buffer)
                         .context("ClearBuffer: invalid buffer handle")?;
@@ -1138,6 +1837,7 @@ pub(super) fn submit_graph(
                     offset,
                     data,
                 } => {
+                    let _tz = tracy_zone!("vk.write_buffer");
                     let buf_state = buffers
                         .get(buf_handle)
                         .context("WriteBuffer: invalid buffer handle")?;
@@ -1172,6 +1872,7 @@ pub(super) fn submit_graph(
                     }
                 }
                 GpuCommand::WriteTexture { .. } | GpuCommand::WriteTextureRegion { .. } => {
+                    let _tz = tracy_zone!("vk.write_texture");
                     let scratch = texture_upload_scratch
                         .get(texture_upload_idx)
                         .context("WriteTexture: scratch missing (internal)")?;
@@ -1183,11 +1884,88 @@ pub(super) fn submit_graph(
                         scratch,
                     )?;
                 }
+                GpuCommand::CopyTexture { src, dst } => {
+                    let _tz = tracy_zone!("vk.copy_texture");
+                    let (src_image, width, height) = {
+                        let ts = state
+                            .textures
+                            .get(src)
+                            .context("CopyTexture: src texture not found")?;
+                        (ts.image, ts.width, ts.height)
+                    };
+                    let dst_image = state
+                        .textures
+                        .get(dst)
+                        .context("CopyTexture: dst texture not found")?
+                        .image;
+                    unsafe {
+                        let mem_barrier = vk::MemoryBarrier2::default()
+                            .src_stage_mask(
+                                vk::PipelineStageFlags2::COMPUTE_SHADER
+                                    | vk::PipelineStageFlags2::TRANSFER,
+                            )
+                            .src_access_mask(
+                                vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE,
+                            )
+                            .dst_stage_mask(vk::PipelineStageFlags2::TRANSFER)
+                            .dst_access_mask(
+                                vk::AccessFlags2::TRANSFER_READ | vk::AccessFlags2::TRANSFER_WRITE,
+                            );
+                        let dep = vk::DependencyInfo::default()
+                            .memory_barriers(std::slice::from_ref(&mem_barrier));
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep);
+
+                        let region = vk::ImageCopy {
+                            src_subresource: vk::ImageSubresourceLayers {
+                                aspect_mask: vk::ImageAspectFlags::COLOR,
+                                mip_level: 0,
+                                base_array_layer: 0,
+                                layer_count: 1,
+                            },
+                            src_offset: vk::Offset3D::default(),
+                            dst_subresource: vk::ImageSubresourceLayers {
+                                aspect_mask: vk::ImageAspectFlags::COLOR,
+                                mip_level: 0,
+                                base_array_layer: 0,
+                                layer_count: 1,
+                            },
+                            dst_offset: vk::Offset3D::default(),
+                            extent: vk::Extent3D {
+                                width,
+                                height,
+                                depth: 1,
+                            },
+                        };
+                        logical_device.device.cmd_copy_image(
+                            cmd,
+                            src_image,
+                            vk::ImageLayout::GENERAL,
+                            dst_image,
+                            vk::ImageLayout::GENERAL,
+                            std::slice::from_ref(&region),
+                        );
+
+                        let mem_barrier2 = vk::MemoryBarrier2::default()
+                            .src_stage_mask(vk::PipelineStageFlags2::TRANSFER)
+                            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                            .dst_stage_mask(
+                                vk::PipelineStageFlags2::COMPUTE_SHADER
+                                    | vk::PipelineStageFlags2::ALL_COMMANDS,
+                            )
+                            .dst_access_mask(
+                                vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE,
+                            );
+                        let dep2 = vk::DependencyInfo::default()
+                            .memory_barriers(std::slice::from_ref(&mem_barrier2));
+                        logical_device.device.cmd_pipeline_barrier2(cmd, &dep2);
+                    }
+                }
             },
             GraphCommand::Render {
                 target,
                 commands: render_cmds,
             } => {
+                let _tz = tracy_zone!("vk.render_pass");
                 // Flush compute writes before the render pass
                 unsafe {
                     let barrier = vk::MemoryBarrier2::default()
@@ -1263,17 +2041,39 @@ pub(super) fn submit_graph(
         }
     }
 
-    // --- Release barrier ---
+    // --- Release barrier: make this CB's writes available to subsequent submits ---
     unsafe {
         let release = vk::MemoryBarrier2::default()
             .src_stage_mask(
                 vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::TRANSFER,
             )
             .src_access_mask(vk::AccessFlags2::SHADER_WRITE | vk::AccessFlags2::TRANSFER_WRITE)
-            .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-            .dst_access_mask(vk::AccessFlags2::MEMORY_READ | vk::AccessFlags2::MEMORY_WRITE);
+            .dst_stage_mask(
+                vk::PipelineStageFlags2::COMPUTE_SHADER
+                    | vk::PipelineStageFlags2::TRANSFER
+                    | vk::PipelineStageFlags2::DRAW_INDIRECT
+                    | vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+            )
+            .dst_access_mask(
+                vk::AccessFlags2::SHADER_READ
+                    | vk::AccessFlags2::SHADER_WRITE
+                    | vk::AccessFlags2::TRANSFER_READ
+                    | vk::AccessFlags2::INDIRECT_COMMAND_READ
+                    | vk::AccessFlags2::COLOR_ATTACHMENT_READ,
+            );
         let dep = vk::DependencyInfo::default().memory_barriers(std::slice::from_ref(&release));
         logical_device.device.cmd_pipeline_barrier2(cmd, &dep);
+    }
+
+    if let Some(ref prof) = vk_gpu_profile {
+        unsafe {
+            logical_device.device.cmd_write_timestamp2(
+                cmd,
+                vk::PipelineStageFlags2::BOTTOM_OF_PIPE,
+                prof.pool,
+                1,
+            );
+        }
     }
 
     // --- End + submit ---
@@ -1307,17 +2107,24 @@ pub(super) fn submit_graph(
         .command_buffer_infos(std::slice::from_ref(&cmd_info))
         .signal_semaphore_infos(std::slice::from_ref(&signal_info));
 
-    if let Err(e) = unsafe {
-        submit_device.device.queue_submit2(
-            submit_device.queue,
-            std::slice::from_ref(&submit_info2),
-            vk::Fence::null(),
-        )
-    } {
+    let queue_submit_result = {
+        let _tz = tracy_zone!("vk.queue_submit2");
+        unsafe {
+            submit_device.device.queue_submit2(
+                submit_device.queue,
+                std::slice::from_ref(&submit_info2),
+                vk::Fence::null(),
+            )
+        }
+    };
+    if let Err(e) = queue_submit_result {
         unsafe {
             submit_device
                 .device
                 .free_command_buffers(submit_device.command_pool, &[cmd]);
+            if let Some(prof) = vk_gpu_profile.take() {
+                submit_device.device.destroy_query_pool(prof.pool, None);
+            }
         }
         return Err(anyhow::anyhow!(
             "Failed to queue_submit2 command buffer: {:?}",
@@ -1329,11 +2136,24 @@ pub(super) fn submit_graph(
         ld.timeline_next = signal_value.saturating_add(1);
     }
 
-    state
-        .timeline_cmd_buffers
-        .entry(signal_value)
-        .or_default()
-        .push((device_handle, cmd));
+    // Post-submit: store the CB for lifecycle management.
+    if let Some(key) = retain_key {
+        // Retained path: store in `retained_compute_cb` (not timeline_cmd_buffers)
+        // so the reap cycle doesn't free it. The CB will be resubmitted next frame.
+        if let Some(ld) = state.devices.get_mut(&device_handle) {
+            ld.retained_compute_cb = Some(super::types::RetainedVkCb {
+                fingerprint: key,
+                command_buffer: cmd,
+            });
+        }
+    } else {
+        // Normal path: track for GPU-retirement-based cleanup.
+        state
+            .timeline_cmd_buffers
+            .entry(signal_value)
+            .or_default()
+            .push((device_handle, cmd));
+    }
 
     if !texture_upload_scratch.is_empty() {
         let pooled: Vec<(vk::Buffer, vk::DeviceMemory)> = texture_upload_scratch
@@ -1351,6 +2171,27 @@ pub(super) fn submit_graph(
         .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
         .finish(signal_value);
 
+    if let Some(prof) = vk_gpu_profile {
+        let (device_clone, timeline_sem) = {
+            let ld = state
+                .devices
+                .get(&device_handle)
+                .context("Invalid device handle")?;
+            (ld.device.clone(), ld.timeline_semaphore)
+        };
+        unsafe {
+            vulkan_finish_gpu_profile(
+                state,
+                device_handle,
+                &device_clone,
+                timeline_sem,
+                signal_value,
+                cmd,
+                prof,
+            )?;
+        }
+    }
+
     // Mark rendered targets
     for t in rendered_targets {
         if let Some(rt) = state.render_targets.get_mut(&t) {
@@ -1365,33 +2206,144 @@ pub(super) fn submit_graph(
     Ok(signal_value)
 }
 
+/// Record, submit, and retain a dispatch command buffer keyed by `key`.
+///
+/// The CB is recorded without `ONE_TIME_SUBMIT` (driver keeps it executable after GPU
+/// completion) and stored in `LogicalDevice::retained_compute_cb` rather than
+/// `timeline_cmd_buffers`, so it survives the normal reap cycle.
+/// On subsequent frames call [`try_resubmit_retained`] to re-execute without re-recording.
+/// If commands contain any WriteBuffer/WriteTexture nodes the call falls back to a normal
+/// (non-retained) submit via [`submit_graph`].
+pub(super) fn submit_graph_and_retain(
+    state: &mut super::types::VulkanState,
+    device_handle: DeviceHandle,
+    commands: &[GraphCommand],
+    key: u64,
+) -> Result<TimelineValue> {
+    // Evict any previously retained CB so we start fresh.
+    evict_retained(state, device_handle, key);
+    // Delegate to the shared inner path with retention enabled.
+    submit_graph_impl(state, device_handle, commands, Some(key))
+}
+
+/// Re-execute the retained dispatch CB without re-recording.
+///
+/// Returns `Ok(Some(tv))` if the retained CB for `key` was found and resubmitted.
+/// Returns `Ok(None)` if no matching retained CB exists.
+/// Safety: The caller must have confirmed that the GPU has completed the previous
+/// submission of this CB (e.g. by `wait_until`) so it is in executable state.
+pub(super) fn try_resubmit_retained(
+    state: &mut super::types::VulkanState,
+    device_handle: DeviceHandle,
+    key: u64,
+) -> Result<Option<TimelineValue>> {
+    let retained_cb = {
+        let ld = state
+            .devices
+            .get(&device_handle)
+            .context("Invalid device handle")?;
+        match ld.retained_compute_cb.as_ref() {
+            Some(r) if r.fingerprint == key => Some(r.command_buffer),
+            _ => None,
+        }
+    };
+
+    let Some(cmd) = retained_cb else {
+        return Ok(None);
+    };
+
+    let signal_value = {
+        let ld = state
+            .devices
+            .get(&device_handle)
+            .context("Invalid device handle")?;
+        ld.timeline_next
+    };
+
+    let submit_device = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?;
+    let cmd_info = vk::CommandBufferSubmitInfo::default().command_buffer(cmd);
+    let signal_info = vk::SemaphoreSubmitInfo::default()
+        .semaphore(submit_device.timeline_semaphore)
+        .value(signal_value)
+        .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
+    let submit_info2 = vk::SubmitInfo2::default()
+        .command_buffer_infos(std::slice::from_ref(&cmd_info))
+        .signal_semaphore_infos(std::slice::from_ref(&signal_info));
+
+    {
+        let _tz = tracy_zone!("vk.resubmit_retained");
+        unsafe {
+            submit_device.device.queue_submit2(
+                submit_device.queue,
+                std::slice::from_ref(&submit_info2),
+                vk::Fence::null(),
+            )
+        }
+        .context("Failed to queue_submit2 retained dispatch CB")?;
+    }
+
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.timeline_next = signal_value.saturating_add(1);
+        ld.process_deletion_queue_up_to_gpu_progress();
+    }
+
+    Ok(Some(signal_value))
+}
+
+/// Evict the retained dispatch CB for `key` (or any retained CB if `key` doesn't match),
+/// returning the `VkCommandBuffer` to `free_cmd_buffers` for pool reuse.
+pub(super) fn evict_retained(
+    state: &mut super::types::VulkanState,
+    device_handle: DeviceHandle,
+    _key: u64,
+) {
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        if let Some(old) = ld.retained_compute_cb.take() {
+            ld.free_cmd_buffers.push(old.command_buffer);
+        }
+    }
+}
+
 pub(super) fn reap_timeline_cmd_buffers_up_to(
     state: &mut super::types::VulkanState,
     device_handle: DeviceHandle,
     max_completed_value: u64,
 ) {
-    let keys: Vec<u64> = state
-        .timeline_cmd_buffers
-        .keys()
-        .copied()
-        .filter(|k| *k <= max_completed_value)
-        .collect();
-    for k in keys {
-        if let Some(entries) = state.timeline_cmd_buffers.remove(&k) {
-            let mut reinsert: Vec<(DeviceHandle, vk::CommandBuffer)> = Vec::new();
-            for (dh, cb) in entries {
-                if dh == device_handle {
-                    if let Some(ld) = state.devices.get(&dh) {
-                        unsafe {
-                            ld.device.free_command_buffers(ld.command_pool, &[cb]);
-                        }
-                    }
-                } else {
-                    reinsert.push((dh, cb));
-                }
+    if state.timeline_cmd_buffers.is_empty() {
+        return;
+    }
+    // Stack buffer for eligible keys; typical steady-state has 1-2 entries.
+    let mut keys_buf = [0u64; 8];
+    let mut n = 0usize;
+    for &k in state.timeline_cmd_buffers.keys() {
+        if k <= max_completed_value {
+            if n < keys_buf.len() {
+                keys_buf[n] = k;
             }
-            if !reinsert.is_empty() {
-                state.timeline_cmd_buffers.insert(k, reinsert);
+            n += 1;
+        }
+    }
+    if n == 0 {
+        return;
+    }
+
+    fn process_key(state: &mut super::types::VulkanState, device_handle: DeviceHandle, k: u64) {
+        if let Some(mut entries) = state.timeline_cmd_buffers.remove(&k) {
+            entries.retain(|(dh, cb)| {
+                if *dh == device_handle {
+                    if let Some(ld) = state.devices.get_mut(dh) {
+                        ld.free_cmd_buffers.push(*cb);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+            if !entries.is_empty() {
+                state.timeline_cmd_buffers.insert(k, entries);
             }
         }
         if let Some(staging) = state
@@ -1401,6 +2353,22 @@ pub(super) fn reap_timeline_cmd_buffers_up_to(
             if let Some(ld) = state.devices.get(&device_handle) {
                 super::texture::destroy_texture_staging_list(ld, staging);
             }
+        }
+    }
+
+    if n <= keys_buf.len() {
+        for &k in &keys_buf[..n] {
+            process_key(state, device_handle, k);
+        }
+    } else {
+        let keys: Vec<u64> = state
+            .timeline_cmd_buffers
+            .keys()
+            .copied()
+            .filter(|k| *k <= max_completed_value)
+            .collect();
+        for k in keys {
+            process_key(state, device_handle, k);
         }
     }
 }

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -413,6 +413,14 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             timeline_semaphore,
             timeline_next: 1,
             pipeline_cache,
+            vk_timestamp_compute_and_graphics: physical_device
+                .properties
+                .limits
+                .timestamp_compute_and_graphics
+                != 0,
+            vk_timestamp_period_ns: physical_device.properties.limits.timestamp_period,
+            free_cmd_buffers: Vec::new(),
+            retained_compute_cb: None,
         },
     );
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1114,6 +1114,27 @@ impl GpuBackend for VulkanBackend {
         compute::submit_graph(&mut self.state, device, commands)
     }
 
+    fn submit_graph_and_retain(
+        &mut self,
+        device: DeviceHandle,
+        commands: &[GraphCommand],
+        key: u64,
+    ) -> Result<crate::timeline::TimelineValue> {
+        compute::submit_graph_and_retain(&mut self.state, device, commands, key)
+    }
+
+    fn try_resubmit_retained(
+        &mut self,
+        device: DeviceHandle,
+        key: u64,
+    ) -> Result<Option<crate::timeline::TimelineValue>> {
+        compute::try_resubmit_retained(&mut self.state, device, key)
+    }
+
+    fn evict_retained(&mut self, device: DeviceHandle, key: u64) {
+        compute::evict_retained(&mut self.state, device, key);
+    }
+
     fn record_gpu_work(&mut self, frame: &FrameToken, commands: &[GpuCommand]) -> Result<()> {
         let surf = self
             .state

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -462,6 +462,7 @@ pub(super) fn acquire(
     state: &mut super::types::VulkanState,
     surface_handle: SurfaceHandle,
 ) -> Result<SwapchainImageHandle> {
+    let _tz = crate::tracy_zone!("vk.surface.acquire");
     // Clean up any previously acquired surface texture that wasn't presented
     if let Some(surface_state) = state.surfaces.get(&surface_handle) {
         if let Some(tex_handle) = surface_state.current_texture_handle {
@@ -493,6 +494,7 @@ pub(super) fn acquire(
         .unwrap_or(0);
 
     let wait_result = {
+        let _wz = crate::tracy_zone!("vk.surface.wait_fence");
         let logical_device = state
             .devices
             .get(&device_handle)
@@ -551,6 +553,7 @@ pub(super) fn acquire(
 
     // Process deferred deletions: GPU timeline has reached `completed` after frame-fence wait.
     {
+        let _dz = crate::tracy_zone!("vk.surface.deferred_deletions");
         let logical_device = state
             .devices
             .get_mut(&device_handle)
@@ -708,12 +711,15 @@ pub(super) fn acquire(
                 .wait_dst_stage_mask(&wait_stages)
                 .command_buffers(std::slice::from_ref(&prep_cmd))
                 .signal_semaphores(&signal_semaphores);
-            let prep_submit_result = unsafe {
-                logical_device.device.queue_submit(
-                    logical_device.queue,
-                    std::slice::from_ref(&prep_submit),
-                    vk::Fence::null(),
-                )
+            let prep_submit_result = {
+                let _ps = crate::tracy_zone!("vk.surface.prep_submit");
+                unsafe {
+                    logical_device.device.queue_submit(
+                        logical_device.queue,
+                        std::slice::from_ref(&prep_submit),
+                        vk::Fence::null(),
+                    )
+                }
             };
             if let Err(e) = &prep_submit_result {
                 tracing::warn!(
@@ -1154,6 +1160,7 @@ pub(super) fn present(
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
 ) -> Result<crate::timeline::TimelineValue> {
+    let _tz = crate::tracy_zone!("vk.surface.present");
     // Take the surface texture handle but do NOT unregister yet — the deferred
     // compute CBs (and the render CB in the graphics path) reference the
     // VkImageView + bindless descriptor.  Vulkan requires the image view to
@@ -1314,12 +1321,15 @@ pub(super) fn present(
             .devices
             .get(&device_handle)
             .context("Surface's device is invalid")?;
-        let submit_result = unsafe {
-            submit_ld.device.queue_submit2(
-                submit_ld.queue,
-                std::slice::from_ref(&submit2),
-                in_flight_fence_present,
-            )
+        let submit_result = {
+            let _sz = crate::tracy_zone!("vk.present.queue_submit2");
+            unsafe {
+                submit_ld.device.queue_submit2(
+                    submit_ld.queue,
+                    std::slice::from_ref(&submit2),
+                    in_flight_fence_present,
+                )
+            }
         };
         if let Err(e) = submit_result {
             tracing::warn!(
@@ -1390,7 +1400,10 @@ pub(super) fn present(
         .swapchains(&swapchains)
         .image_indices(&image_indices);
 
-    let result = unsafe { swapchain_loader.queue_present(present_ld.queue, &present_info) };
+    let result = {
+        let _pz = crate::tracy_zone!("vk.present.queue_present");
+        unsafe { swapchain_loader.queue_present(present_ld.queue, &present_info) }
+    };
     // `queue_present` returns Ok on SUCCESS and SUBOPTIMAL_KHR; Err on real failures.
     let mark_image_presented = result.is_ok();
     if let Err(e) = &result {

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -333,6 +333,26 @@ pub(crate) struct LogicalDevice {
 
     /// Optional driver pipeline cache persisted to disk (`~/.cache/goldy/pipeline_cache_<adapter>.bin`).
     pub pipeline_cache: vk::PipelineCache,
+
+    /// Timestamp query support (`VkPhysicalDeviceLimits::timestamp_compute_and_graphics`).
+    pub vk_timestamp_compute_and_graphics: bool,
+    pub vk_timestamp_period_ns: f32,
+
+    /// Recycled command buffers available for reuse (avoids alloc/free per submit).
+    pub free_cmd_buffers: Vec<vk::CommandBuffer>,
+    /// Retained dispatch command buffer for resubmission without re-recording.
+    /// `None` until a `submit_graph_and_retain` call stores a completed CB here.
+    /// At `cleanup_depth=1` the CB is guaranteed to be in executable state at
+    /// the start of the next frame (GPU has completed it via `wait_until`).
+    pub retained_compute_cb: Option<RetainedVkCb>,
+}
+
+/// A Vulkan command buffer retained for resubmission.
+pub(crate) struct RetainedVkCb {
+    /// Opaque key used to detect staleness (binding fingerprint).
+    pub fingerprint: u64,
+    /// The retained `VkCommandBuffer` (in executable state when GPU has completed).
+    pub command_buffer: vk::CommandBuffer,
 }
 
 impl LogicalDevice {

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -227,6 +227,7 @@ impl<'a> ComputePass<'a> {
     /// - `dispatch(256, 1, 1)` runs 256 * 64 = 16384 threads
     pub fn dispatch(&mut self, workgroups_x: u32, workgroups_y: u32, workgroups_z: u32) {
         self.encoder.commands.push(GpuCommand::Dispatch {
+            label: None,
             workgroups_x,
             workgroups_y,
             workgroups_z,
@@ -240,6 +241,7 @@ impl<'a> ComputePass<'a> {
     /// compute pass (e.g. a setup shader that writes the counts).
     pub fn dispatch_indirect(&mut self, buffer: &Buffer, offset: u64) {
         self.encoder.commands.push(GpuCommand::DispatchIndirect {
+            label: None,
             buffer: buffer.handle,
             offset,
         });
@@ -295,10 +297,12 @@ mod tests {
         assert_eq!(commands.len(), 1);
         match &commands[0] {
             GpuCommand::Dispatch {
+                label,
                 workgroups_x,
                 workgroups_y,
                 workgroups_z,
             } => {
+                assert!(label.is_none());
                 assert_eq!(*workgroups_x, 4);
                 assert_eq!(*workgroups_y, 2);
                 assert_eq!(*workgroups_z, 1);

--- a/src/device.rs
+++ b/src/device.rs
@@ -554,6 +554,7 @@ impl Device {
     /// Latest GPU completion counter on this device's timeline (`wait_until(value)` is valid once
     /// `gpu_progress() >= value`).
     pub fn gpu_progress(&self) -> TimelineValue {
+        let _tz = crate::tracy_zone!("device.gpu_progress");
         let backend = self.inner.backend.lock().unwrap();
         backend.gpu_progress(self.inner.handle)
     }
@@ -654,6 +655,7 @@ impl Device {
     /// [`DeferredPayload`]: crate::vram_allocator::DeferredPayload
     /// [`defer_release`]: Self::defer_release
     pub fn flush_deferred_deletions(&self) {
+        let _tz = crate::tracy_zone!("device.flush_deferred_deletions");
         let mut backend = self.inner.backend.lock().unwrap();
         backend.flush_deferred_deletions(self.inner.handle);
         let progress = backend.gpu_progress(self.inner.handle);
@@ -707,7 +709,7 @@ impl Device {
     /// by the device. The heap is lazily created on first use and reused across
     /// submissions — callers never need to manage transient buffer backing
     /// storage, view creation, or bindless index patching.
-    pub fn submit(&self, graph: &TaskGraph) -> Result<TimelineValue, GoldyError> {
+    pub fn submit(&self, graph: &mut TaskGraph) -> Result<TimelineValue, GoldyError> {
         if !graph.has_transient_resources() {
             let mut backend = self.inner.backend.lock().unwrap();
             let tv = graph
@@ -758,7 +760,8 @@ impl Device {
     ///
     /// [`Self::submit`] still waits on transient resources — that path remains the
     /// safe default for one-shot submission.
-    pub fn submit_pipelined(&self, graph: &TaskGraph) -> Result<TimelineValue, GoldyError> {
+    pub fn submit_pipelined(&self, graph: &mut TaskGraph) -> Result<TimelineValue, GoldyError> {
+        let _tz = crate::tracy_zone!("device.submit_pipelined");
         if !graph.has_transient_resources() {
             let mut backend = self.inner.backend.lock().unwrap();
             let tv = graph
@@ -800,6 +803,57 @@ impl Device {
         Ok(tv)
     }
 
+    /// Submit a task graph and retain the closed command list for potential reuse.
+    ///
+    /// Works like [`Self::submit_pipelined`] but also stores the compiled command list
+    /// keyed by `key`.  Call [`Self::try_resubmit_retained`] on the next frame to
+    /// re-execute the same list without re-recording when the graph is unchanged.
+    ///
+    /// Graphs with transient resources are not eligible for retention (they use
+    /// placement-heap allocations that are recycled each frame); the call degrades
+    /// gracefully to a plain submit in that case.
+    pub fn submit_pipelined_and_retain(
+        &self,
+        graph: &mut TaskGraph,
+        key: u64,
+    ) -> Result<TimelineValue, GoldyError> {
+        if graph.has_transient_resources() {
+            // Transient-buffer graphs cannot be safely retained; fall back.
+            return self.submit_pipelined(graph);
+        }
+        let mut backend = self.inner.backend.lock().unwrap();
+        let tv = graph
+            .submit_with_backend_and_retain(self, backend.as_mut(), key)
+            .map_err(|e| {
+                drop(backend);
+                self.classify(e)
+            })?;
+        self.inner
+            .high_water_timeline
+            .fetch_max(tv, Ordering::Relaxed);
+        Ok(tv)
+    }
+
+    /// Re-execute a previously retained command list without re-recording.
+    ///
+    /// Returns `Ok(Some(tv))` on success, `Ok(None)` if no matching retained list exists
+    /// (caller should fall back to a full submit-and-retain cycle).
+    pub fn try_resubmit_retained(&self, key: u64) -> Result<Option<TimelineValue>, GoldyError> {
+        let mut backend = self.inner.backend.lock().unwrap();
+        let result = backend
+            .try_resubmit_retained(self.inner.handle, key)
+            .map_err(|e| {
+                drop(backend);
+                self.classify(e)
+            })?;
+        if let Some(tv) = result {
+            self.inner
+                .high_water_timeline
+                .fetch_max(tv, Ordering::Relaxed);
+        }
+        Ok(result)
+    }
+
     /// Default pipeline depth for initial placement heap sizing.
     pub(crate) const DEFAULT_PIPELINE_DEPTH: u64 = 4;
 
@@ -812,7 +866,7 @@ impl Device {
     /// 5. Submit the resolved IR (views kept alive in the heap ring until GPU retires)
     fn submit_with_placement_heap(
         &self,
-        graph: &TaskGraph,
+        graph: &mut TaskGraph,
         tex_handles: &HashMap<u32, backend::TextureHandle>,
         wait_for_transient_completion: bool,
     ) -> Result<TimelineValue> {
@@ -882,7 +936,7 @@ impl Device {
         let resolved_ir = graph.lower_transient_buffers_with_bindless(&range_map, &bindless_map)?;
 
         // Build a resolved graph (no transient specs) and submit.
-        let resolved_graph = graph.into_resolved(resolved_ir);
+        let mut resolved_graph = graph.into_resolved(resolved_ir);
 
         // Drop the heap lock before acquiring the backend lock for submission.
         drop(heap_guard);
@@ -907,7 +961,7 @@ impl Device {
     }
 
     /// Submit a task graph and block until it completes.
-    pub fn dispatch(&self, graph: &TaskGraph) -> Result<(), GoldyError> {
+    pub fn dispatch(&self, graph: &mut TaskGraph) -> Result<(), GoldyError> {
         let v = self.submit(graph)?;
         self.wait_until(v)
     }
@@ -1203,12 +1257,12 @@ mod tests {
         use crate::task_graph::TaskGraph;
         let device = test_device();
         assert_eq!(device.high_water_timeline(), 0);
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
         assert!(tv > 0);
         assert_eq!(device.high_water_timeline(), tv);
         // Second submit advances it further.
-        let tv2 = device.submit(&graph).unwrap();
+        let tv2 = device.submit(&mut graph).unwrap();
         assert!(tv2 > tv);
         assert_eq!(device.high_water_timeline(), tv2);
     }
@@ -1217,8 +1271,8 @@ mod tests {
     fn defer_until_resources_are_not_dropped_before_epoch() {
         use crate::task_graph::TaskGraph;
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(99u32);
         let weak = std::sync::Arc::downgrade(&alive);
@@ -1238,8 +1292,8 @@ mod tests {
     fn defer_until_resources_dropped_after_flush_at_epoch() {
         use crate::task_graph::TaskGraph;
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(42u32);
         let weak = std::sync::Arc::downgrade(&alive);
@@ -1259,8 +1313,8 @@ mod tests {
     fn defer_release_drops_all_on_device_drop() {
         use crate::task_graph::TaskGraph;
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(7u32);
         let weak = std::sync::Arc::downgrade(&alive);

--- a/src/frame_orchestrator.rs
+++ b/src/frame_orchestrator.rs
@@ -9,8 +9,65 @@ use crate::error::GoldyError;
 use crate::surface::Frame;
 use crate::task_graph::TaskGraph;
 use crate::timeline::TimelineValue;
+use crate::tracy_frame_mark;
+use crate::tracy_zone;
 use anyhow::anyhow;
 use std::collections::VecDeque;
+
+/// Semantic hint for how the frame pipeline should be scheduled.
+///
+/// The application chooses based on its tolerance for input lag vs. desire for
+/// throughput. Goldy selects the optimal internal strategy (pipelining depth,
+/// buffer allocation, CB retention) accordingly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameStrategy {
+    /// Minimize latency. Frames are fully synchronous: the CPU blocks until the
+    /// GPU finishes each frame before starting the next. CPU recording overhead
+    /// is eliminated via command buffer retention when the binding structure is
+    /// stable across frames.
+    ///
+    /// Best for: interactive applications, games, live previews.
+    LowLatency,
+
+    /// Balanced throughput. Two frames overlap: the CPU records frame N+1 while
+    /// the GPU executes frame N. VRAM stays bounded via graph coloring across
+    /// staggered pipeline stages.
+    ///
+    /// Best for: applications that can tolerate one frame of input lag.
+    Balanced,
+
+    /// Maximum throughput. Deeply pipelined: the CPU is always recording ahead
+    /// of the GPU. Latency is highest but FPS ceiling is maximized.
+    ///
+    /// Best for: offline rendering, benchmarks, batch processing.
+    MaxThroughput {
+        /// Maximum number of frames allowed in-flight. Defaults to 3 if `None`.
+        max_frames_in_flight: Option<u32>,
+    },
+}
+
+impl FrameStrategy {
+    /// Derive the pipelining depth from the strategy.
+    pub fn depth(&self) -> usize {
+        match self {
+            FrameStrategy::LowLatency => 1,
+            FrameStrategy::Balanced => 2,
+            FrameStrategy::MaxThroughput {
+                max_frames_in_flight,
+            } => max_frames_in_flight.unwrap_or(3) as usize,
+        }
+    }
+
+    /// Whether transient-buffer graph coloring should be used for VRAM reuse.
+    ///
+    /// At depth=1 (LowLatency) all buffers are persistent — graph coloring adds
+    /// overhead with no benefit and prevents stable bindless indices needed for CB
+    /// retention. At depth>1 graph coloring aliases physical memory across
+    /// staggered pipeline stages.
+    pub fn use_graph_coloring(&self) -> bool {
+        self.depth() > 1
+    }
+}
 
 /// Token returned from [`FrameOrchestrator::begin_frame`]; must be passed to
 /// [`FrameOrchestrator::flush`], [`FrameOrchestrator::end_frame_standalone`], or
@@ -41,6 +98,7 @@ struct FrameSlot<T> {
 /// 4. For swapchain frames, [`Self::note_presented`] after [`Frame::present`].
 pub struct FrameOrchestrator<T> {
     device: Device,
+    strategy: FrameStrategy,
     max_depth: usize,
     ring: VecDeque<FrameSlot<T>>,
     /// Monotonic id for the next [`FrameHandle`].
@@ -54,13 +112,41 @@ impl<T> FrameOrchestrator<T> {
     /// next [`Self::begin_frame`] blocks or forces the oldest slot to retire (same role as
     /// `max_regions` on pooled transient allocators).
     pub fn new(device: &Device, max_depth: usize) -> Self {
+        let strategy = match max_depth {
+            0 | 1 => FrameStrategy::LowLatency,
+            2 => FrameStrategy::Balanced,
+            n => FrameStrategy::MaxThroughput {
+                max_frames_in_flight: Some(n as u32),
+            },
+        };
         Self {
             device: device.clone(),
+            strategy,
             max_depth: max_depth.max(1),
             ring: VecDeque::new(),
             next_id: 1,
             open: None,
         }
+    }
+
+    /// Create an orchestrator from a [`FrameStrategy`], which derives the
+    /// pipelining depth automatically.
+    pub fn with_strategy(device: &Device, strategy: FrameStrategy) -> Self {
+        let max_depth = strategy.depth();
+        Self {
+            device: device.clone(),
+            strategy,
+            max_depth,
+            ring: VecDeque::new(),
+            next_id: 1,
+            open: None,
+        }
+    }
+
+    /// The frame scheduling strategy configured at construction.
+    #[inline]
+    pub fn strategy(&self) -> FrameStrategy {
+        self.strategy
     }
 
     /// Maximum number of in-flight frame slots (configured at construction).
@@ -113,6 +199,7 @@ impl<T> FrameOrchestrator<T> {
         E: std::fmt::Display,
         F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
     {
+        let _tz = tracy_zone!("orchestrator.begin_frame");
         if self.open.is_some() {
             return Err(GoldyError::Backend(anyhow!(
                 "FrameOrchestrator::begin_frame: a frame is already open"
@@ -127,26 +214,29 @@ impl<T> FrameOrchestrator<T> {
 
     /// Mid-frame submit: dispatches the current graph and starts a fresh one.
     ///
-    /// Uses [`Device::submit_pipelined`] on standalone paths so transient-buffer regions can overlap
-    /// CPU recording with GPU execution across flushes.
+    /// Always uses [`Device::submit_pipelined`] so the GPU can begin executing the submitted
+    /// work (e.g. coarse rasterization) while the CPU continues recording subsequent work
+    /// (e.g. fine rasterization) into a new [`TaskGraph`].  This creates a real command-buffer
+    /// boundary on all backends, including windowed/surface frames where the fine pass and
+    /// present are submitted later via [`Self::end_frame_for_surface`].
+    ///
+    /// Because Metal (and Vulkan/DX12) execute command buffers on the same queue in submission
+    /// order, the fine command buffer automatically waits for the coarse one to complete —
+    /// no explicit fence is required.
     pub fn flush(
         &mut self,
         handle: FrameHandle,
         graph: &mut TaskGraph,
-        surface_frame: Option<&Frame>,
         last_timeline: &mut Option<TimelineValue>,
     ) -> Result<(), GoldyError> {
+        let _tz = tracy_zone!("orchestrator.flush");
         self.expect_open(handle)?;
         if graph.is_empty() {
             return Ok(());
         }
-        if let Some(frame) = surface_frame {
-            frame.submit_compute(graph).map_err(GoldyError::from)?;
-        } else {
-            let tv = self.device.submit_pipelined(graph)?;
-            *last_timeline = Some(tv);
-        }
-        *graph = TaskGraph::new();
+        let tv = self.device.submit_pipelined(graph)?;
+        *last_timeline = Some(tv);
+        graph.clear();
         Ok(())
     }
 
@@ -158,21 +248,23 @@ impl<T> FrameOrchestrator<T> {
     pub fn end_frame_standalone(
         &mut self,
         handle: FrameHandle,
-        graph: TaskGraph,
+        mut graph: TaskGraph,
         fallback_timeline: Option<TimelineValue>,
         cleanup: T,
     ) -> Result<TimelineValue, GoldyError> {
+        let _tz = tracy_zone!("orchestrator.end_frame_standalone");
         self.expect_open(handle)?;
         let tv = if graph.is_empty() {
             fallback_timeline.unwrap_or_else(|| self.device.gpu_progress())
         } else {
-            self.device.submit_pipelined(&graph)?
+            self.device.submit_pipelined(&mut graph)?
         };
         self.ring.push_back(FrameSlot {
             timeline: Some(tv),
             data: cleanup,
         });
         self.open = None;
+        tracy_frame_mark!();
         Ok(tv)
     }
 
@@ -181,10 +273,11 @@ impl<T> FrameOrchestrator<T> {
     pub fn end_frame_for_surface(
         &mut self,
         handle: FrameHandle,
-        graph: &TaskGraph,
+        graph: &mut TaskGraph,
         frame: &Frame,
         cleanup: T,
     ) -> Result<(), GoldyError> {
+        let _tz = tracy_zone!("orchestrator.end_frame_for_surface");
         self.expect_open(handle)?;
         if !graph.is_empty() {
             frame.submit_compute(graph).map_err(GoldyError::from)?;
@@ -256,7 +349,8 @@ impl<T> FrameOrchestrator<T> {
         E: std::fmt::Display,
         F: FnMut(&Device, RetiredFrame<T>) -> Result<(), E>,
     {
-        let progress = self.device.gpu_progress();
+        let _tz = tracy_zone!("orchestrator.drain_ring");
+        let mut progress = self.device.gpu_progress();
         while let Some(front) = self.ring.front() {
             let done = match front.timeline {
                 Some(tv) => progress >= tv,
@@ -266,19 +360,24 @@ impl<T> FrameOrchestrator<T> {
             if done || must_wait {
                 let slot = self.ring.pop_front().unwrap();
                 if let Some(tv) = slot.timeline {
-                    if self.device.gpu_progress() < tv && must_wait {
+                    if progress < tv && must_wait {
+                        let _wz = tracy_zone!("orchestrator.wait_gpu");
                         self.device.wait_until(tv)?;
+                        progress = tv;
                     }
                 }
                 let timeline = slot.timeline.unwrap_or(0);
-                retire(
-                    &self.device,
-                    RetiredFrame {
-                        timeline,
-                        data: slot.data,
-                    },
-                )
-                .map_err(|e| GoldyError::Backend(anyhow!("{e}")))?;
+                {
+                    let _rz = tracy_zone!("orchestrator.retire_cb");
+                    retire(
+                        &self.device,
+                        RetiredFrame {
+                            timeline,
+                            data: slot.data,
+                        },
+                    )
+                    .map_err(|e| GoldyError::Backend(anyhow!("{e}")))?;
+                }
             } else {
                 break;
             }

--- a/src/gpu_guard.rs
+++ b/src/gpu_guard.rs
@@ -15,8 +15,8 @@
 //! # use goldy::buffer::Buffer;
 //! # use goldy::task_graph::TaskGraph;
 //! # fn example(device: &Device, buf: Buffer) -> anyhow::Result<()> {
-//! let graph = TaskGraph::new(); // ... build your graph using buf ...
-//! let tv = device.submit(&graph)?;
+//! let mut graph = TaskGraph::new(); // ... build your graph using buf ...
+//! let tv = device.submit(&mut graph)?;
 //!
 //! let mut guard = GpuGuard::new(device, tv);
 //! guard.hold(buf); // buf is now safe: dropped only after tv retires
@@ -149,8 +149,8 @@ mod tests {
     #[test]
     fn gpu_guard_resources_not_dropped_before_epoch() {
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(99u32);
         let weak = std::sync::Arc::downgrade(&alive);
@@ -172,8 +172,8 @@ mod tests {
     #[test]
     fn gpu_guard_resources_dropped_after_epoch_and_flush() {
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(42u32);
         let weak = std::sync::Arc::downgrade(&alive);
@@ -197,8 +197,8 @@ mod tests {
         // one real submitted epoch (tv) and one far-future epoch (tv + 100) that hasn't
         // been submitted and therefore remains unretired after wait_until(tv).
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
         let tv_future = tv + 100;
 
         let alive_past = std::sync::Arc::new(1u32);
@@ -238,8 +238,8 @@ mod tests {
     #[test]
     fn gpu_guard_resources_cleaned_up_on_device_drop() {
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         let alive = std::sync::Arc::new(7u32);
         let weak = std::sync::Arc::downgrade(&alive);
@@ -260,8 +260,8 @@ mod tests {
     #[test]
     fn gpu_guard_hold_multiple_resource_types() {
         let device = test_device();
-        let graph = TaskGraph::new();
-        let tv = device.submit(&graph).unwrap();
+        let mut graph = TaskGraph::new();
+        let tv = device.submit(&mut graph).unwrap();
 
         // Allocate a real buffer and hold it in a guard.
         let buf = device

--- a/src/gpu_profiler.rs
+++ b/src/gpu_profiler.rs
@@ -1,0 +1,180 @@
+//! GPU profiling helpers controlled by `GOLDY_GPU_PROFILE`.
+//!
+//! - Any non-empty value enables structured [`tracing`] logs for GPU timings.
+//! - `chrome`, `chrome:`, `chrome=<path>`, or `chrome:<path>` additionally writes a
+//!   Perfetto-compatible Chrome trace JSON array (pretty-printed) to disk after each readback.
+
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Parsed configuration from [`std::env::var`] `"GOLDY_GPU_PROFILE"`.
+#[derive(Clone, Debug)]
+pub struct GpuProfileConfig {
+    pub enabled: bool,
+    pub chrome_path: Option<PathBuf>,
+}
+
+impl GpuProfileConfig {
+    pub fn from_env() -> Self {
+        let Ok(raw) = std::env::var("GOLDY_GPU_PROFILE") else {
+            return Self {
+                enabled: false,
+                chrome_path: None,
+            };
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Self {
+                enabled: false,
+                chrome_path: None,
+            };
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        let chrome_path = if lower.starts_with("chrome") {
+            let rest = trimmed
+                .get("chrome".len()..)
+                .unwrap_or("")
+                .trim_start_matches(':')
+                .trim_start_matches('=')
+                .trim();
+            if rest.is_empty() {
+                Some(PathBuf::from("goldy_gpu_trace.json"))
+            } else {
+                Some(PathBuf::from(rest))
+            }
+        } else {
+            None
+        };
+
+        Self {
+            enabled: true,
+            chrome_path,
+        }
+    }
+}
+
+pub static GPU_PROFILE_CONFIG: LazyLock<GpuProfileConfig> =
+    LazyLock::new(GpuProfileConfig::from_env);
+
+#[inline]
+pub fn gpu_profile_enabled() -> bool {
+    GPU_PROFILE_CONFIG.enabled
+}
+
+/// GPU duration for one dispatch (nanoseconds).
+#[derive(Clone, Copy, Debug)]
+pub struct DispatchGpuNs {
+    pub label: &'static str,
+    pub gpu_ns: u64,
+}
+
+pub fn log_cb_timing(backend: &str, timeline: u64, gpu_ms: f64) {
+    if !gpu_profile_enabled() {
+        return;
+    }
+    tracing::info!("[GPU] backend={backend} timeline={timeline} gpu={gpu_ms:.3}ms");
+    chrome_record_complete(backend, timeline, None, gpu_ms * 1_000_000.0);
+}
+
+pub fn log_dispatch_timings(backend: &str, timeline: u64, dispatches: &[DispatchGpuNs]) {
+    if !gpu_profile_enabled() {
+        return;
+    }
+    let mut total_ns = 0u64;
+    for d in dispatches {
+        let ms = d.gpu_ns as f64 / 1_000_000.0;
+        total_ns = total_ns.saturating_add(d.gpu_ns);
+        tracing::info!(
+            "[GPU] backend={backend} timeline={timeline} dispatch={:?} gpu={ms:.3}ms",
+            d.label
+        );
+        chrome_record_complete(backend, timeline, Some(d.label), ms * 1_000_000.0);
+    }
+    let total_ms = total_ns as f64 / 1_000_000.0;
+    tracing::info!(
+        "[GPU] backend={backend} timeline={timeline} total_dispatch_gpu={total_ms:.3}ms"
+    );
+}
+
+fn wall_ts_us() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64() * 1_000_000.0)
+        .unwrap_or(0.0)
+}
+
+fn escape_json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn chrome_record_complete(
+    backend: &str,
+    timeline: u64,
+    dispatch_label: Option<&'static str>,
+    dur_us: f64,
+) {
+    let Some(path) = GPU_PROFILE_CONFIG.chrome_path.clone() else {
+        return;
+    };
+    let name = match dispatch_label {
+        Some(l) => format!("goldy-{backend}-{l}"),
+        None => format!("goldy-{backend}-cmdbuf-timeline-{timeline}"),
+    };
+    let ts_us = wall_ts_us();
+    let tid = format!("goldy-{backend}");
+
+    let mut guard = CHROME_EVENTS.lock().unwrap();
+    guard.push(ChromeEvent {
+        name,
+        ts_us,
+        dur_us,
+        tid,
+        timeline,
+    });
+    if let Err(e) = flush_chrome_trace(&path, &guard) {
+        tracing::warn!("GOLDY_GPU_PROFILE chrome export failed: {e}");
+    }
+}
+
+struct ChromeEvent {
+    name: String,
+    ts_us: f64,
+    dur_us: f64,
+    tid: String,
+    timeline: u64,
+}
+
+static CHROME_EVENTS: Mutex<Vec<ChromeEvent>> = Mutex::new(Vec::new());
+
+fn flush_chrome_trace(path: &Path, events: &[ChromeEvent]) -> std::io::Result<()> {
+    let mut s = String::from("[\n");
+    for (i, e) in events.iter().enumerate() {
+        if i > 0 {
+            s.push_str(",\n");
+        }
+        s.push_str(&format!(
+            r#"  {{"name":"{}","cat":"gpu","ph":"X","ts":{:.3},"dur":{:.3},"pid":1,"tid":"{}","args":{{"timeline":{}}}}}"#,
+            escape_json_str(&e.name),
+            e.ts_us,
+            e.dur_us,
+            escape_json_str(&e.tid),
+            e.timeline
+        ));
+    }
+    s.push_str("\n]");
+    std::fs::write(path, s)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,19 @@ pub mod validation_env;
 
 // Structured instrumentation for debugging and profiling
 pub mod gpu_guard;
+pub mod gpu_profiler;
 pub mod instrumentation;
+pub mod tracy;
+
+#[cfg(feature = "tracy")]
+#[doc(hidden)]
+pub use tracy_client as _tracy_client;
 pub mod placement_heap;
 pub mod timeline;
 pub mod transient_allocator;
 pub mod vram_allocator;
 pub use error::GoldyError;
-pub use frame_orchestrator::{FrameHandle, FrameOrchestrator, RetiredFrame};
+pub use frame_orchestrator::{FrameHandle, FrameOrchestrator, FrameStrategy, RetiredFrame};
 pub use gpu_guard::GpuGuard;
 pub use vram_allocator::DeferredPayload;
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -9,6 +9,8 @@ use crate::encoder::CommandEncoder;
 use crate::task_graph::TaskGraph;
 use crate::texture::Texture;
 use crate::timeline::TimelineValue;
+use crate::tracy_frame_mark;
+use crate::tracy_zone;
 use crate::types::{PresentMode, SurfaceConfig, TextureFormat};
 use crate::vram_allocator::DeferredPayload;
 use anyhow::{Context, Result};
@@ -107,6 +109,7 @@ impl Surface {
 
     /// Begin the next frame (acquire swapchain image and open the frame bracket).
     pub fn begin(&self) -> Result<Frame> {
+        let _tz = tracy_zone!("surface.begin");
         let (token, texture_handle, w, h, format) = {
             let mut backend = self.backend.lock().unwrap();
             let (tok, th) = backend.begin_frame(self.handle)?;
@@ -232,7 +235,8 @@ impl Frame {
     /// automatically using the device-owned placement heap. The caller does not need
     /// to call [`Device::submit`](crate::Device::submit) for graphs with transients;
     /// this method handles the full resolution transparently.
-    pub fn submit_compute(&self, graph: &TaskGraph) -> Result<()> {
+    pub fn submit_compute(&self, graph: &mut TaskGraph) -> Result<()> {
+        let _tz = tracy_zone!("frame.submit_compute");
         if !graph.has_transient_resources() {
             let commands = graph.compile_commands();
             let mut backend = self.backend.lock().unwrap();
@@ -362,6 +366,7 @@ impl Frame {
     }
 
     fn do_present(&mut self) -> Result<TimelineValue> {
+        let _tz = tracy_zone!("frame.present");
         if self.presented {
             let backend = self.backend.lock().unwrap();
             return Ok(backend.gpu_progress(self.device_handle));
@@ -373,6 +378,7 @@ impl Frame {
             let mut backend = self.backend.lock().unwrap();
             backend.end_frame(token)?
         };
+        tracy_frame_mark!();
         // Stamp any pending placement heap regions with the present timeline.
         if let Ok(mut heap_guard) = self._device.inner.placement_heap.lock() {
             if let Some(ref mut heap) = *heap_guard {

--- a/src/task_graph/analysis.rs
+++ b/src/task_graph/analysis.rs
@@ -23,12 +23,14 @@
 //!    Each [`NodeKind`] variant emits different commands.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use super::ir::{BarrierSet, CompiledSchedule, GraphIR, NodeKind, ResourceBinding, Wave};
 // NodeAccess is used in the test module via `super::*`
 #[cfg(test)]
 use super::ir::NodeAccess;
 use super::ResourceId;
+use crate::backend::shared::DISPATCH_BATCH_STRIDE;
 use crate::backend::{GpuCommand, GraphCommand};
 use anyhow::Result;
 
@@ -455,48 +457,156 @@ pub fn emit_commands(ir: &GraphIR, schedule: &CompiledSchedule) -> Vec<GpuComman
                         data: data.clone(),
                     });
                 }
+                NodeKind::CopyTexture { src, dst } => {
+                    commands.push(GpuCommand::CopyTexture {
+                        src: *src,
+                        dst: *dst,
+                    });
+                }
                 NodeKind::Dispatch { .. } | NodeKind::RenderPass { .. } => {}
             }
         }
 
-        for &idx in &wave.node_indices {
-            let node = &ir.nodes[idx];
-            match &node.kind {
-                NodeKind::Dispatch {
+        // Emit dispatch nodes, batching consecutive same-pipeline direct dispatches
+        // into a single `DispatchBatch` command that can be executed with
+        // `ExecuteIndirect` on DX12 (reducing per-dispatch CPU recording cost).
+        //
+        // Indirect dispatches (GPU-driven counts) are NOT batched because they
+        // already read counts from a GPU buffer; mixing them with the CPU arg
+        // buffer layout is not straightforward.
+        {
+            // Build a list of (pipeline, resource_slots, user_slots, dispatch) tuples
+            // for this wave's dispatch nodes, in order.
+            struct PendingDispatch<'n> {
+                label: &'static str,
+                pipeline: crate::backend::ComputePipelineHandle,
+                resource_slots: &'n Vec<u32>,
+                user_slots: &'n Vec<u32>,
+                x: u32,
+                y: u32,
+                z: u32,
+            }
+
+            // Collect all DIRECT dispatch nodes in this wave (excluding indirect).
+            let mut pending: Vec<PendingDispatch<'_>> = Vec::new();
+            let mut has_indirect = false;
+            for &idx in &wave.node_indices {
+                let node = &ir.nodes[idx];
+                if let NodeKind::Dispatch {
                     pipeline,
                     resource_slots,
                     user_slots,
-                    dispatch,
-                } => {
-                    commands.push(GpuCommand::SetPipeline(*pipeline));
-                    if !resource_slots.is_empty() || !user_slots.is_empty() {
-                        commands.push(GpuCommand::BindResourcesRaw {
-                            indices: resource_slots.clone(),
-                            user: user_slots.clone(),
+                    dispatch: super::ir::DispatchDim::Direct { x, y, z },
+                } = &node.kind
+                {
+                    pending.push(PendingDispatch {
+                        label: node.label,
+                        pipeline: *pipeline,
+                        resource_slots,
+                        user_slots,
+                        x: *x,
+                        y: *y,
+                        z: *z,
+                    });
+                } else if let NodeKind::Dispatch {
+                    dispatch: super::ir::DispatchDim::Indirect { .. },
+                    ..
+                } = &node.kind
+                {
+                    has_indirect = true;
+                }
+            }
+
+            // Emit indirect dispatches one by one (existing path).
+            if has_indirect {
+                for &idx in &wave.node_indices {
+                    let node = &ir.nodes[idx];
+                    if let NodeKind::Dispatch {
+                        pipeline,
+                        resource_slots,
+                        user_slots,
+                        dispatch: super::ir::DispatchDim::Indirect { buffer, offset },
+                    } = &node.kind
+                    {
+                        commands.push(GpuCommand::SetPipeline(*pipeline));
+                        if !resource_slots.is_empty() || !user_slots.is_empty() {
+                            commands.push(GpuCommand::BindResourcesRaw {
+                                indices: resource_slots.clone(),
+                                user: user_slots.clone(),
+                            });
+                        }
+                        commands.push(GpuCommand::DispatchIndirect {
+                            label: Some(node.label),
+                            buffer: *buffer,
+                            offset: *offset,
                         });
                     }
-                    match dispatch {
-                        super::ir::DispatchDim::Direct { x, y, z } => {
-                            commands.push(GpuCommand::Dispatch {
-                                workgroups_x: *x,
-                                workgroups_y: *y,
-                                workgroups_z: *z,
-                            });
-                        }
-                        super::ir::DispatchDim::Indirect { buffer, offset } => {
-                            commands.push(GpuCommand::DispatchIndirect {
-                                buffer: *buffer,
-                                offset: *offset,
-                            });
-                        }
+                }
+            }
+
+            // Emit direct dispatches, batching consecutive same-pipeline groups.
+            let mut i = 0;
+            while i < pending.len() {
+                let cur_pipeline = pending[i].pipeline;
+                // Find the run of dispatches sharing the same pipeline.
+                let run_end = pending[i..]
+                    .iter()
+                    .take_while(|d| d.pipeline == cur_pipeline)
+                    .count();
+                let run = &pending[i..i + run_end];
+
+                if run.len() > 1 {
+                    // Build the flat argument buffer: [PushLayout | wg_x | wg_y | wg_z] per entry.
+                    let mut arg_data: Vec<u8> =
+                        Vec::with_capacity(run.len() * DISPATCH_BATCH_STRIDE);
+                    for d in run {
+                        // Reconstruct PushLayout bytes from resource/user slots.
+                        let mut layout = crate::backend::shared::PushLayout::default();
+                        crate::backend::shared::fill_raw(
+                            &mut layout,
+                            d.resource_slots,
+                            d.user_slots,
+                        );
+                        arg_data.extend_from_slice(bytemuck::bytes_of(&layout));
+                        arg_data.extend_from_slice(&d.x.to_ne_bytes());
+                        arg_data.extend_from_slice(&d.y.to_ne_bytes());
+                        arg_data.extend_from_slice(&d.z.to_ne_bytes());
                     }
+                    commands.push(GpuCommand::SetPipeline(cur_pipeline));
+                    commands.push(GpuCommand::DispatchBatch {
+                        label: Some(run[0].label),
+                        arg_data: Arc::from(arg_data.as_slice()),
+                        count: run.len() as u32,
+                    });
+                } else {
+                    // Single dispatch — use existing per-dispatch path.
+                    let d = &run[0];
+                    commands.push(GpuCommand::SetPipeline(cur_pipeline));
+                    if !d.resource_slots.is_empty() || !d.user_slots.is_empty() {
+                        commands.push(GpuCommand::BindResourcesRaw {
+                            indices: d.resource_slots.clone(),
+                            user: d.user_slots.clone(),
+                        });
+                    }
+                    commands.push(GpuCommand::Dispatch {
+                        label: Some(d.label),
+                        workgroups_x: d.x,
+                        workgroups_y: d.y,
+                        workgroups_z: d.z,
+                    });
                 }
-                NodeKind::RenderPass { .. } => {
-                    panic!(
-                        "emit_commands: graph contains render_pass; use emit_graph_commands / TaskGraph::compile_graph_commands"
-                    );
-                }
-                _ => {}
+
+                i += run_end;
+            }
+        }
+
+        // Handle RenderPass nodes (not expected here — checked for completeness).
+        for &idx in &wave.node_indices {
+            let node = &ir.nodes[idx];
+            if let NodeKind::RenderPass { .. } = &node.kind {
+                panic!(
+                    "emit_commands: graph contains render_pass; use emit_graph_commands / TaskGraph::compile_graph_commands"
+                );
             }
         }
     }
@@ -572,6 +682,12 @@ pub fn emit_graph_commands(ir: &GraphIR, schedule: &CompiledSchedule) -> Vec<Gra
                         data: data.clone(),
                     }));
                 }
+                NodeKind::CopyTexture { src, dst } => {
+                    commands.push(GraphCommand::Compute(GpuCommand::CopyTexture {
+                        src: *src,
+                        dst: *dst,
+                    }));
+                }
                 NodeKind::Dispatch { .. } | NodeKind::RenderPass { .. } => {}
             }
         }
@@ -596,6 +712,7 @@ pub fn emit_graph_commands(ir: &GraphIR, schedule: &CompiledSchedule) -> Vec<Gra
                     match dispatch {
                         super::ir::DispatchDim::Direct { x, y, z } => {
                             commands.push(GraphCommand::Compute(GpuCommand::Dispatch {
+                                label: Some(node.label),
                                 workgroups_x: *x,
                                 workgroups_y: *y,
                                 workgroups_z: *z,
@@ -603,6 +720,7 @@ pub fn emit_graph_commands(ir: &GraphIR, schedule: &CompiledSchedule) -> Vec<Gra
                         }
                         super::ir::DispatchDim::Indirect { buffer, offset } => {
                             commands.push(GraphCommand::Compute(GpuCommand::DispatchIndirect {
+                                label: Some(node.label),
                                 buffer: *buffer,
                                 offset: *offset,
                             }));
@@ -910,6 +1028,7 @@ mod tests {
             cmds[1],
             GpuCommand::Dispatch {
                 workgroups_x: 8,
+                label: Some("A"),
                 ..
             }
         ));
@@ -919,6 +1038,7 @@ mod tests {
             cmds[4],
             GpuCommand::Dispatch {
                 workgroups_x: 4,
+                label: Some("B"),
                 ..
             }
         ));
@@ -973,6 +1093,7 @@ mod tests {
             cmds[2],
             GpuCommand::Dispatch {
                 workgroups_x: 1,
+                label: Some("A"),
                 ..
             }
         ));

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -1,13 +1,16 @@
 //! `TaskGraph` — analyzed GPU task graph with automatic barrier insertion.
 
 use super::analysis;
-use super::ir::{DispatchDim, GraphIR, NodeAccess, NodeKind, ResourceBinding, TaskNode};
+use super::ir::{
+    CompiledSchedule, DispatchDim, GraphIR, NodeAccess, NodeKind, ResourceBinding, TaskNode,
+};
 use super::{
     ResourceId, TransientBufferSpec, TransientId, TransientTextureId, TransientTextureKey,
     TransientTextureSpec,
 };
 use crate::backend::{
-    BufferHandle, GpuBackend, GraphCommand, RenderCommand, RenderTargetHandle, TextureHandle,
+    BufferHandle, GpuBackend, GpuCommand, GraphCommand, RenderCommand, RenderTargetHandle,
+    TextureHandle,
 };
 use crate::buffer::{Buffer, BufferView};
 use crate::compute::ComputePipeline;
@@ -20,6 +23,7 @@ use crate::timeline::TimelineValue;
 use crate::types::{SpatialAccess, TextureFlags, TextureFormat};
 use anyhow::Result;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 fn gcd(mut a: u64, mut b: u64) -> u64 {
@@ -29,6 +33,64 @@ fn gcd(mut a: u64, mut b: u64) -> u64 {
         a = t;
     }
     a
+}
+
+/// Build a map from each upload command index in `commands` back to its IR node index.
+///
+/// On a cache hit we use this to refresh `Arc<[u8]>` payloads from the current IR.
+fn build_upload_remap(ir: &GraphIR, commands: &[GpuCommand]) -> Vec<(usize, usize)> {
+    let mut remap = Vec::with_capacity(8);
+    let mut consumed = vec![false; ir.nodes.len()];
+    for (cmd_idx, cmd) in commands.iter().enumerate() {
+        let mut found: Option<usize> = None;
+        for (n_idx, node) in ir.nodes.iter().enumerate() {
+            if consumed[n_idx] {
+                continue;
+            }
+            let matches = match (cmd, &node.kind) {
+                (
+                    GpuCommand::WriteBuffer {
+                        buffer: cb,
+                        offset: co,
+                        ..
+                    },
+                    NodeKind::WriteBuffer {
+                        buffer: nb,
+                        offset: no,
+                        ..
+                    },
+                ) => cb == nb && co == no,
+                (
+                    GpuCommand::WriteTexture { texture: ct, .. },
+                    NodeKind::WriteTexture { texture: nt, .. },
+                ) => ct == nt,
+                (
+                    GpuCommand::WriteTextureRegion {
+                        texture: ct,
+                        x: cx,
+                        y: cy,
+                        ..
+                    },
+                    NodeKind::WriteTextureRegion {
+                        texture: nt,
+                        x: nx,
+                        y: ny,
+                        ..
+                    },
+                ) => ct == nt && cx == nx && cy == ny,
+                _ => false,
+            };
+            if matches {
+                found = Some(n_idx);
+                break;
+            }
+        }
+        if let Some(n_idx) = found {
+            consumed[n_idx] = true;
+            remap.push((cmd_idx, n_idx));
+        }
+    }
+    remap
 }
 
 fn lcm(a: u64, b: u64) -> u64 {
@@ -73,6 +135,31 @@ pub struct TaskGraph {
     next_transient_id: u32,
     pub(crate) transient_texture_specs: Vec<TransientTextureSpec>,
     next_transient_texture_id: u32,
+    /// Cached schedule + emitted command list, keyed on binding fingerprint.
+    ///
+    /// The fingerprint is a hash of the graph's binding structure (node count + per-node
+    /// resource-access pairs).  When the graph is rebuilt with the same bindings but
+    /// different data payloads (e.g. same shader dispatch topology but new scene data),
+    /// the schedule and emitted commands are reused, skipping `build_edges` +
+    /// `schedule_waves` + `emit_commands`.
+    ///
+    /// On a cache hit, upload command payloads (`WriteBuffer`, `WriteTexture`,
+    /// `WriteTextureRegion`) are refreshed from the current IR via `upload_remap`
+    /// — the binding fingerprint excludes data bytes, so cached `Arc<[u8]>` Arcs
+    /// would otherwise be stale.  The Arc swap is a single atomic refcount bump.
+    schedule_cache: Option<CompiledCacheEntry>,
+}
+
+/// Cache entry holding both the wave schedule and the emitted compute command stream.
+pub(crate) struct CompiledCacheEntry {
+    fp: u64,
+    schedule: CompiledSchedule,
+    /// `None` when the graph contains render-pass nodes (caller uses `emit_graph_commands`)
+    /// or when no compute commands have been emitted yet for this fingerprint.
+    commands: Option<Vec<GpuCommand>>,
+    /// `(command_index, ir_node_index)` for each upload command in `commands`.
+    /// Used to refresh `Arc<[u8]>` payloads from the current IR on cache hit.
+    upload_remap: Vec<(usize, usize)>,
 }
 
 impl TaskGraph {
@@ -83,6 +170,7 @@ impl TaskGraph {
             next_transient_id: 0,
             transient_texture_specs: Vec::new(),
             next_transient_texture_id: 0,
+            schedule_cache: None,
         }
     }
 
@@ -147,7 +235,7 @@ impl TaskGraph {
     }
 
     pub(crate) fn submit_with_backend(
-        &self,
+        &mut self,
         device: &Device,
         backend: &mut dyn GpuBackend,
         transient_buffer_ranges: Option<&HashMap<u32, (BufferHandle, u64, u64)>>,
@@ -181,7 +269,14 @@ impl TaskGraph {
             ir = Self::lower_transient_textures(&ir, transient_texture_handles)?;
         }
 
-        let tv = Self::submit_resolved_ir(device, backend, &ir)?;
+        // Use the schedule cache when the IR is unmodified (no transients), otherwise build fresh.
+        let tv = if self.transient_specs.is_empty() && self.transient_texture_specs.is_empty() {
+            Self::submit_resolved_ir(&mut self.schedule_cache, device, backend, &ir)?
+        } else {
+            // IR was lowered (has transients); cache is keyed to the original IR — skip.
+            let mut local_cache = None;
+            Self::submit_resolved_ir(&mut local_cache, device, backend, &ir)?
+        };
         if wait_for_transient_completion && self.needs_transient_gpu_wait() {
             backend.wait_until(device.inner.handle, tv)?;
         }
@@ -189,6 +284,7 @@ impl TaskGraph {
     }
 
     fn submit_resolved_ir(
+        cache: &mut Option<CompiledCacheEntry>,
         device: &Device,
         backend: &mut dyn GpuBackend,
         ir: &GraphIR,
@@ -202,11 +298,59 @@ impl TaskGraph {
             let g = Self::compile_graph_commands_for_ir(ir);
             backend.submit_graph(device.inner.handle, &g)
         } else {
-            let edges = analysis::build_edges(ir);
-            let schedule = analysis::schedule_waves(ir, &edges);
-            let cmds = analysis::emit_commands(ir, &schedule);
-            backend.submit_standalone(device.inner.handle, &cmds)
+            let cmds = Self::get_or_build_compute_commands(cache, ir);
+            backend.submit_standalone(device.inner.handle, cmds)
         }
+    }
+
+    fn submit_resolved_ir_and_retain(
+        cache: &mut Option<CompiledCacheEntry>,
+        device: &Device,
+        backend: &mut dyn GpuBackend,
+        ir: &GraphIR,
+        key: u64,
+    ) -> Result<TimelineValue> {
+        let has_render = ir
+            .nodes
+            .iter()
+            .any(|n| matches!(n.kind, NodeKind::RenderPass { .. }));
+
+        if has_render {
+            // Render-pass graphs cannot be retained (mixed command lists); fall back.
+            let g = Self::compile_graph_commands_for_ir(ir);
+            backend.submit_graph(device.inner.handle, &g)
+        } else {
+            // The retention path needs a `Vec<GraphCommand>`, so we clone the
+            // cached compute stream — `Arc<[u8]>` payloads are cheap to clone
+            // (refcount bump only).  The schedule + emit work is still saved.
+            let cmds = Self::get_or_build_compute_commands(cache, ir);
+            let graph_cmds: Vec<GraphCommand> =
+                cmds.iter().cloned().map(GraphCommand::Compute).collect();
+            backend.submit_graph_and_retain(device.inner.handle, &graph_cmds, key)
+        }
+    }
+
+    /// Like [`Self::submit_with_backend`] but retains the closed command list for `key`.
+    ///
+    /// Graphs with transient resources are not eligible for retention and silently fall
+    /// back to a normal submit.  Called from [`Device::submit_pipelined_and_retain`].
+    pub(crate) fn submit_with_backend_and_retain(
+        &mut self,
+        device: &Device,
+        backend: &mut dyn GpuBackend,
+        key: u64,
+    ) -> Result<TimelineValue> {
+        // Only retain pure compute graphs (no transients, no render passes).
+        if self.has_transient_resources() {
+            return Self::submit_resolved_ir(&mut self.schedule_cache, device, backend, &self.ir);
+        }
+        Self::submit_resolved_ir_and_retain(
+            &mut self.schedule_cache,
+            device,
+            backend,
+            &self.ir,
+            key,
+        )
     }
 
     /// Pack transient buffers into a heap using wave live ranges: transients whose
@@ -348,6 +492,8 @@ impl TaskGraph {
             next_transient_id: 0,
             transient_texture_specs: self.transient_texture_specs.clone(),
             next_transient_texture_id: self.next_transient_texture_id,
+            // Resolved graphs are ephemeral (transient buffers were lowered); no cache.
+            schedule_cache: None,
         }
     }
 
@@ -728,6 +874,34 @@ impl TaskGraph {
         Ok(())
     }
 
+    /// Add a GPU-side full-texture copy node from `src` to `dst`.
+    ///
+    /// Both textures must have identical dimensions and compatible formats.
+    /// The backend inserts appropriate memory barriers and layout transitions.
+    /// `src` should have [`crate::types::TextureFlags::COPY_SRC`] and
+    /// `dst` should have [`crate::types::TextureFlags::COPY_DST`].
+    pub fn copy_texture(&mut self, src: &Texture, dst: &Texture) {
+        let src_h = src.handle();
+        let dst_h = dst.handle();
+        self.ir.nodes.push(TaskNode {
+            label: "copy_texture",
+            bindings: vec![
+                ResourceBinding {
+                    resource: ResourceId::Texture(src_h),
+                    access: NodeAccess::Read,
+                },
+                ResourceBinding {
+                    resource: ResourceId::Texture(dst_h),
+                    access: NodeAccess::Write,
+                },
+            ],
+            kind: NodeKind::CopyTexture {
+                src: src_h,
+                dst: dst_h,
+            },
+        });
+    }
+
     /// Add a CPU→GPU texture upload node for a subrectangle.
     pub fn write_texture_region(
         &mut self,
@@ -794,12 +968,12 @@ impl TaskGraph {
 
     /// Analyze the graph and submit all tasks with optimal barriers.
     /// Returns the device [`TimelineValue`] to pass to [`Device::wait_until`].
-    pub fn submit(&self, device: &Device) -> Result<TimelineValue, GoldyError> {
+    pub fn submit(&mut self, device: &Device) -> Result<TimelineValue, GoldyError> {
         device.submit(self)
     }
 
     /// Analyze the graph, submit, and block until complete.
-    pub fn dispatch(&self, device: &Device) -> Result<(), GoldyError> {
+    pub fn dispatch(&mut self, device: &Device) -> Result<(), GoldyError> {
         device.dispatch(self)
     }
 
@@ -812,9 +986,141 @@ impl TaskGraph {
         self.ir.nodes.is_empty()
     }
 
+    /// Returns `true` if the graph contains any `WriteBuffer` nodes.
+    ///
+    /// Used by the command-list retention path to detect staging-belt uploads.
+    /// A command list that contains `CopyBufferRegion` commands sourced from the
+    /// staging belt cannot be safely retained across frames because the staging
+    /// belt recycles its chunks once the GPU fence is met.  Callers should
+    /// fall back to a normal (non-retained) submit when this returns `true`.
+    pub fn has_write_buffer(&self) -> bool {
+        self.ir
+            .nodes
+            .iter()
+            .any(|n| matches!(n.kind, NodeKind::WriteBuffer { .. }))
+    }
+
+    /// Reset the graph to empty while retaining all heap allocations for reuse.
+    ///
+    /// Equivalent to `*self = TaskGraph::new()` but avoids freeing and
+    /// re-allocating the internal `Vec` buffers. Call this after submitting the
+    /// graph to reuse its capacity for the next frame's recording pass.
+    pub fn clear(&mut self) {
+        self.ir.nodes.clear();
+        self.transient_specs.clear();
+        self.transient_texture_specs.clear();
+        self.next_transient_id = 0;
+        self.next_transient_texture_id = 0;
+    }
+
     /// Access the raw IR for internal use (e.g. transient lowering from outside the task_graph module).
     pub(crate) fn ir(&self) -> &GraphIR {
         &self.ir
+    }
+
+    /// Compute a fingerprint of the graph's binding structure for schedule caching.
+    ///
+    /// Only hashes the dependency-relevant parts: node count and per-node
+    /// Compute a fingerprint of the current graph based on node bindings.
+    ///
+    /// This captures pipeline handles, buffer bindless indices, and workgroup sizes
+    /// but NOT data payloads. Two graphs with the same binding fingerprint record
+    /// identical `VkCommandBuffer` contents and can be resubmitted interchangeably.
+    pub fn compute_binding_fingerprint(&self) -> u64 {
+        Self::binding_fingerprint(&self.ir)
+    }
+
+    /// `(resource_id, access)` pairs.  Data payloads (`WriteBuffer` bytes, dispatch
+    /// dimensions) are intentionally excluded — the schedule depends only on which
+    /// resources are read/written, not what values they carry.
+    fn binding_fingerprint(ir: &GraphIR) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        let mut h = DefaultHasher::new();
+        ir.nodes.len().hash(&mut h);
+        for node in &ir.nodes {
+            node.bindings.len().hash(&mut h);
+            for b in &node.bindings {
+                b.hash(&mut h);
+            }
+        }
+        h.finish()
+    }
+
+    /// Return a reference to the compiled schedule for `ir`, using the cache when possible.
+    ///
+    /// On a miss the schedule is built and stored; on a hit it is returned directly.
+    fn get_or_build_schedule<'c>(
+        cache: &'c mut Option<CompiledCacheEntry>,
+        ir: &GraphIR,
+    ) -> &'c CompiledSchedule {
+        let fp = Self::binding_fingerprint(ir);
+        if cache.as_ref().is_some_and(|e| e.fp == fp) {
+            return &cache.as_ref().unwrap().schedule;
+        }
+        let edges = analysis::build_edges(ir);
+        let schedule = analysis::schedule_waves(ir, &edges);
+        *cache = Some(CompiledCacheEntry {
+            fp,
+            schedule,
+            commands: None,
+            upload_remap: Vec::new(),
+        });
+        &cache.as_ref().unwrap().schedule
+    }
+
+    /// Return cached emitted commands for `ir`, building them if necessary.
+    ///
+    /// Used by the standalone-compute submit path to skip `emit_commands` when the
+    /// graph topology is unchanged.  Upload command payloads are refreshed from
+    /// the current IR on hit; `Arc<[u8]>` swaps are a single atomic refcount bump.
+    fn get_or_build_compute_commands<'c>(
+        cache: &'c mut Option<CompiledCacheEntry>,
+        ir: &GraphIR,
+    ) -> &'c [GpuCommand] {
+        let fp = Self::binding_fingerprint(ir);
+        let needs_build = match cache.as_ref() {
+            Some(e) => e.fp != fp || e.commands.is_none(),
+            None => true,
+        };
+
+        if !needs_build {
+            // Hit: refresh upload `Arc<[u8]>` payloads from the current IR.
+            let entry = cache.as_mut().unwrap();
+            if let Some(commands) = entry.commands.as_mut() {
+                for &(cmd_idx, node_idx) in &entry.upload_remap {
+                    let node = &ir.nodes[node_idx];
+                    match (&mut commands[cmd_idx], &node.kind) {
+                        (
+                            GpuCommand::WriteBuffer { data, .. },
+                            NodeKind::WriteBuffer { data: src, .. },
+                        ) => *data = src.clone(),
+                        (
+                            GpuCommand::WriteTexture { data, .. },
+                            NodeKind::WriteTexture { data: src, .. },
+                        ) => *data = src.clone(),
+                        (
+                            GpuCommand::WriteTextureRegion { data, .. },
+                            NodeKind::WriteTextureRegion { data: src, .. },
+                        ) => *data = src.clone(),
+                        _ => {} // mismatch should not occur if fp matches
+                    }
+                }
+            }
+            return cache.as_ref().unwrap().commands.as_deref().unwrap();
+        }
+
+        // Miss: rebuild schedule (if needed) and emit commands fresh.
+        let edges = analysis::build_edges(ir);
+        let schedule = analysis::schedule_waves(ir, &edges);
+        let commands = analysis::emit_commands(ir, &schedule);
+        let upload_remap = build_upload_remap(ir, &commands);
+        *cache = Some(CompiledCacheEntry {
+            fp,
+            schedule,
+            commands: Some(commands),
+            upload_remap,
+        });
+        cache.as_ref().unwrap().commands.as_deref().unwrap()
     }
 
     /// Compile the graph into a flat command stream.
@@ -826,7 +1132,7 @@ impl TaskGraph {
     ///
     /// If the graph contains render-pass nodes or transient buffers, use
     /// [`Self::compile_graph_commands`] or [`Device::submit`](crate::Device::submit) instead.
-    pub fn compile_commands(&self) -> Vec<crate::backend::GpuCommand> {
+    pub fn compile_commands(&mut self) -> Vec<crate::backend::GpuCommand> {
         assert!(
             self.transient_specs.is_empty(),
             "compile_commands: graph uses transient_buffer; use Device::submit"
@@ -838,9 +1144,7 @@ impl TaskGraph {
         if Self::has_render_passes_in_ir(&self.ir) {
             panic!("compile_commands: graph contains render_pass; use compile_graph_commands or Device::submit");
         }
-        let edges = analysis::build_edges(&self.ir);
-        let schedule = analysis::schedule_waves(&self.ir, &edges);
-        analysis::emit_commands(&self.ir, &schedule)
+        Self::get_or_build_compute_commands(&mut self.schedule_cache, &self.ir).to_vec()
     }
 
     /// Compile a pre-lowered [`GraphIR`] into a flat GPU command stream.
@@ -856,7 +1160,7 @@ impl TaskGraph {
     }
 
     /// Like [`Self::compile_commands`] but allows graphs that include render-pass nodes.
-    pub fn compile_graph_commands(&self) -> Vec<GraphCommand> {
+    pub fn compile_graph_commands(&mut self) -> Vec<GraphCommand> {
         assert!(
             self.transient_specs.is_empty(),
             "compile_graph_commands: graph uses transient_buffer; use Device::submit"
@@ -865,9 +1169,8 @@ impl TaskGraph {
             self.transient_texture_specs.is_empty(),
             "compile_graph_commands: graph uses transient_texture; use Device::submit"
         );
-        let edges = analysis::build_edges(&self.ir);
-        let schedule = analysis::schedule_waves(&self.ir, &edges);
-        analysis::emit_graph_commands(&self.ir, &schedule)
+        let schedule = Self::get_or_build_schedule(&mut self.schedule_cache, &self.ir);
+        analysis::emit_graph_commands(&self.ir, schedule)
     }
 }
 
@@ -1084,6 +1387,16 @@ mod tests {
     use crate::shader::ShaderModule;
     use crate::types::{Color, TextureFormat};
     use crate::Texture;
+
+    fn count_logical_dispatches(cmds: &[GpuCommand]) -> usize {
+        cmds.iter()
+            .map(|c| match c {
+                GpuCommand::Dispatch { .. } => 1,
+                GpuCommand::DispatchBatch { count, .. } => *count as usize,
+                _ => 0,
+            })
+            .sum()
+    }
 
     fn mock_device() -> Device {
         Device::from_backend(Box::new(MockBackend::new())).unwrap()
@@ -1321,17 +1634,12 @@ mod tests {
         assert!(!cmds
             .iter()
             .any(|c| matches!(c, GpuCommand::ResourceBarrier { .. })));
-        assert_eq!(
-            cmds.iter()
-                .filter(|c| matches!(c, GpuCommand::Dispatch { .. }))
-                .count(),
-            2
-        );
+        assert_eq!(count_logical_dispatches(&cmds), 2);
     }
 
     #[test]
     fn compile_empty_graph() {
-        let graph = TaskGraph::new();
+        let mut graph = TaskGraph::new();
         let cmds = graph.compile_commands();
         assert!(cmds.is_empty());
     }
@@ -1696,12 +2004,7 @@ mod tests {
         assert!(!cmds
             .iter()
             .any(|c| matches!(c, GpuCommand::ResourceBarrier { .. })));
-        assert_eq!(
-            cmds.iter()
-                .filter(|c| matches!(c, GpuCommand::Dispatch { .. }))
-                .count(),
-            2
-        );
+        assert_eq!(count_logical_dispatches(&cmds), 2);
     }
 
     #[test]
@@ -1730,12 +2033,7 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(
-            cmds.iter()
-                .filter(|c| matches!(c, GpuCommand::Dispatch { .. }))
-                .count(),
-            2
-        );
+        assert_eq!(count_logical_dispatches(&cmds), 2);
     }
 
     #[test]
@@ -1886,12 +2184,7 @@ mod tests {
                 .any(|c| matches!(c, GpuCommand::ResourceBarrier { .. })),
             "10 independent pool views should produce zero barriers"
         );
-        assert_eq!(
-            cmds.iter()
-                .filter(|c| matches!(c, GpuCommand::Dispatch { .. }))
-                .count(),
-            10
-        );
+        assert_eq!(count_logical_dispatches(&cmds), 10);
     }
 
     #[test]
@@ -1975,12 +2268,7 @@ mod tests {
         assert!(matches!(cmds[0], GpuCommand::ClearBuffer { .. }));
 
         // Two dispatches present
-        assert_eq!(
-            cmds.iter()
-                .filter(|c| matches!(c, GpuCommand::Dispatch { .. }))
-                .count(),
-            2
-        );
+        assert_eq!(count_logical_dispatches(&cmds), 2);
     }
 
     #[test]

--- a/src/task_graph/ir.rs
+++ b/src/task_graph/ir.rs
@@ -37,7 +37,7 @@ impl NodeAccess {
 }
 
 /// A single resource binding within a task node.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceBinding {
     /// Graph IR only; not exposed publicly so [`super::ResourceId`] can stay crate-private.
     pub(crate) resource: ResourceId,
@@ -94,6 +94,15 @@ pub enum NodeKind {
         height: u32,
         data: Arc<[u8]>,
     },
+    /// Copy the full contents of one texture into another.
+    ///
+    /// Both textures must have compatible formats and identical dimensions.
+    /// `src` must have [`crate::types::TextureFlags::COPY_SRC`] and
+    /// `dst` must have [`crate::types::TextureFlags::COPY_DST`].
+    CopyTexture {
+        src: TextureHandle,
+        dst: TextureHandle,
+    },
     /// Offscreen render pass targeting a [`crate::RenderTarget`].
     ///
     /// Declare all buffers and textures read by draw commands via
@@ -108,7 +117,6 @@ pub enum NodeKind {
 /// A single node in the task graph.
 #[derive(Debug, Clone)]
 pub struct TaskNode {
-    #[allow(dead_code)]
     pub label: &'static str,
     /// Resource access declarations used by the dependency analyzer.
     pub bindings: Vec<ResourceBinding>,

--- a/src/tracy.rs
+++ b/src/tracy.rs
@@ -1,0 +1,82 @@
+//! Tracy profiler integration.
+//!
+//! Provides thin wrappers around the [`tracy-client`](https://docs.rs/tracy-client) crate
+//! that compile to no-ops when the `tracy` feature is disabled.
+//!
+//! # Quick start
+//!
+//! 1. Build with `--features tracy`
+//! 2. Launch the [Tracy profiler](https://github.com/wolfpld/tracy) GUI
+//! 3. It will auto-discover the running application via broadcast
+//!
+//! # Macros
+//!
+//! | Macro | Purpose |
+//! |-------|---------|
+//! | [`tracy_zone!()`][macro@crate::tracy_zone] | CPU zone — measures wall time of the enclosing scope |
+//! | [`tracy_frame_mark!()`][macro@crate::tracy_frame_mark] | Main frame boundary marker |
+//! | [`tracy_plot!()`][macro@crate::tracy_plot] | Numeric value plotted over time |
+
+/// Mark a CPU profiling zone that lasts until the binding is dropped.
+///
+/// ```rust,ignore
+/// let _z = tracy_zone!("submit");
+/// let _z = tracy_zone!("dispatch", "my_shader.slang");
+/// ```
+#[cfg(feature = "tracy")]
+#[macro_export]
+macro_rules! tracy_zone {
+    ($name:expr) => {
+        $crate::_tracy_client::span!($name, 0)
+    };
+    ($name:expr, $text:expr) => {{
+        let mut span = $crate::_tracy_client::span!($name, 0);
+        span.emit_text($text);
+        span
+    }};
+}
+
+#[cfg(not(feature = "tracy"))]
+#[macro_export]
+macro_rules! tracy_zone {
+    ($name:expr) => {
+        $crate::tracy::NoopZone
+    };
+    ($name:expr, $text:expr) => {
+        $crate::tracy::NoopZone
+    };
+}
+
+/// Mark the end of the main frame (Tracy's primary frame counter).
+#[cfg(feature = "tracy")]
+#[macro_export]
+macro_rules! tracy_frame_mark {
+    () => {
+        $crate::_tracy_client::frame_mark()
+    };
+}
+
+#[cfg(not(feature = "tracy"))]
+#[macro_export]
+macro_rules! tracy_frame_mark {
+    () => {};
+}
+
+/// Plot a named numeric value over time in Tracy's plot view.
+#[cfg(feature = "tracy")]
+#[macro_export]
+macro_rules! tracy_plot {
+    ($name:expr, $value:expr) => {
+        $crate::_tracy_client::plot!($name, $value)
+    };
+}
+
+#[cfg(not(feature = "tracy"))]
+#[macro_export]
+macro_rules! tracy_plot {
+    ($name:expr, $value:expr) => {};
+}
+
+/// No-op zone guard when Tracy is disabled.
+#[cfg(not(feature = "tracy"))]
+pub struct NoopZone;

--- a/src/transient_allocator.rs
+++ b/src/transient_allocator.rs
@@ -64,9 +64,6 @@ use std::collections::{BTreeMap, VecDeque};
 pub struct TransientAllocatorConfig {
     /// Initial backing-storage size, in bytes. Allocators may grow beyond this on demand.
     pub initial_size: u64,
-    /// Hint for peak demand. Used by backends that support capacity reservation (e.g. Metal
-    /// placement heaps) to pre-reserve virtual address range and avoid mid-frame reallocations.
-    pub expected_max: u64,
     /// Minimum region size for region-based strategies (e.g. [`EpochRegionsAllocator`]). Ignored
     /// by non-regional strategies. Default 4 MiB; smaller values trade region overhead for
     /// finer-grained reclamation.
@@ -86,7 +83,6 @@ impl Default for TransientAllocatorConfig {
     fn default() -> Self {
         Self {
             initial_size: 64 * 1024,
-            expected_max: 16 * 1024 * 1024,
             min_region_size: 4 * 1024 * 1024,
             max_regions: 3,
             alignment: 256,
@@ -171,6 +167,15 @@ pub trait TransientAllocator: Send {
     /// The default implementation is a no-op — bump-style allocators that reclaim entire
     /// regions at once simply ignore per-view frees.
     fn free(&mut self, _offset: u64, _size: u64, _epoch: Option<TimelineValue>) {}
+
+    /// Release backing capacity that exceeds the observed peak working set.
+    ///
+    /// Implementations compact their free lists / watermarks and, where possible, downsize
+    /// the backing buffer or hint the backend that trailing pages are unused. Safe to call
+    /// at any time — live allocations are preserved.
+    ///
+    /// The default is a no-op; strategies that grow dynamically should override.
+    fn shrink_to_fit(&mut self) {}
 
     /// Optional emergency reset — drops all backing storage and forgets any in-flight epochs.
     /// Callers are responsible for ensuring no GPU work still references this allocator's
@@ -262,7 +267,6 @@ impl Drop for ResetToken {
 pub struct BumpResetAllocator {
     pool: BufferPool,
     last_epoch: Option<TimelineValue>,
-    expected_max: u64,
     /// Set to `true` once the deferred reset token is dropped after `gpu_progress >= last_epoch`.
     /// Reset to `false` in `end_frame` when a new token is issued.
     reset_ready: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -271,17 +275,17 @@ pub struct BumpResetAllocator {
 impl BumpResetAllocator {
     /// Create a new allocator. Allocates initial backing immediately.
     pub fn new(device: &Device, config: TransientAllocatorConfig) -> Result<Self> {
+        let initial = config.initial_size.max(config.alignment);
         let pool = BufferPool::with_alignment_capacity_hint_and_flags(
             device,
-            config.initial_size.max(config.alignment),
-            config.expected_max.max(config.initial_size),
+            initial,
+            initial,
             config.alignment,
             config.flags,
         )?;
         Ok(Self {
             pool,
             last_epoch: None,
-            expected_max: config.expected_max,
             reset_ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         })
     }
@@ -324,8 +328,7 @@ impl TransientAllocator for BumpResetAllocator {
             let target = used
                 .saturating_add(size)
                 .saturating_mul(2)
-                .max(self.pool.capacity().saturating_mul(2))
-                .max(self.expected_max);
+                .max(self.pool.capacity().saturating_mul(2));
             self.pool.resize(target)?;
         }
         self.pool.alloc_bytes(size, element_stride)
@@ -464,8 +467,8 @@ impl EpochRegionsAllocator {
         min_size: u64,
     ) -> Result<Region> {
         let size = config.min_region_size.max(min_size).max(config.alignment);
-        // Capacity hint is per-region, not the global expected_max. Each region only
-        // needs to handle its own share of per-frame demand, not the entire frame.
+        // Capacity hint equals the region size — each region only needs to handle
+        // its own share of per-frame demand, not the entire frame.
         let pool = BufferPool::with_alignment_capacity_hint_and_flags(
             device,
             size,
@@ -803,14 +806,17 @@ pub struct HeapTransientAllocator {
     live_bytes: u64,
     /// Peak `live_bytes` observed across the lifetime of this allocator (diagnostic).
     peak_live_bytes: u64,
+    /// Frame counter — used to defer `shrink_to_fit` until the pipeline has warmed up.
+    frame_count: u64,
 }
 
 impl HeapTransientAllocator {
     pub fn new(device: &Device, config: TransientAllocatorConfig) -> Result<Self> {
+        let initial = config.initial_size.max(config.alignment);
         let pool = BufferPool::with_alignment_capacity_hint_and_flags(
             device,
-            config.initial_size.max(config.alignment),
-            config.expected_max.max(config.initial_size),
+            initial,
+            initial,
             config.alignment,
             config.flags,
         )?;
@@ -823,6 +829,7 @@ impl HeapTransientAllocator {
             pending_frees: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             live_bytes: 0,
             peak_live_bytes: 0,
+            frame_count: 0,
         })
     }
 
@@ -953,10 +960,9 @@ impl HeapTransientAllocator {
 
     fn grow(&mut self, min_capacity: u64) -> Result<()> {
         let current = self.pool.capacity();
-        // Grow to at least min_capacity with 25% headroom. No hard cap: with pipelining
-        // the concurrent live set spans multiple frames, so the pool must be allowed to
-        // grow beyond the single-frame `expected_max`. The heap recycles freed ranges, so
-        // once the pipeline is full the capacity stabilises at the peak concurrent set.
+        // Grow to at least min_capacity with 25% headroom. The heap recycles freed ranges,
+        // so once the pipeline is full the capacity stabilises at the peak concurrent set.
+        // After warmup, `shrink_to_fit` trims any excess.
         let target = min_capacity.max(current + current / 4);
         self.pool.resize(target)
     }
@@ -968,14 +974,23 @@ impl HeapTransientAllocator {
     }
 }
 
+/// Frames to wait before the first auto-shrink. Lets the pipeline fill and the
+/// peak working set stabilise before we trim.
+const HEAP_WARMUP_FRAMES: u64 = 8;
+
 impl TransientAllocator for HeapTransientAllocator {
     fn begin_frame(&mut self, device: &Device, _hint_size: u64) -> Result<()> {
+        self.frame_count += 1;
         // Flush any deferred frees with known epochs (e.g., from post-end_frame free calls).
         self.flush_deferred_to_vram(device);
         // Process any ranges whose tokens have been dropped by the VramAllocator ring.
         device.flush_deferred_deletions();
         self.drain_pending_frees();
         self.compact_watermark();
+        // After warmup, auto-shrink if we over-grew during the first few frames.
+        if self.frame_count == HEAP_WARMUP_FRAMES {
+            self.shrink_to_fit();
+        }
         Ok(())
     }
 
@@ -1058,6 +1073,24 @@ impl TransientAllocator for HeapTransientAllocator {
         "heap"
     }
 
+    fn shrink_to_fit(&mut self) {
+        self.compact_watermark();
+        let target = self.watermark.max(self.peak_live_bytes);
+        if target > 0 && self.pool.capacity() > target * 2 {
+            let new_cap = target + target / 4; // 25 % headroom
+            if new_cap < self.pool.capacity() {
+                tracing::info!(
+                    capacity = self.pool.capacity(),
+                    watermark = self.watermark,
+                    peak_live = self.peak_live_bytes,
+                    new_cap,
+                    "HeapTransientAllocator: shrink_to_fit"
+                );
+                self.pool.hint_unused_above(new_cap);
+            }
+        }
+    }
+
     fn clear(&mut self) {
         self.watermark = 0;
         self.free_list.clear();
@@ -1066,6 +1099,7 @@ impl TransientAllocator for HeapTransientAllocator {
             pending.clear();
         }
         self.live_bytes = 0;
+        self.frame_count = 0;
     }
 }
 
@@ -1127,7 +1161,6 @@ mod tests {
         assert!(c.initial_size > 0);
         assert!(c.min_region_size > 0);
         assert!(c.max_regions > 0);
-        assert!(c.expected_max >= c.initial_size);
     }
 
     // ---------------------------------------------------------------
@@ -1144,7 +1177,6 @@ mod tests {
     fn heap_config() -> TransientAllocatorConfig {
         TransientAllocatorConfig {
             initial_size: 64 * 1024,
-            expected_max: 1024 * 1024,
             min_region_size: 64 * 1024,
             max_regions: 3,
             alignment: 256,
@@ -1329,7 +1361,6 @@ mod tests {
         let device = test_device();
         let config = TransientAllocatorConfig {
             initial_size: 1024,
-            expected_max: 1024,
             ..heap_config()
         };
         let mut alloc = HeapTransientAllocator::new(&device, config).unwrap();
@@ -1349,7 +1380,6 @@ mod tests {
     fn small_config() -> TransientAllocatorConfig {
         TransientAllocatorConfig {
             initial_size: 4 * 1024,
-            expected_max: 16 * 1024,
             min_region_size: 4 * 1024,
             max_regions: 3,
             alignment: 256,
@@ -1366,8 +1396,8 @@ mod tests {
 
         a.begin_frame(&device, 0).expect("begin 1");
         let _v = a.alloc(&device, 1024, Some(4)).expect("alloc");
-        let graph = crate::task_graph::TaskGraph::new();
-        let tv = device.submit(&graph).expect("submit");
+        let mut graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&mut graph).expect("submit");
 
         a.end_frame(&device, tv);
         // Regions are now DeferredReclaim, not Empty.
@@ -1404,8 +1434,8 @@ mod tests {
         alloc.begin_frame(&device, 0).unwrap();
         let v1 = alloc.alloc(&device, 1024, Some(4)).unwrap();
         let offset = v1.offset();
-        let graph = crate::task_graph::TaskGraph::new();
-        let tv = device.submit(&graph).expect("submit");
+        let mut graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&mut graph).expect("submit");
 
         // Free with known epoch.
         alloc.free(offset, 1024, Some(tv));
@@ -1436,8 +1466,8 @@ mod tests {
 
         a.begin_frame(&device, 0).expect("begin 1");
         let _v = a.alloc(&device, 512, Some(4)).expect("alloc");
-        let graph = crate::task_graph::TaskGraph::new();
-        let tv = device.submit(&graph).expect("submit");
+        let mut graph = crate::task_graph::TaskGraph::new();
+        let tv = device.submit(&mut graph).expect("submit");
 
         a.end_frame(&device, tv);
         // reset_ready is now false.

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -2386,7 +2386,6 @@ use goldy::{
 fn small_config() -> TransientAllocatorConfig {
     TransientAllocatorConfig {
         initial_size: 4 * 1024,
-        expected_max: 64 * 1024,
         min_region_size: 4 * 1024,
         max_regions: 4,
         alignment: 256,


### PR DESCRIPTION
Vulkan:
- Move pipeline barriers from per-dispatch to wave boundaries
- Reuse command buffers via free-list instead of alloc/free per submit
- Narrow cross-submission barriers to specific stages and access types
- Bind descriptor set once per command buffer instead of per pipeline switch

DX12:
- Reuse command lists via allocator slot pool
- Refactor compute submission to use local references

Metal:
- Batch resource declarations to reduce ObjC message overhead
- Log GPU execution time when profiling is enabled

Infrastructure:
- Add GPU profiling support (dispatch labels, timing) across all backends
- Add Tracy profiler integration (feature-gated, zero-cost when disabled)
- Introduce FrameStrategy enum (LowLatency/Balanced/MaxThroughput)
- FrameOrchestrator flush always uses submit_pipelined for coarse/fine overlap
- TaskGraph::clear() retains heap allocations
- Change submit/dispatch/submit_pipelined to take &mut TaskGraph
- Remove expected_max from TransientAllocatorConfig, add shrink_to_fit
- Add CopyTexture and DispatchBatch command variants
- Add submit_graph_and_retain/try_resubmit_retained API surface (inert)