### PR TITLE
Add sampler argument encoder to Metal backend

### DIFF
--- a/src/backend/metal/device.rs
+++ b/src/backend/metal/device.rs
@@ -92,7 +92,7 @@ pub(super) fn create(state: &mut MetalState, adapter_id: u32) -> Result<DeviceHa
     let heap_size = INITIAL_HEAP_SIZE;
     let (heap_allocator, texture_heap) = create_heaps(&device, heap_size);
 
-    let (argument_encoder, texture_encoder, storage_image_encoder) =
+    let (argument_encoder, texture_encoder, storage_image_encoder, sampler_encoder) =
         create_argument_encoders(&device);
 
     let handle = state.next_device_handle;
@@ -116,6 +116,7 @@ pub(super) fn create(state: &mut MetalState, adapter_id: u32) -> Result<DeviceHa
             argument_encoder,
             texture_encoder,
             storage_image_encoder,
+            sampler_encoder,
             resource_registry: ResourceRegistry::new(),
             timeline_next: 1,
             timeline_scheduled_max: 0,
@@ -189,10 +190,12 @@ fn create_heaps(device: &MTLDevice, heap_size: u64) -> (HeapAllocator, TextureHe
     (heap_allocator, texture_heap)
 }
 
-/// Create the three argument encoders used for buffers, sampled textures, and storage images.
-fn create_argument_encoders(
+/// Create the four argument encoders used for buffers, sampled textures, storage images,
+/// and samplers.
+pub(super) fn create_argument_encoders(
     device: &MTLDevice,
 ) -> (
+    mtl::ArgumentEncoder,
     mtl::ArgumentEncoder,
     mtl::ArgumentEncoder,
     mtl::ArgumentEncoder,
@@ -235,7 +238,37 @@ fn create_argument_encoders(
         storage_image_encoder.encoded_length()
     );
 
-    (argument_encoder, texture_encoder, storage_image_encoder)
+    // Encoder for samplers.  Samplers are read-only by nature; the access field
+    // is ignored by Metal for sampler descriptors but we set ReadOnly for clarity.
+    let sampler_arg_desc = mtl::ArgumentDescriptor::new();
+    sampler_arg_desc.set_index(0);
+    sampler_arg_desc.set_data_type(mtl::MTLDataType::Sampler);
+    sampler_arg_desc.set_access(mtl::MTLArgumentAccess::ReadOnly);
+    let sampler_encoder = device.new_argument_encoder(mtl::Array::from_slice(&[sampler_arg_desc]));
+    let sampler_stride = sampler_encoder.encoded_length();
+    tracing::info!(
+        "Created sampler ArgumentEncoder (encoded_length={})",
+        sampler_stride
+    );
+
+    // Every resource category in the argument buffer is laid out as
+    // MAX_RESOURCES_PER_CATEGORY × 8 bytes.  ARGUMENT_BUFFER_SIZE is derived
+    // from that assumption.  Fail loudly at device creation if this GPU returns
+    // a different stride so that sampler offsets never silently diverge.
+    assert_eq!(
+        sampler_stride, 8,
+        "Metal sampler argument encoder reported encoded_length={sampler_stride}, \
+         expected 8 (MTLResourceID size on Apple Silicon / Intel / AMD). \
+         ARGUMENT_BUFFER_SIZE and the sampler slot layout assume an 8-byte stride; \
+         please update ARGUMENT_BUFFER_SIZE and GPU_RESOURCE_STRIDE to match."
+    );
+
+    (
+        argument_encoder,
+        texture_encoder,
+        storage_image_encoder,
+        sampler_encoder,
+    )
 }
 
 /// Destroy a logical device and clean up resources owned by it.

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -1005,6 +1005,72 @@ mod tests {
         assert!(!backend.is_device_valid(device));
     }
 
+    /// Regression test for issue #162 (secondary concern): the sampler argument
+    /// encoder's stride must match the 8-byte-per-slot assumption baked into
+    /// `ARGUMENT_BUFFER_SIZE` and the sampler category layout.
+    ///
+    /// Before the fix, `sampler.rs` hardcoded `GPU_RESOURCE_ID_BYTES = 8` as the
+    /// per-slot stride and wrote sampler GPU resource IDs via an unsafe pointer
+    /// cast.  If Metal ever returned a different `encoded_length()` for a sampler
+    /// argument encoder (e.g. on a future GPU family), the sampler slots would
+    /// silently diverge from the buffer/texture slots, corrupting all bindless
+    /// sampler reads.
+    ///
+    /// The fix:
+    ///   1. A `sampler_encoder` (`MTLDataType::Sampler`) is created at device
+    ///      construction and stored in `LogicalDevice`.
+    ///   2. `sampler.rs` derives the stride from `sampler_encoder.encoded_length()`
+    ///      and uses `set_argument_buffer` + `set_sampler_state` to write — the
+    ///      same pattern as buffer and texture encoding.
+    ///   3. Device creation asserts `encoded_length() == 8` and panics loudly if
+    ///      the assumption is ever violated.
+    ///
+    /// This test verifies that a freshly-constructed device reports stride 8 for
+    /// the sampler encoder, and that the stride exposed by `create_argument_encoders`
+    /// matches the per-slot size implied by `ARGUMENT_BUFFER_SIZE`.
+    #[test]
+    fn test_sampler_encoder_stride() {
+        use super::device::create_argument_encoders;
+        use super::types::ARGUMENT_BUFFER_SIZE;
+        use ::metal::Device as MTLDevice;
+
+        let device = MTLDevice::system_default().expect("No Metal device available");
+        let (buf_enc, tex_enc, si_enc, smp_enc) = create_argument_encoders(&device);
+
+        // All four encoders must report the same 8-byte stride.
+        assert_eq!(
+            smp_enc.encoded_length(),
+            8,
+            "sampler encoder stride is {}, expected 8",
+            smp_enc.encoded_length()
+        );
+        assert_eq!(
+            buf_enc.encoded_length(),
+            smp_enc.encoded_length(),
+            "buffer and sampler encoder strides differ"
+        );
+        assert_eq!(
+            tex_enc.encoded_length(),
+            smp_enc.encoded_length(),
+            "texture and sampler encoder strides differ"
+        );
+        assert_eq!(
+            si_enc.encoded_length(),
+            smp_enc.encoded_length(),
+            "storage-image and sampler encoder strides differ"
+        );
+
+        // The stride must evenly divide ARGUMENT_BUFFER_SIZE so that all 5
+        // resource categories fit without overflow.
+        assert_eq!(
+            ARGUMENT_BUFFER_SIZE % smp_enc.encoded_length(),
+            0,
+            "ARGUMENT_BUFFER_SIZE={ARGUMENT_BUFFER_SIZE} is not a multiple of \
+             sampler stride={}",
+            smp_enc.encoded_length()
+        );
+    }
+
     #[test]
     fn test_metal_buffer_operations() {
         let mut backend = MetalBackend::new().unwrap();

--- a/src/backend/metal/sampler.rs
+++ b/src/backend/metal/sampler.rs
@@ -6,11 +6,6 @@ use super::utils::{address_mode_to_mtl, compare_to_mtl, filter_to_mtl, mipmap_mo
 use ::metal as mtl;
 use anyhow::{Context, Result};
 
-/// Size in bytes of a single GPU resource ID entry in the argument buffer.
-/// Each sampler is encoded as one `MTLResourceID` value which is 8 bytes on all
-/// Apple Silicon and Intel platforms.
-const GPU_RESOURCE_ID_BYTES: u64 = 8;
-
 /// Create a sampler.
 pub(super) fn create(
     state: &mut MetalState,
@@ -52,25 +47,25 @@ pub(super) fn create(
         encoding_index
     );
 
-    let offset = (encoding_index as u64) * GPU_RESOURCE_ID_BYTES;
-    if offset + GPU_RESOURCE_ID_BYTES <= ARGUMENT_BUFFER_SIZE {
-        let gpu_id = sampler.gpu_resource_id();
-        unsafe {
-            let ptr = logical_device
-                .argument_buffer
-                .contents()
-                .add(offset as usize) as *mut u64;
-            *ptr = gpu_id._impl;
-        }
+    let encoded_length = logical_device.sampler_encoder.encoded_length();
+    let offset = (encoding_index as u64) * encoded_length;
+    if offset + encoded_length <= ARGUMENT_BUFFER_SIZE {
+        logical_device
+            .sampler_encoder
+            .set_argument_buffer(&logical_device.argument_buffer, offset);
+        logical_device
+            .sampler_encoder
+            .set_sampler_state(0, &sampler);
         tracing::trace!(
-            "Encoded sampler {} GPU ID at arg buffer offset {}",
+            "Encoded sampler {} at arg buffer offset {} (stride={})",
             handle,
-            offset
+            offset,
+            encoded_length,
         );
     } else {
         tracing::error!(
             "Sampler {handle}: argument buffer overflow — \
-             offset {offset} + GPU_RESOURCE_ID_BYTES {GPU_RESOURCE_ID_BYTES} \
+             offset {offset} + encoded_length {encoded_length} \
              exceeds ARGUMENT_BUFFER_SIZE {ARGUMENT_BUFFER_SIZE}; \
              sampler will not be encoded and shaders may see a stale binding"
         );

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -626,6 +626,10 @@ pub(crate) struct LogicalDevice {
     pub texture_encoder: ArgumentEncoder,
     /// Encoder for writing storage images (ReadWrite) to the argument buffer
     pub storage_image_encoder: ArgumentEncoder,
+    /// Encoder for writing samplers to the argument buffer (MTLDataType::Sampler).
+    /// Its `encoded_length()` is the authoritative per-slot stride for the sampler
+    /// category; never hardcode 8 when encoding sampler offsets.
+    pub sampler_encoder: ArgumentEncoder,
     /// Registry tracking resource indices in the argument buffer
     pub resource_registry: ResourceRegistry,
     /// Device-global submission sequence (contexts signal their own shared events).


### PR DESCRIPTION
Enhanced the Metal backend by introducing a sampler argument encoder, which is now created during device initialization. Updated the `create_argument_encoders` function to include the sampler encoder, ensuring it adheres to the expected 8-byte stride for sampler resources. Added a regression test to verify the sampler encoder's stride and its alignment with the argument buffer size, preventing potential resource binding issues. This change improves resource management and consistency in GPU operations.

closes #162 