### PR TITLE
Change VRAM allocation tracking

### DIFF
--- a/docs/src/resources/vram-allocator.md
+++ b/docs/src/resources/vram-allocator.md
@@ -43,7 +43,7 @@ let buf = Buffer::new(&device, size, DataAccess::Scattered)?;
 let tex = Texture::new(&device, width, height, format, access, flags)?;
 ```
 
-Only allocations through `device.alloc_*` attach an allocator **deed** and call [`VramAllocator::notify_freed`] on drop. Borrowing sub-parcels such as `BufferView` never account.
+Only allocations through `device.alloc_*` attach an allocator **deed** and call `VramAllocator::notify_freed` on drop. Borrowing sub-parcels such as `BufferView` never account.
 
 Goldy's built-in pooling systems (`TexturePool`, `BufferPool`, ekrano's `ResourcePool`) all route through the device's allocator automatically.
 

--- a/docs/src/resources/vram-allocator.md
+++ b/docs/src/resources/vram-allocator.md
@@ -34,14 +34,16 @@ The `VramAllocator` trait sits **below** all three, providing a single customiza
 Every `Device` ships with a `DefaultVramAllocator` that delegates directly to the backend with zero overhead. You can allocate through it explicitly via convenience methods:
 
 ```rust
-// These go through the device's VramAllocator:
+// These go through the device's VramAllocator (parcel carries a deed; Drop notifies the allocator):
 let buf = device.alloc_buffer(size, DataAccess::Scattered, None, BufferFlags::empty())?;
 let tex = device.alloc_texture(width, height, format, access, flags)?;
 
-// These bypass the allocator (direct backend call):
+// These bypass the allocator (direct backend call; no deed, no allocator accounting on Drop):
 let buf = Buffer::new(&device, size, DataAccess::Scattered)?;
 let tex = Texture::new(&device, width, height, format, access, flags)?;
 ```
+
+Only allocations through `device.alloc_*` attach an allocator **deed** and call [`VramAllocator::notify_freed`] on drop. Borrowing sub-parcels such as `BufferView` never account.
 
 Goldy's built-in pooling systems (`TexturePool`, `BufferPool`, ekrano's `ResourcePool`) all route through the device's allocator automatically.
 
@@ -113,11 +115,21 @@ impl VramAllocator for MyAllocator {
         Texture::new(device, width, height, format, access, flags)
     }
 
+    fn notify_freed(
+        &self,
+        reserved: u64,
+        _committed: u64,
+        _kind: goldy::vram_allocator::ParcelKind,
+    ) {
+        // Decrement your tracked bytes (reserved is the parcel's reserved backing size).
+        let _ = reserved;
+    }
+
     fn name(&self) -> &'static str { "my-allocator" }
 }
 ```
 
-All trait methods have default implementations that delegate to the standard constructors, so you only need to override the methods you care about.
+All trait methods have default implementations that delegate to the standard constructors, so you only need to override the methods you care about. Parcels allocated via `Device::alloc_buffer` / `alloc_texture` notify your allocator automatically on drop when you install it with `with_vram_allocator`.
 
 ## Relationship to TransientAllocator
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,8 +3,9 @@
 use crate::backend::{BufferHandle, GpuBackend};
 use crate::device::Device;
 use crate::types::{BindlessCategory, BindlessHandle, BufferFlags, DataAccess};
+use crate::vram_allocator::{ParcelKind, VramAllocator};
 use anyhow::Result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 /// Types allowed as elements in [`Buffer::with_data`] and [`BufferPool::alloc_with_data`].
 ///
