### PR TITLE
Add tests for texture slot management and allocator behavior

### DIFF
--- a/src/placement_heap.rs
+++ b/src/placement_heap.rs
@@ -782,4 +782,98 @@ mod tests {
             "same keys on second frame must be cache hits"
         );
     }
+
+    fn sample_texture_keys() -> Vec<TransientTextureKey> {
+        vec![TransientTextureKey {
+            width: 4,
+            height: 4,
+            format: TextureFormat::Rgba8Unorm,
+        }]
+    }
+
+    /// `slot_timelines` must withhold a cached texture while the slot epoch is in-flight.
+    #[test]
+    fn texture_slot_gate_withholds_until_retired() {
+        let device = test_device();
+        let mut heap = PlacementHeap::with_capacity(&device, 64 * 1024).unwrap();
+        heap.configure_pages(1024, 2, &device).unwrap();
+
+        let keys = sample_texture_keys();
+        let slot = 0usize;
+        const SLOT_EPOCH: TimelineValue = 10;
+
+        let _ = heap.advance_page();
+        let handles_initial = heap
+            .get_or_create_textures(&device, &keys, slot, 0)
+            .unwrap();
+        assert_eq!(heap.texture_create_count(), 1);
+        heap.stamp_pending(SLOT_EPOCH);
+
+        // Wrap back to the same page slot before the GPU has retired SLOT_EPOCH.
+        let _ = heap.advance_page();
+        let _ = heap.advance_page();
+
+        let handles_in_flight = heap
+            .get_or_create_textures(&device, &keys, slot, SLOT_EPOCH - 1)
+            .unwrap();
+        assert_eq!(
+            heap.texture_create_count(),
+            2,
+            "in-flight slot must allocate a fresh texture, not reuse the cached handle"
+        );
+        assert_ne!(
+            handles_initial[0], handles_in_flight[0],
+            "in-flight reuse would be a write-write race on the same TextureHandle"
+        );
+
+        // Once retired_timeline catches up, the cached texture is safe to hand back.
+        let handles_retired = heap
+            .get_or_create_textures(&device, &keys, slot, SLOT_EPOCH)
+            .unwrap();
+        assert_eq!(
+            heap.texture_create_count(),
+            2,
+            "retired slot must be a cache hit (no extra Texture::new)"
+        );
+        assert_eq!(
+            handles_retired[0], handles_in_flight[0],
+            "retired path should return the texture created for the in-flight render"
+        );
+    }
+
+    /// Two concurrent renders sharing one heap that wrap to the same page slot must not
+    /// reuse a live `TextureHandle` before the prior occupant retires.
+    #[test]
+    fn texture_slot_gate_concurrent_wraparound_race() {
+        let device = test_device();
+        let mut heap = PlacementHeap::with_capacity(&device, 64 * 1024).unwrap();
+        heap.configure_pages(1024, 2, &device).unwrap();
+
+        let keys = sample_texture_keys();
+
+        // Render A: page slot 0, timeline 5 still in flight.
+        let _ = heap.advance_page();
+        let render_a = heap.get_or_create_textures(&device, &keys, 0, 0).unwrap();
+        heap.stamp_pending(5);
+
+        // Render B: uses slot 1, then wraps to slot 0 while render A is still in flight.
+        let _ = heap.advance_page();
+        let _ = heap.advance_page();
+        let render_b = heap.get_or_create_textures(&device, &keys, 0, 3).unwrap();
+
+        assert_eq!(
+            heap.texture_create_count(),
+            2,
+            "wraparound while slot epoch=5 > retired=3 must force a fresh texture"
+        );
+        assert_ne!(
+            render_a[0], render_b[0],
+            "concurrent renders must not share a TextureHandle on the same page slot"
+        );
+
+        // After retirement, slot 0 reuses render B's texture.
+        let render_c = heap.get_or_create_textures(&device, &keys, 0, 5).unwrap();
+        assert_eq!(heap.texture_create_count(), 2);
+        assert_eq!(render_c[0], render_b[0]);
+    }
 }