@@ -61,12 +62,19 @@ pub struct Buffer {
     peak_committed_bytes: u64,
     /// Number of completed [`Self::resize_to`] / [`Self::resize_to_uninitialized`] calls.
     resize_count: u32,
+    /// Allocator deed for accounting on drop; set only when allocated via [`Device::alloc_buffer`].
+    deed: Option<Weak<dyn VramAllocator>>,
 }
 
 impl Buffer {
     #[inline]
     pub(crate) fn gpu_buffer_handle(&self) -> BufferHandle {
         self.handle
+    }
+
+    /// Attach the allocator deed (called from [`Device::alloc_buffer`] paths only).
+    pub(crate) fn set_deed(&mut self, deed: Weak<dyn VramAllocator>) {
+        self.deed = Some(deed);
     }
 
     /// Create a new buffer with the specified access pattern.
@@ -143,6 +151,7 @@ impl Buffer {
             flags,
             peak_committed_bytes: allocated_size,
             resize_count: 0,
+            deed: None,
         })
     }
     pub fn new_with_stride(
@@ -183,6 +192,7 @@ impl Buffer {
             flags,
             peak_committed_bytes: size,
             resize_count: 0,
+            deed: None,
         })
     }
 
@@ -236,6 +246,7 @@ impl Buffer {
             flags,
             peak_committed_bytes: bytes.len() as u64,
             resize_count: 0,
+            deed: None,
         };
         buffer.write(0, bytes)?;
         Ok(buffer)
@@ -303,6 +314,7 @@ impl Buffer {
             flags,
             peak_committed_bytes: data.len() as u64,
             resize_count: 0,
+            deed: None,
         };
         buffer.write(0, data)?;
         Ok(buffer)
@@ -540,6 +552,9 @@ impl Drop for Buffer {
         tracing::trace!(size = self.size, access = ?self.access, "Destroying buffer");
         let mut backend = self.backend.lock().unwrap();
         backend.destroy_buffer(self.handle);
+        if let Some(allocator) = self.deed.as_ref().and_then(Weak::upgrade) {
+            allocator.notify_freed(self.allocated_size, self.size, ParcelKind::Buffer);
+        }
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -477,13 +477,10 @@ impl Device {
         element_stride: Option<u32>,
         flags: BufferFlags,
     ) -> anyhow::Result<crate::buffer::Buffer> {
-        let mut buf = self.inner.vram_allocator.alloc_buffer(
-            self,
-            size,
-            access,
-            element_stride,
-            flags,
-        )?;
+        let mut buf =
+            self.inner
+                .vram_allocator
+                .alloc_buffer(self, size, access, element_stride, flags)?;
         buf.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
         Ok(buf)
     }
@@ -526,14 +523,10 @@ impl Device {
         access: SpatialAccess,
         flags: TextureFlags,
     ) -> anyhow::Result<crate::texture::Texture> {
-        let mut tex = self.inner.vram_allocator.alloc_texture(
-            self,
-            width,
-            height,
-            format,
-            access,
-            flags,
-        )?;
+        let mut tex = self
+            .inner
+            .vram_allocator
+            .alloc_texture(self, width, height, format, access, flags)?;
         tex.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
         Ok(tex)
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -477,9 +477,15 @@ impl Device {
         element_stride: Option<u32>,
         flags: BufferFlags,
     ) -> anyhow::Result<crate::buffer::Buffer> {
-        self.inner
-            .vram_allocator
-            .alloc_buffer(self, size, access, element_stride, flags)
+        let mut buf = self.inner.vram_allocator.alloc_buffer(
+            self,
+            size,
+            access,
+            element_stride,
+            flags,
+        )?;
+        buf.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
+        Ok(buf)
     }
 
     /// Allocate a GPU buffer with a capacity hint through the device's [`VramAllocator`].
@@ -492,13 +498,15 @@ impl Device {
         access: DataAccess,
         flags: BufferFlags,
     ) -> anyhow::Result<crate::buffer::Buffer> {
-        self.inner.vram_allocator.alloc_buffer_with_capacity(
+        let mut buf = self.inner.vram_allocator.alloc_buffer_with_capacity(
             self,
             initial_size,
             expected_max,
             access,
             flags,
-        )
+        )?;
+        buf.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
+        Ok(buf)
     }
 
     /// Allocate a GPU texture through the device's [`VramAllocator`].
@@ -518,9 +526,16 @@ impl Device {
         access: SpatialAccess,
         flags: TextureFlags,
     ) -> anyhow::Result<crate::texture::Texture> {
-        self.inner
-            .vram_allocator
-            .alloc_texture(self, width, height, format, access, flags)
+        let mut tex = self.inner.vram_allocator.alloc_texture(
+            self,
+            width,
+            height,
+            format,
+            access,
+            flags,
+        )?;
+        tex.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
+        Ok(tex)
     }
 
     // =======================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod vram_allocator;
 pub use error::GoldyError;
 pub use frame_orchestrator::{FrameHandle, FrameOrchestrator, RetiredFrame};
 pub use gpu_guard::GpuGuard;
-pub use vram_allocator::DeferredPayload;
+pub use vram_allocator::{DeferredPayload, ParcelKind};
 
 // Re-export main types
 pub use buffer::{Buffer, BufferPool, BufferSource, BufferView, StructuredBufferElement};

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -7,8 +7,9 @@
 use crate::backend::{GpuBackend, TextureHandle};
 use crate::device::Device;
 use crate::types::{BindlessCategory, BindlessHandle, SpatialAccess, TextureFlags, TextureFormat};
+use crate::vram_allocator::{ParcelKind, VramAllocator};
 use anyhow::Result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 /// A GPU texture that can be sampled in shaders.
 ///
@@ -25,9 +26,16 @@ pub struct Texture {
     access: SpatialAccess,
     flags: TextureFlags,
     owned: bool,
+    /// Allocator deed for accounting on drop; set only when allocated via [`Device::alloc_texture`].
+    deed: Option<Weak<dyn VramAllocator>>,
 }
 
 impl Texture {
+    /// Attach the allocator deed (called from [`Device::alloc_texture`] only).
+    pub(crate) fn set_deed(&mut self, deed: Weak<dyn VramAllocator>) {
+        self.deed = Some(deed);
+    }
+
     /// Create a new empty texture with the specified access pattern.
     ///
     /// The texture is created with uninitialized data. Use `write()` to
@@ -77,6 +85,7 @@ impl Texture {
             access,
             flags,
             owned: true,
+            deed: None,
         })
     }
 
@@ -339,6 +348,7 @@ impl Texture {
             access: self.access,
             flags: self.flags,
             owned: false,
+            deed: None,
         }
     }
 
@@ -367,6 +377,7 @@ impl Texture {
             access: SpatialAccess::Direct,
             flags: TextureFlags::empty(),
             owned: false,
+            deed: None,
         }
     }
 }
@@ -384,6 +395,10 @@ impl Drop for Texture {
         );
         if let Ok(mut backend) = self.backend.lock() {
             backend.destroy_texture(self.handle);
+        }
+        if let Some(allocator) = self.deed.as_ref().and_then(Weak::upgrade) {
+            let byte_size = self.byte_size() as u64;
+            allocator.notify_freed(byte_size, byte_size, ParcelKind::Texture);
         }
     }
 }

--- a/src/vram_allocator.rs
+++ b/src/vram_allocator.rs
@@ -194,7 +194,7 @@ pub trait VramAllocator: Send + Sync {
     ///
     /// Called automatically from [`Buffer::drop`] / [`Texture::drop`] when the parcel
     /// was allocated through the device's [`VramAllocator`] (and carries a deed).
-    /// Borrowing sub-parcels (e.g. [`BufferView`]) never call this.
+    /// Borrowing sub-parcels (e.g. [`crate::buffer::BufferView`]) never call this.
     ///
     /// `reserved` is the parcel's reserved backing size; `committed` is the runtime's
     /// handed-out estimate (logical size for buffers, [`Texture::byte_size`] for textures).

--- a/src/vram_allocator.rs
+++ b/src/vram_allocator.rs
@@ -120,6 +120,19 @@ impl Default for DeferredPayload {
 }
 
 // -----------------------------------------------------------------------
+// ParcelKind
+// -----------------------------------------------------------------------
+
+/// Zoning / telemetry label for a freed parcel (buffer-kind vs texture-kind).
+///
+/// Not used for separate accounting code paths — only passed to [`VramAllocator::notify_freed`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParcelKind {
+    Buffer,
+    Texture,
+}
+
+// -----------------------------------------------------------------------
 // Trait
 // -----------------------------------------------------------------------
 