--- a/src/transient_allocator.rs
+++ b/src/transient_allocator.rs
@@ -999,4 +999,68 @@ mod tests {
             .expect("wait");
         a.begin_frame(&device, 0).expect("begin 2 should not block");
     }
+
+    /// `end_frame` may arrive after the next `begin_frame` (surface-present path).
+    /// Mid-frame frees with `epoch=None` must still be stamped and reclaimed correctly.
+    #[test]
+    fn heap_end_frame_after_next_begin_frame() {
+        let device = test_device();
+        let mut alloc = HeapTransientAllocator::new(&device, heap_config()).unwrap();
+
+        alloc.begin_frame(&device, 0).unwrap();
+        let v1 = alloc.alloc(&device, 1024, Some(4)).unwrap();
+        let (v1_off, v1_sz) = (v1.offset(), v1.size());
+        alloc.free(v1_off, v1_sz, None);
+
+        // Next frame begins before the previous frame's epoch is known.
+        alloc.begin_frame(&device, 0).unwrap();
+        let v2 = alloc.alloc(&device, 1024, Some(4)).unwrap();
+        assert_ne!(
+            v2.offset(),
+            v1_off,
+            "None-epoch range must not be reused before end_frame stamps it"
+        );
+
+        let mut graph = crate::task_graph::TaskGraph::new();
+        let ctx = device.create_context().unwrap();
+        let tv = ctx.submit(&mut graph).expect("submit");
+        alloc.end_frame(&device, tv);
+
+        ctx.wait_until(tv).unwrap();
+        alloc.begin_frame(&device, 0).unwrap();
+        let v3 = alloc.alloc(&device, 1024, Some(4)).unwrap();
+        assert_eq!(
+            v3.offset(),
+            v1_off,
+            "stamped range should be reused after the epoch retires"
+        );
+    }
+
+    /// `begin_frame` must block until the previous frame's epoch retires before resetting.
+    #[test]
+    fn bump_reset_begin_frame_blocks_until_epoch_retires() {
+        let device = test_device();
+        let mut alloc = BumpResetAllocator::new(&device, small_config()).expect("create");
+
+        alloc.begin_frame(&device, 0).expect("begin 1");
+        let v1 = alloc.alloc(&device, 512, Some(4)).expect("alloc");
+        let v1_off = v1.offset();
+        let mut graph = crate::task_graph::TaskGraph::new();
+        let ctx = device.create_context().unwrap();
+        let tv = ctx.submit(&mut graph).expect("submit");
+        alloc.end_frame(&device, tv);
+
+        // Do not wait — begin_frame should internally wait for tv before reset.
+        alloc
+            .begin_frame(&device, 0)
+            .expect("begin 2 blocks then resets");
+        let v2 = alloc
+            .alloc(&device, 512, Some(4))
+            .expect("alloc after reset");
+        assert_eq!(
+            v2.offset(),
+            v1_off,
+            "bump pool should reset and reuse offset 0 after epoch retires"
+        );
+    }
 }

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -2786,6 +2786,97 @@ fn test_regular_buffer_write_then_copy() {
     );
 }
 