@@ -177,18 +190,15 @@ pub trait VramAllocator: Send + Sync {
         Texture::new(device, width, height, format, access, flags)
     }
 
-    /// Notify the allocator that a buffer has been freed.
+    /// Notify the allocator that a deed-holding parcel has been freed.
     ///
-    /// Called automatically by [`Buffer::drop`] when the allocator is installed on the
-    /// device. Implementations should decrement their tracked byte counts here.
-    /// The `size` is the buffer's allocated size at the time of destruction.
-    fn notify_buffer_freed(&self, _size: u64) {}
-
-    /// Notify the allocator that a texture has been freed.
+    /// Called automatically from [`Buffer::drop`] / [`Texture::drop`] when the parcel
+    /// was allocated through the device's [`VramAllocator`] (and carries a deed).
+    /// Borrowing sub-parcels (e.g. [`BufferView`]) never call this.
     ///
-    /// Called automatically by [`Texture::drop`] when the allocator is installed on the
-    /// device. The `byte_size` is [`Texture::byte_size`] at the time of destruction.
-    fn notify_texture_freed(&self, _byte_size: usize) {}
+    /// `reserved` is the parcel's reserved backing size; `committed` is the runtime's
+    /// handed-out estimate (logical size for buffers, [`Texture::byte_size`] for textures).
+    fn notify_freed(&self, _reserved: u64, _committed: u64, _kind: ParcelKind) {}
 
     /// Net bytes allocated by this allocator (allocations minus frees).
     ///
@@ -459,15 +469,10 @@ impl VramAllocator for TrackingVramAllocator {
         Ok(tex)
     }
 
-    fn notify_buffer_freed(&self, size: u64) {
-        self.live_bytes.fetch_sub(size as i64, Ordering::Relaxed);
-        self.inner.notify_buffer_freed(size);
-    }
-
-    fn notify_texture_freed(&self, byte_size: usize) {
+    fn notify_freed(&self, reserved: u64, committed: u64, kind: ParcelKind) {
         self.live_bytes
-            .fetch_sub(byte_size as i64, Ordering::Relaxed);
-        self.inner.notify_texture_freed(byte_size);
+            .fetch_sub(reserved as i64, Ordering::Relaxed);
+        self.inner.notify_freed(reserved, committed, kind);
     }
 
     fn allocated_bytes(&self) -> u64 {
@@ -532,6 +537,17 @@ mod tests {
         Device::from_backend(Box::new(MockBackend::new())).unwrap()
     }
 
+    /// Returns `(base, device, tracking)`. Keep `base` alive for the test body so the
+    /// mock backend device handle remains valid on the cloned `device` handle.
+    fn device_with_tracking() -> (Device, Device, Arc<TrackingVramAllocator>) {
+        let base = test_device();
+        let tracking = Arc::new(TrackingVramAllocator::new(Arc::new(
+            DefaultVramAllocator::new(),
+        )));
+        let device = base.with_vram_allocator(tracking.clone());
+        (base, device, tracking)
+    }
+
     #[test]
     fn default_allocator_creates_buffer() {
         let device = test_device();
@@ -568,26 +584,17 @@ mod tests {
 
     #[test]
     fn tracking_allocator_tracks_bytes() {
-        let device = test_device();
-        let alloc = TrackingVramAllocator::new(Arc::new(DefaultVramAllocator::new()));
+        let (_base, device, tracking) = device_with_tracking();
 
-        assert_eq!(alloc.allocated_bytes(), 0);
+        assert_eq!(tracking.allocated_bytes(), 0);
 
-        let buf = alloc
-            .alloc_buffer(
-                &device,
-                4096,
-                DataAccess::Scattered,
-                None,
-                BufferFlags::empty(),
-            )
+        let buf = device
+            .alloc_buffer(4096, DataAccess::Scattered, None, BufferFlags::empty())
             .unwrap();
-        assert!(alloc.allocated_bytes() >= 4096);
+        assert!(tracking.allocated_bytes() >= 4096);
 
-        let size = buf.allocated_size();
         drop(buf);
-        alloc.notify_buffer_freed(size);
-        assert_eq!(alloc.allocated_bytes(), 0);
+        assert_eq!(tracking.allocated_bytes(), 0);
     }
 
     #[test]
@@ -617,12 +624,10 @@ mod tests {
 
     #[test]
     fn tracking_allocator_texture_tracking() {
-        let device = test_device();
-        let alloc = TrackingVramAllocator::new(Arc::new(DefaultVramAllocator::new()));
+        let (_base, device, tracking) = device_with_tracking();
 
-        let tex = alloc
+        let tex = device
             .alloc_texture(
-                &device,
                 32,
                 32,
                 TextureFormat::Rgba8Unorm,
@@ -630,12 +635,69 @@ mod tests {
                 TextureFlags::COPY_DST | TextureFlags::COPY_SRC,
             )
             .unwrap();
-        let byte_size = tex.byte_size();
-        assert!(alloc.allocated_bytes() > 0);
+        assert!(tracking.allocated_bytes() > 0);
 
         drop(tex);
-        alloc.notify_texture_freed(byte_size);
-        assert_eq!(alloc.allocated_bytes(), 0);
+        assert_eq!(tracking.allocated_bytes(), 0);
+    }
+
+    #[test]
+    fn accounting_round_trip_mixed_parcels() {
+        let (_base, device, tracking) = device_with_tracking();
+        const N: usize = 8;
+
+        for _ in 0..N {
+            assert_eq!(tracking.allocated_bytes(), 0);
+
+            let buf = device
+                .alloc_buffer(1024, DataAccess::Scattered, None, BufferFlags::empty())
+                .unwrap();
+            let hinted = device
+                .alloc_buffer_with_capacity(512, 4096, DataAccess::Scattered, BufferFlags::empty())
+                .unwrap();
+            let tex = device
+                .alloc_texture(
+                    16,
+                    16,
+                    TextureFormat::Rgba8Unorm,
+                    SpatialAccess::Interpolated,
+                    TextureFlags::COPY_DST,
+                )
+                .unwrap();
+
+            let bytes_with_parcels = tracking.allocated_bytes();
+            assert!(bytes_with_parcels > 0);
+
+            let view = buf.create_view(0, 256, Some(4)).unwrap();
+            let bytes_before_view_drop = tracking.allocated_bytes();
+            drop(view);
+            assert_eq!(
+                tracking.allocated_bytes(),
+                bytes_before_view_drop,
+                "BufferView drop must not change allocator accounting"
+            );
+
+            drop(buf);
+            drop(hinted);
+            drop(tex);
+            assert_eq!(tracking.allocated_bytes(), 0);
+        }
+    }
+
+    #[test]
+    fn deed_survives_with_vram_allocator_clone() {
+        let base = test_device();
+        let tracking = Arc::new(TrackingVramAllocator::new(Arc::new(
+            DefaultVramAllocator::new(),
+        )));
+        let device = base.with_vram_allocator(tracking.clone());
+
+        let buf = device
+            .alloc_buffer(2048, DataAccess::Scattered, None, BufferFlags::empty())
+            .unwrap();
+        assert!(tracking.allocated_bytes() >= 2048);
+        drop(buf);
+        assert_eq!(tracking.allocated_bytes(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Use deeds for both buffers and textures. Allocations through `Device::alloc_buffer` and `Device::alloc_texture` now attach a deed that notifies the allocator upon drop, improving memory management and accounting. Updated documentation to reflect these changes and added tests for mixed parcel accounting.