+/// Scale each element: `data[id.x] = (id.x + 1) * 100`.
+const WRITE_SCALE_SHADER: &str = r#"
+import goldy_exp;
+
+[goldy_compute]
+[numthreads(64, 1, 1)]
+void cs_main(Scattered<uint> data, ThreadId id) {
+    if (id.x < 64) data[id.x] = (id.x + 1u) * 100u;
+}
+"#;
+
+/// Two transients with disjoint wave lifetimes alias the same heap offset via graph
+/// coloring. Wave 0 writes `t0`; wave 1 overwrites the aliased bytes via `t1` with a
+/// different pattern; wave 2 copies `t1` to a regular output buffer.
+#[test]
+fn test_transient_buffer_aliased_disjoint_waves() {
+    use goldy::{NodeAccess, TaskGraph};
+
+    let device = make_device();
+    let ctx = submission_context(&device);
+
+    let iota_shader =
+        ShaderModule::from_slang(&device, WRITE_IOTA_SHADER).expect("compile iota shader");
+    let iota_pipeline = ComputePipeline::new(&device, &iota_shader).expect("create iota pipeline");
+
+    let scale_shader =
+        ShaderModule::from_slang(&device, WRITE_SCALE_SHADER).expect("compile scale shader");
+    let scale_pipeline =
+        ComputePipeline::new(&device, &scale_shader).expect("create scale pipeline");
+
+    let copy_shader = ShaderModule::from_slang(&device, COPY_SHADER).expect("compile copy shader");
+    let copy_pipeline = ComputePipeline::new(&device, &copy_shader).expect("create copy pipeline");
+
+    const N: usize = 64;
+    let byte_size = (N * core::mem::size_of::<u32>()) as u64;
+
+    let bridge = device
+        .alloc_buffer(byte_size, BufferKind::Scattered, None, BufferFlags::empty())
+        .expect("bridge buffer");
+    let output = device
+        .alloc_buffer(byte_size, BufferKind::Scattered, None, BufferFlags::empty())
+        .expect("output buffer");
+    let output_uav = output
+        .resource_index(ResourceAccess::Write)
+        .expect("output UAV");
+
+    let mut graph = TaskGraph::new();
+    let t0 = graph.transient_buffer(byte_size);
+    let t1 = graph.transient_buffer(byte_size);
+
+    // Wave 0: populate t0. The bridge write is a schedule-only edge (shader has one slot).
+    graph
+        .node("wave0_iota", &iota_pipeline)
+        .bind_transient_buffer(t0, NodeAccess::Write)
+        .bind_buffer(&bridge, NodeAccess::Write)
+        .bind_resources_raw_slice(&[u32::MAX])
+        .dispatch(1, 1, 1);
+
+    // Wave 1: bridge read forces wave ordering; overwrite aliased bytes via t1.
+    // Transient is listed first so the single shader slot resolves to t1 (not bridge).
+    graph
+        .node("wave1_scale", &scale_pipeline)
+        .bind_transient_buffer(t1, NodeAccess::Write)
+        .bind_buffer(&bridge, NodeAccess::Read)
+        .bind_resources_raw_slice(&[u32::MAX])
+        .dispatch(1, 1, 1);
+
+    // Wave 2: copy the final aliased transient to a regular buffer for readback.
+    graph
+        .node("wave2_copy", &copy_pipeline)
+        .bind_transient_buffer(t1, NodeAccess::ReadWrite)
+        .bind_buffer(&output, NodeAccess::Write)
+        .bind_resources_raw_slice(&[u32::MAX, output_uav])
+        .dispatch(1, 1, 1);
+
+    graph
+        .dispatch(&ctx)
+        .expect("dispatch aliased transient graph");
+
+    let mut raw = vec![0u8; byte_size as usize];
+    output.read_to_cpu(&device, &mut raw).expect("read output");
+    let result: &[u32] = bytemuck::cast_slice(&raw);
+
+    let expected: Vec<u32> = (1..=N as u32).map(|i| i * 100).collect();
+    assert_eq!(
+        result,
+        &expected[..],
+        "aliased transient buffers produced wrong data — graph coloring or heap placement bug"
+    );
+}
+
 // ─── collectives: GPU execution tests ────────────────────────────────────────
 //
 // Each test runs a small compute shader that exercises one collective algorithm


### PR DESCRIPTION
Implemented new tests in `placement_heap.rs` to verify that cached textures are correctly withheld during in-flight operations and that concurrent renders do not share `TextureHandle` instances. Added tests in `transient_allocator.rs` to ensure proper behavior when `end_frame` is called after `begin_frame`, and that `begin_frame` blocks until the previous frame's epoch retires. These additions enhance the robustness of the texture and memory management systems.