### PR TITLE
Refactor buffer and texture slot management in DX12 and Vulkan backends

### DIFF
--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -1274,7 +1274,7 @@ pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
             }
 
             if buffer.transient_placed {
-                device.resource_registry.unregister_buffer(buffer_handle);
+                device.reclaim_buffer_slots(buffer_handle);
                 return;
             }
             if buffer.coherent_readback_mapped.is_some() {

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -50,8 +50,18 @@ fn collect_bindless_slots_from_gpu_commands(
                     if base + layout_size <= arg_data.len() {
                         let layout: &PushLayout =
                             bytemuck::from_bytes(&arg_data[base..base + layout_size]);
+                        // Skip zero entries: PushLayout::bindless is a fixed [u16; N]
+                        // array default-initialised to 0. Positions the caller did not
+                        // fill remain 0 and do not correspond to an actual binding.
+                        // Tracking them would create spurious slot_last_seen[0] entries
+                        // on every batch submit, causing CbvSrvUav(0) reclamation to
+                        // wait for unrelated contexts. BindResourcesRaw/Typed are not
+                        // filtered because those vecs contain only the slots the caller
+                        // explicitly provided.
                         for &idx in &layout.bindless {
-                            slots.push(DeferredSlot::CbvSrvUav(idx as u32));
+                            if idx != 0 {
+                                slots.push(DeferredSlot::CbvSrvUav(idx as u32));
+                            }
                         }
                     }
                 }

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -1,13 +1,14 @@
 //! Compute pipeline and dispatch logic.
 
 use super::super::shared;
+use super::super::shared::{PushLayout, DISPATCH_BATCH_STRIDE};
 use super::barriers;
 use super::pso_cache;
 use super::shader;
 use super::staging;
-use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, Dx12State};
+use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, DeferredSlot, Dx12State};
 use super::{ComputePipelineHandle, ContextHandle, DeviceHandle, RenderTargetHandle, ShaderHandle};
-use crate::backend::{GpuCommand, GraphCommand};
+use crate::backend::{GpuCommand, GraphCommand, RenderCommand};
 use crate::timeline::TimelineValue;
 use crate::tracy_zone;
 use anyhow::{Context, Result};
@@ -16,6 +17,96 @@ use windows::Win32::Graphics::Direct3D12::*;
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_UNKNOWN, DXGI_SAMPLE_DESC};
 
 use crate::task_graph::{NodeAccessUnion, SlotUsageSet, UsageKindFlags};
+
+/// Collect bindless heap indices referenced by a flat GPU command stream.
+fn collect_bindless_slots_from_gpu_commands(
+    commands: &[GpuCommand],
+    buffers: &std::collections::HashMap<super::BufferHandle, types::BufferState>,
+) -> Vec<DeferredSlot> {
+    let mut slots = Vec::new();
+    for cmd in commands {
+        match cmd {
+            GpuCommand::BindResources {
+                buffers: buf_handles,
+            } => {
+                for h in buf_handles {
+                    if let Some(offset) = buffers.get(h).and_then(|b| b.bindless_offset) {
+                        slots.push(DeferredSlot::CbvSrvUav(offset));
+                    }
+                }
+            }
+            GpuCommand::BindResourcesRaw { indices, .. } => {
+                slots.extend(indices.iter().copied().map(DeferredSlot::CbvSrvUav));
+            }
+            GpuCommand::BindResourcesTyped { handles } => {
+                slots.extend(handles.iter().map(|h| DeferredSlot::CbvSrvUav(h.index())));
+            }
+            GpuCommand::DispatchBatch {
+                arg_data, count, ..
+            } => {
+                let layout_size = std::mem::size_of::<PushLayout>();
+                for i in 0..*count as usize {
+                    let base = i * DISPATCH_BATCH_STRIDE;
+                    if base + layout_size <= arg_data.len() {
+                        let layout: &PushLayout =
+                            bytemuck::from_bytes(&arg_data[base..base + layout_size]);
+                        for &idx in &layout.bindless {
+                            slots.push(DeferredSlot::CbvSrvUav(idx as u32));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    slots
+}
+
+/// Collect bindless heap indices from a mixed compute/render graph submission.
+fn collect_bindless_slots_from_graph_commands(
+    commands: &[GraphCommand],
+    buffers: &std::collections::HashMap<super::BufferHandle, types::BufferState>,
+) -> Vec<DeferredSlot> {
+    let mut slots = Vec::new();
+    for gc in commands {
+        match gc {
+            GraphCommand::Compute(cmd) => {
+                slots.extend(collect_bindless_slots_from_gpu_commands(
+                    std::slice::from_ref(cmd),
+                    buffers,
+                ));
+            }
+            GraphCommand::Render {
+                commands: render_cmds,
+                ..
+            } => {
+                for rc in render_cmds {
+                    match rc {
+                        RenderCommand::BindResources {
+                            buffers: buf_handles,
+                        } => {
+                            for h in buf_handles {
+                                if let Some(offset) = buffers.get(h).and_then(|b| b.bindless_offset)
+                                {
+                                    slots.push(DeferredSlot::CbvSrvUav(offset));
+                                }
+                            }
+                        }
+                        RenderCommand::BindResourcesRaw { indices, .. } => {
+                            slots.extend(indices.iter().copied().map(DeferredSlot::CbvSrvUav));
+                        }
+                        RenderCommand::BindResourcesTyped { handles } => {
+                            slots
+                                .extend(handles.iter().map(|h| DeferredSlot::CbvSrvUav(h.index())));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    slots
+}
 
 /// Convert the Koubaa-level producer/consumer kind set to a DX12 sync scope.
 ///
@@ -1286,6 +1377,7 @@ struct SubmitFinish {
     fence_value: u64,
     slot_idx: usize,
     retain_key: Option<u64>,
+    used_slots: Vec<DeferredSlot>,
 }
 
 struct StagingFinish {
@@ -1330,6 +1422,7 @@ fn execute_signal_and_finish(
         fence_value,
         slot_idx,
         retain_key,
+        used_slots,
     } = submit;
     let StagingFinish {
         texture_uploads: staged_texture_uploads,
@@ -1356,6 +1449,10 @@ fn execute_signal_and_finish(
     }
 
     let cmd_list: ID3D12CommandList = command_list.cast().context("Failed to cast command list")?;
+
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.record_slot_usage(ctx, fence_value, used_slots.iter().copied());
+    }
 
     let logical_device = state.devices.get(&device_handle).unwrap();
     let ctx_fence = state
@@ -1403,6 +1500,7 @@ fn execute_signal_and_finish(
                     fingerprint: key,
                     command_list: cl,
                     slot_idx,
+                    used_slots,
                 });
             }
         }
@@ -1412,6 +1510,7 @@ fn execute_signal_and_finish(
     let retired = super::context::device_retired(state, device_handle);
     if let Some(dev) = state.devices.get_mut(&device_handle) {
         dev.process_deletion_queue_up_to(retired);
+        dev.drain_ready_slot_reclamations(&state.contexts);
     }
 
     state
@@ -1655,6 +1754,7 @@ pub(super) fn submit(
         }
     }
 
+    let used_slots = collect_bindless_slots_from_gpu_commands(commands, &state.buffers);
     execute_signal_and_finish(
         state,
         &command_list,
@@ -1665,6 +1765,7 @@ pub(super) fn submit(
             fence_value,
             slot_idx,
             retain_key: None,
+            used_slots,
         },
         StagingFinish {
             texture_uploads: staged_texture_uploads,
@@ -1961,6 +2062,7 @@ pub(super) fn submit_graph(
         }
     }
 
+    let used_slots = collect_bindless_slots_from_graph_commands(commands, &state.buffers);
     let result = execute_signal_and_finish(
         state,
         &command_list,
@@ -1971,6 +2073,7 @@ pub(super) fn submit_graph(
             fence_value,
             slot_idx,
             retain_key,
+            used_slots,
         },
         StagingFinish {
             texture_uploads: staged_texture_uploads,
@@ -2006,12 +2109,14 @@ pub(super) fn try_resubmit_retained(
     let retained = {
         let sc = state.contexts.get(&ctx).context("Invalid context handle")?;
         match sc.retained_graph.as_ref() {
-            Some(r) if r.fingerprint == key => Some((r.command_list.clone(), r.slot_idx)),
+            Some(r) if r.fingerprint == key => {
+                Some((r.command_list.clone(), r.slot_idx, r.used_slots.clone()))
+            }
             _ => None,
         }
     };
 
-    let Some((command_list, slot_idx)) = retained else {
+    let Some((command_list, slot_idx, used_slots)) = retained else {
         return Ok(None);
     };
 
@@ -2046,6 +2151,10 @@ pub(super) fn try_resubmit_retained(
             .context("Failed to signal context fence after retained resubmit")?;
     }
 
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.record_slot_usage(ctx, fence_value, used_slots.iter().copied());
+    }
+
     if let Some(sc) = state.contexts.get_mut(&ctx) {
         if let Some(slot) = sc.compute_allocator_pool.get_mut(slot_idx) {
             slot.fence_value = fence_value;
@@ -2056,6 +2165,7 @@ pub(super) fn try_resubmit_retained(
     let retired = super::context::device_retired(state, device_handle);
     if let Some(dev) = state.devices.get_mut(&device_handle) {
         dev.process_deletion_queue_up_to(retired);
+        dev.drain_ready_slot_reclamations(&state.contexts);
     }
 
     Ok(Some(fence_value))

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -443,6 +443,8 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             resource_registry,
             zero_buffer,
             deletion_queue: super::types::DeletionQueue::new(),
+            slot_last_seen: HashMap::new(),
+            pending_slot_reclamations: Vec::new(),
             graphics_pso_blobs,
             compute_pso_blobs,
             pso_disk_cache_dirty: false,

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -964,6 +964,7 @@ impl GpuBackend for Dx12Backend {
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(value.min(retired));
+            ld.drain_ready_slot_reclamations(&self.state.contexts);
         }
         Ok(())
     }
@@ -999,6 +1000,7 @@ impl GpuBackend for Dx12Backend {
             let retired = context::device_retired(&self.state, device_handle);
             if let Some(dev) = self.state.devices.get_mut(&device_handle) {
                 dev.process_deletion_queue_up_to(value.min(retired));
+                dev.drain_ready_slot_reclamations(&self.state.contexts);
             }
         }
         Ok(ok)
@@ -1236,6 +1238,7 @@ impl GpuBackend for Dx12Backend {
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
+            ld.drain_ready_slot_reclamations(&self.state.contexts);
         }
     }
 

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -386,6 +386,12 @@ pub(super) fn render(
         .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
+    // Reset the single shared command allocator. This is safe only because we do
+    // a blocking CPU wait at the end of every render_to_target call (see below);
+    // that guarantees no GPU work recorded with this allocator is still in-flight.
+    // The compute/submit_graph paths avoid this stall by using a pool of allocators
+    // (ComputeAllocatorSlot) where each slot is reset only after its fence retires.
+    // Upgrading render_to_target to a pool would eliminate the wait but is not yet done.
     unsafe { logical_device.command_allocator.Reset() }
         .context("Failed to reset command allocator")?;
 
@@ -428,6 +434,8 @@ pub(super) fn render(
             .Signal(&logical_device.fence, fence_value)
     }
     .context("Failed to signal fence")?;
+    // Blocking wait — required so the shared command_allocator can be safely
+    // Reset() before the next render_to_target call (see comment above Reset()).
     wait_for_fence(&logical_device.fence, fence_value)?;
 
     if let Some(dev) = state.devices.get_mut(&device_handle) {

--- a/src/backend/dx12/sampler.rs
+++ b/src/backend/dx12/sampler.rs
@@ -69,7 +69,11 @@ pub(super) fn create(
 
 /// Destroy a sampler.
 pub(super) fn destroy(state: &mut Dx12State, sampler_handle: SamplerHandle) {
-    state.samplers.remove(&sampler_handle);
+    if let Some(sampler) = state.samplers.remove(&sampler_handle) {
+        if let Some(ld) = state.devices.get_mut(&sampler.device_handle) {
+            ld.reclaim_sampler_slots(sampler_handle);
+        }
+    }
 }
 
 /// Get the bindless index for a sampler.

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -1062,7 +1062,7 @@ pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
     if let Some(tex) = state.textures.remove(&texture_handle) {
         if let Some(dev) = state.devices.get_mut(&tex.device_handle) {
             if tex.transient_placed {
-                dev.resource_registry.unregister_texture(texture_handle);
+                dev.reclaim_texture_slots(texture_handle);
                 return;
             }
             let last_fence = dev.timeline_next.saturating_sub(1);

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -134,29 +134,56 @@ impl ResourceRegistry {
         self.cbv_srv_uav.alloc()
     }
 
-    /// Unregister a buffer, returning all of its descriptor slots to the free list.
-    ///
-    /// Storage buffers may occupy two slots (UAV primary + SRV secondary); both are
-    /// recycled here. Without this, per-frame buffer churn exhausts the 16 384-slot
-    /// heap in seconds and subsequent descriptor writes corrupt adjacent entries.
-    pub fn unregister_buffer(&mut self, handle: BufferHandle) {
+    /// Remove a buffer's handle mappings and return its raw descriptor slot(s)
+    /// without recycling them (caller must [`LogicalDevice::queue_slot_reclamation`]).
+    pub fn extract_buffer_slots(&mut self, handle: BufferHandle) -> Vec<u32> {
+        let mut slots = Vec::new();
         if let Some(offset) = self.buffer_offsets.remove(&handle) {
-            self.cbv_srv_uav.free(offset);
+            slots.push(offset);
         }
         if let Some(offset) = self.buffer_srv_offsets.remove(&handle) {
-            self.cbv_srv_uav.free(offset);
+            slots.push(offset);
+        }
+        slots
+    }
+
+    /// Remove a texture's handle mappings and return its raw descriptor slot(s)
+    /// without recycling them (caller must [`LogicalDevice::queue_slot_reclamation`]).
+    pub fn extract_texture_slots(&mut self, handle: TextureHandle) -> Vec<u32> {
+        let mut slots = Vec::new();
+        if let Some(offset) = self.texture_offsets.remove(&handle) {
+            slots.push(offset);
+        }
+        if let Some(offset) = self.texture_uav_offsets.remove(&handle) {
+            slots.push(offset);
+        }
+        slots
+    }
+
+    /// Return a CBV/SRV/UAV slot to the free list (immediate reclaim).
+    pub fn free_cbv_srv_uav_slot(&mut self, slot: u32) {
+        self.cbv_srv_uav.free(slot);
+    }
+
+    /// Remove a sampler's handle mapping and return its slot without recycling.
+    pub fn extract_sampler_slots(&mut self, handle: SamplerHandle) -> Vec<DeferredSlot> {
+        if let Some(offset) = self.sampler_offsets.remove(&handle) {
+            vec![DeferredSlot::Sampler(offset)]
+        } else {
+            Vec::new()
         }
     }
 
-    /// Unregister a texture, returning all of its descriptor slots to the free list.
-    ///
-    /// Storage textures may occupy two slots (SRV + UAV); both are recycled here.
-    pub fn unregister_texture(&mut self, handle: TextureHandle) {
-        if let Some(offset) = self.texture_offsets.remove(&handle) {
-            self.cbv_srv_uav.free(offset);
-        }
-        if let Some(offset) = self.texture_uav_offsets.remove(&handle) {
-            self.cbv_srv_uav.free(offset);
+    /// Return a sampler slot to the free list (immediate reclaim).
+    pub fn free_sampler_slot(&mut self, slot: u32) {
+        self.sampler.free(slot);
+    }
+
+    /// Free a [`DeferredSlot`] — dispatches to the correct heap allocator.
+    pub fn free_deferred_slot(&mut self, slot: DeferredSlot) {
+        match slot {
+            DeferredSlot::CbvSrvUav(s) => self.cbv_srv_uav.free(s),
+            DeferredSlot::Sampler(s) => self.sampler.free(s),
         }
     }
 
@@ -194,6 +221,18 @@ impl ResourceRegistry {
 mod registry_tests {
     use super::*;
 
+    fn free_buffer_slots(reg: &mut ResourceRegistry, handle: BufferHandle) {
+        for slot in reg.extract_buffer_slots(handle) {
+            reg.free_cbv_srv_uav_slot(slot);
+        }
+    }
+
+    fn free_texture_slots(reg: &mut ResourceRegistry, handle: TextureHandle) {
+        for slot in reg.extract_texture_slots(handle) {
+            reg.free_cbv_srv_uav_slot(slot);
+        }
+    }
+
     /// Simulate the per-frame create/destroy churn that ekrano generates for transient
     /// pool-view buffers. The counter must stay bounded — well below MAX_BINDLESS_CBV_SRV_UAV
     /// — even after far more iterations than the heap limit.
@@ -203,7 +242,7 @@ mod registry_tests {
         for i in 0..50_000u64 {
             let handle = i as BufferHandle;
             reg.register_buffer_uav(handle);
-            reg.unregister_buffer(handle);
+            free_buffer_slots(&mut reg, handle);
         }
         assert_eq!(
             reg.cbv_srv_uav.next_fresh(),
@@ -222,7 +261,7 @@ mod registry_tests {
             let handle = i as BufferHandle;
             reg.register_buffer_uav(handle);
             reg.register_buffer_srv(handle);
-            reg.unregister_buffer(handle);
+            free_buffer_slots(&mut reg, handle);
         }
         assert_eq!(
             reg.cbv_srv_uav.next_fresh(),
@@ -244,7 +283,7 @@ mod registry_tests {
             let handle = i as TextureHandle;
             reg.register_texture(handle);
             reg.register_texture_uav(handle);
-            reg.unregister_texture(handle);
+            free_texture_slots(&mut reg, handle);
         }
         assert_eq!(reg.cbv_srv_uav.next_fresh(), 2);
         assert_eq!(reg.cbv_srv_uav.free_count(), 2);
@@ -292,7 +331,7 @@ mod registry_tests {
             reg.register_buffer_uav(i as BufferHandle);
         }
         for i in LIVE..LIVE + ROUNDS {
-            reg.unregister_buffer((i - LIVE) as BufferHandle);
+            free_buffer_slots(&mut reg, (i - LIVE) as BufferHandle);
             reg.register_buffer_uav(i as BufferHandle);
         }
         assert!(
@@ -300,6 +339,111 @@ mod registry_tests {
             "counter ({}) exceeded live count ({LIVE}); slot recycling broken",
             reg.cbv_srv_uav.next_fresh()
         );
+    }
+
+    /// Per-slot retirement: slot stays off the free list until referencing contexts retire.
+    #[test]
+    fn slot_deferred_until_context_retires() {
+        use crate::backend::ContextHandle;
+        let mut reg = ResourceRegistry::new();
+        let handle = 1u64 as BufferHandle;
+        let slot = reg.register_buffer_uav(handle);
+        const CTX_A: ContextHandle = 10;
+        const SEQ: u64 = 5;
+
+        let slots = reg.extract_buffer_slots(handle);
+        assert_eq!(slots, vec![slot]);
+
+        let mut pending = vec![PendingSlotReclamation {
+            slot: DeferredSlot::CbvSrvUav(slot),
+            requirements: vec![(CTX_A, SEQ)],
+        }];
+
+        assert_eq!(
+            reg.cbv_srv_uav.free_count(),
+            0,
+            "slot must not be freed yet"
+        );
+
+        let mut retired = HashMap::from([(CTX_A, 4u64)]);
+        let mut drain_pending =
+            |retired: &HashMap<ContextHandle, u64>,
+             reg: &mut ResourceRegistry,
+             pending: &mut Vec<PendingSlotReclamation>| {
+                let mut i = 0;
+                while i < pending.len() {
+                    let ready = pending[i]
+                        .requirements
+                        .iter()
+                        .all(|(ctx, seq)| retired.get(ctx).copied().unwrap_or(0) >= *seq);
+                    if ready {
+                        let entry = pending.swap_remove(i);
+                        reg.free_deferred_slot(entry.slot);
+                    } else {
+                        i += 1;
+                    }
+                }
+            };
+
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.cbv_srv_uav.free_count(), 0, "still in flight at seq 4");
+
+        retired.insert(CTX_A, SEQ);
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(
+            reg.cbv_srv_uav.free_count(),
+            1,
+            "slot freed after context retires"
+        );
+    }
+
+    /// Slot used by two contexts waits for both to retire.
+    #[test]
+    fn slot_waits_for_all_referencing_contexts() {
+        use crate::backend::ContextHandle;
+        let mut reg = ResourceRegistry::new();
+        let handle = 2u64 as BufferHandle;
+        let slot = reg.register_buffer_uav(handle);
+        const CTX_A: ContextHandle = 1;
+        const CTX_B: ContextHandle = 2;
+
+        let mut pending = vec![PendingSlotReclamation {
+            slot: DeferredSlot::CbvSrvUav(slot),
+            requirements: vec![(CTX_A, 3), (CTX_B, 7)],
+        }];
+        reg.extract_buffer_slots(handle);
+
+        let mut retired = HashMap::from([(CTX_A, 0u64), (CTX_B, 0u64)]);
+
+        let mut drain_pending =
+            |retired: &HashMap<ContextHandle, u64>,
+             reg: &mut ResourceRegistry,
+             pending: &mut Vec<PendingSlotReclamation>| {
+                let mut i = 0;
+                while i < pending.len() {
+                    let ready = pending[i]
+                        .requirements
+                        .iter()
+                        .all(|(ctx, seq)| retired.get(ctx).copied().unwrap_or(0) >= *seq);
+                    if ready {
+                        let entry = pending.swap_remove(i);
+                        reg.free_deferred_slot(entry.slot);
+                    } else {
+                        i += 1;
+                    }
+                }
+            };
+
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.cbv_srv_uav.free_count(), 0);
+
+        retired.insert(CTX_A, 3);
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.cbv_srv_uav.free_count(), 0, "CTX_B still in flight");
+
+        retired.insert(CTX_B, 7);
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.cbv_srv_uav.free_count(), 1);
     }
 }
 
@@ -356,6 +500,8 @@ pub(crate) struct RetainedGraph {
     pub command_list: Direct3D12::ID3D12GraphicsCommandList,
     /// Index into [`Dx12SubmissionContext::compute_allocator_pool`] for the backing allocator slot.
     pub slot_idx: usize,
+    /// Bindless heap indices baked into this command list (for slot retirement on resubmit).
+    pub used_slots: Vec<DeferredSlot>,
 }
 
 /// Resource pending deferred deletion.
@@ -394,6 +540,23 @@ pub(crate) enum PendingDeletion {
     /// tracked in any resource map.  Dropping it releases the COM reference and
     /// frees the GPU memory once the fence is met.
     StandaloneResource(Direct3D12::ID3D12Resource),
+}
+
+/// Identifies which descriptor heap owns a deferred slot reclamation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DeferredSlot {
+    /// Slot in the shared CBV/SRV/UAV heap (buffers and textures).
+    CbvSrvUav(u32),
+    /// Slot in the separate sampler heap.
+    Sampler(u32),
+}
+
+/// One deferred descriptor-slot reclamation.
+/// Ready when every `(context, required_seq)` pair has retired.
+pub(crate) struct PendingSlotReclamation {
+    pub slot: DeferredSlot,
+    /// `(context_handle, min_seq_that_must_retire)`
+    pub requirements: Vec<(super::ContextHandle, u64)>,
 }
 
 /// Deferred deletion queue for a DX12 device.
@@ -472,6 +635,11 @@ pub(crate) struct LogicalDevice {
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
     pub deletion_queue: DeletionQueue,
+    /// Maps bindless slot → per-context last-submitted seq that referenced it.
+    /// Updated at every submit. Entry removed when the slot is queued for reclamation.
+    pub slot_last_seen: HashMap<DeferredSlot, HashMap<super::ContextHandle, u64>>,
+    /// Slots waiting for referencing contexts to retire before returning to the free list.
+    pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
     /// Cached graphics PSO blobs from `ID3D12PipelineState::GetCachedBlob` (cold-load via `CachedPSO`).
     pub graphics_pso_blobs: HashMap<u64, Vec<u8>>,
     /// Cached compute PSO blobs.
@@ -481,6 +649,85 @@ pub(crate) struct LogicalDevice {
 }
 
 impl LogicalDevice {
+    /// Record that `ctx` submitted `seq` referencing each bindless slot in `slots`.
+    pub(crate) fn record_slot_usage(
+        &mut self,
+        ctx: super::ContextHandle,
+        seq: u64,
+        slots: impl IntoIterator<Item = DeferredSlot>,
+    ) {
+        for slot in slots {
+            self.slot_last_seen
+                .entry(slot)
+                .or_default()
+                .entry(ctx)
+                .and_modify(|v| *v = (*v).max(seq))
+                .or_insert(seq);
+        }
+    }
+
+    /// Queue a slot for deferred reclamation once all referencing contexts retire.
+    pub(crate) fn queue_slot_reclamation(&mut self, slot: DeferredSlot) {
+        let requirements: Vec<_> = self
+            .slot_last_seen
+            .remove(&slot)
+            .map(|m| m.into_iter().collect())
+            .unwrap_or_default();
+        if requirements.is_empty() {
+            self.resource_registry.free_deferred_slot(slot);
+        } else {
+            self.pending_slot_reclamations
+                .push(PendingSlotReclamation { slot, requirements });
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed buffer handle.
+    pub(crate) fn reclaim_buffer_slots(&mut self, handle: BufferHandle) {
+        let slots = self.resource_registry.extract_buffer_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(DeferredSlot::CbvSrvUav(slot));
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed texture handle.
+    pub(crate) fn reclaim_texture_slots(&mut self, handle: TextureHandle) {
+        let slots = self.resource_registry.extract_texture_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(DeferredSlot::CbvSrvUav(slot));
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed sampler handle.
+    pub(crate) fn reclaim_sampler_slots(&mut self, handle: SamplerHandle) {
+        let slots = self.resource_registry.extract_sampler_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    /// Return pending slots to the free list once every referencing context has retired.
+    pub(crate) fn drain_ready_slot_reclamations(
+        &mut self,
+        contexts: &HashMap<super::ContextHandle, Dx12SubmissionContext>,
+    ) {
+        let mut i = 0;
+        while i < self.pending_slot_reclamations.len() {
+            let ready = self.pending_slot_reclamations[i].requirements.iter().all(
+                |(ctx_id, required_seq)| {
+                    contexts
+                        .get(ctx_id)
+                        .is_none_or(|ctx| unsafe { ctx.fence.GetCompletedValue() >= *required_seq })
+                },
+            );
+            if ready {
+                let entry = self.pending_slot_reclamations.swap_remove(i);
+                self.resource_registry.free_deferred_slot(entry.slot);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
     pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
         let batch = self.deletion_queue.drain_up_to_completed(completed);
         for resource in batch {
@@ -489,6 +736,12 @@ impl LogicalDevice {
     }
 
     pub(crate) fn flush_deletion_queue(&mut self) {
+        // Called only at device teardown, after wait_for_gpu ensures all GPU work has
+        // completed. Slots queued here via reclaim_*_slots will have empty requirements
+        // (slot_last_seen was cleared as contexts were destroyed before the device) and
+        // are freed immediately in queue_slot_reclamation. Any slots that somehow still
+        // have requirements are just dropped with the LogicalDevice — the whole allocator
+        // is discarded at this point, so skipping drain_ready_slot_reclamations is safe.
         let batch = self.deletion_queue.drain_everything();
         for resource in batch {
             destroy_pending_deletion(self, resource);
@@ -505,7 +758,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             coherent_readback,
             reserved_tiles,
         } => {
-            ld.resource_registry.unregister_buffer(buffer_handle);
+            ld.reclaim_buffer_slots(buffer_handle);
             if let Some(tiles) = reserved_tiles {
                 super::tiles::teardown_reserved_mappings(
                     &ld.command_queue,
@@ -526,7 +779,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             drop(coherent_readback);
         }
         PendingDeletion::BufferView { buffer_handle } => {
-            ld.resource_registry.unregister_buffer(buffer_handle);
+            ld.reclaim_buffer_slots(buffer_handle);
         }
         PendingDeletion::ReplacedBufferGpu {
             resource,
@@ -564,7 +817,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             texture_handle,
             resource,
         } => {
-            ld.resource_registry.unregister_texture(texture_handle);
+            ld.reclaim_texture_slots(texture_handle);
             drop(resource);
         }
         PendingDeletion::StandaloneResource(resource) => {

--- a/src/backend/metal/context.rs
+++ b/src/backend/metal/context.rs
@@ -8,6 +8,11 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// Latest device-global seq retired on `device` (max over live context shared events, floored).
+///
+/// Sound only because all contexts commit to a single `LogicalDevice::command_queue`
+/// (FIFO order guaranteed by Metal).  If contexts ever get their own queues, the
+/// `max`-over-contexts approach breaks: a slot freed once context A retires could
+/// still be live in context B.  See `LogicalDevice::command_queue` for details.
 pub(super) fn device_retired(state: &MetalState, device: DeviceHandle) -> u64 {
     let floor = state
         .devices

--- a/src/backend/metal/types.rs
+++ b/src/backend/metal/types.rs
@@ -658,6 +658,22 @@ pub(crate) struct MetalSubmissionContext {
 /// Requires Argument Buffers Tier 2 (Apple Silicon, Intel 2017+, AMD 2015+).
 pub(crate) struct LogicalDevice {
     pub device: MTLDevice,
+    /// The single command queue shared by all contexts on this device.
+    ///
+    /// Metal guarantees that command buffers committed to the same queue execute
+    /// in FIFO order.  The slot-reclamation logic in `unregister_buffer` and
+    /// `drain_pending_slots_up_to` relies on this: it defers recycling a
+    /// descriptor slot until `device_retired` (max signaled timeline across all
+    /// contexts) passes `timeline_scheduled_max`, which is only sound when every
+    /// submission that could reference the slot is ordered behind every other
+    /// submission on the same queue.
+    ///
+    /// **If this ever changes to per-context `MTLCommandQueue`s**, that ordering
+    /// guarantee disappears.  Submissions from different contexts could then race,
+    /// and a slot freed once *one* context retires could still be in use by
+    /// another.  The fix would be the same per-resource per-context retirement
+    /// tracking used by the DX12/Vulkan backends (see `slot_last_seen` and
+    /// `pending_slot_reclamations` there).
     pub command_queue: CommandQueue,
 
     // Bindless infrastructure (always present — Tier 2 required)

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -1217,7 +1217,7 @@ pub(super) fn destroy(
             }
 
             if buffer.transient_heap_suballoc {
-                device.resource_registry.unregister_buffer(buffer_handle);
+                device.reclaim_buffer_slots(buffer_handle);
                 unsafe {
                     device.device.destroy_buffer(buffer.buffer, None);
                 }

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -1,10 +1,13 @@
 //! Compute pipeline and dispatch logic.
 
 use super::super::shared;
+use super::super::shared::DISPATCH_BATCH_STRIDE;
 use super::staging;
-use super::types::{ComputePipelineState, LogicalDevice, PushLayout};
-use super::{ComputePipelineHandle, DeviceHandle, RenderTargetHandle};
-use crate::backend::{GpuCommand, GraphCommand};
+use super::types::{ComputePipelineState, LogicalDevice, PipelineState, PushLayout, SlotKey};
+use super::{
+    BufferHandle, ComputePipelineHandle, DeviceHandle, PipelineHandle, RenderTargetHandle,
+};
+use crate::backend::{GpuCommand, GraphCommand, RenderCommand};
 use crate::gpu_profiler::{self, DispatchGpuNs};
 use crate::task_graph::{NodeAccessUnion, SlotUsageSet, UsageKindFlags};
 use crate::timeline::TimelineValue;
@@ -13,6 +16,202 @@ use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
+
+fn slot_key_from_category(cat: crate::types::ResourceCategory, index: u32) -> Option<SlotKey> {
+    use crate::types::ResourceCategory;
+    match cat {
+        ResourceCategory::Scattered => Some(SlotKey::StorageBuffer(index)),
+        ResourceCategory::Broadcast => Some(SlotKey::UniformBuffer(index)),
+        ResourceCategory::Texture => Some(SlotKey::SampledTexture(index)),
+        ResourceCategory::StorageImage => Some(SlotKey::StorageImage(index)),
+        ResourceCategory::Sampler => Some(SlotKey::Sampler(index)),
+    }
+}
+
+fn collect_slots_from_raw_bind(
+    indices: &[u32],
+    categories: &[Option<crate::types::ResourceCategory>],
+) -> Vec<SlotKey> {
+    let mut slots = Vec::new();
+    for (i, &idx) in indices.iter().enumerate() {
+        if let Some(Some(cat)) = categories.get(i) {
+            if let Some(key) = slot_key_from_category(*cat, idx) {
+                slots.push(key);
+            }
+        }
+    }
+    slots
+}
+
+fn collect_slot_keys_from_gpu_commands(
+    commands: &[GpuCommand],
+    compute_pipelines: &HashMap<ComputePipelineHandle, ComputePipelineState>,
+    buffers: &HashMap<BufferHandle, super::types::BufferState>,
+) -> Vec<SlotKey> {
+    let mut current_pipeline = None;
+    let mut slots = Vec::new();
+    for cmd in commands {
+        match cmd {
+            GpuCommand::SetPipeline(p) => current_pipeline = Some(*p),
+            GpuCommand::BindResources {
+                buffers: buf_handles,
+            } => {
+                for h in buf_handles {
+                    if let Some(idx) = buffers.get(h).and_then(|b| b.bindless_index) {
+                        slots.push(SlotKey::StorageBuffer(idx));
+                    }
+                }
+            }
+            GpuCommand::BindResourcesRaw { indices, .. } => {
+                if let Some(p) = current_pipeline.and_then(|h| compute_pipelines.get(&h)) {
+                    slots.extend(collect_slots_from_raw_bind(
+                        indices,
+                        &p.push_constant_categories,
+                    ));
+                }
+            }
+            GpuCommand::BindResourcesTyped { handles } => {
+                for h in handles {
+                    if let Some(key) = slot_key_from_category(h.category(), h.index()) {
+                        slots.push(key);
+                    }
+                }
+            }
+            GpuCommand::DispatchBatch {
+                arg_data, count, ..
+            } => {
+                if let Some(p) = current_pipeline.and_then(|h| compute_pipelines.get(&h)) {
+                    let layout_size = std::mem::size_of::<PushLayout>();
+                    for i in 0..*count as usize {
+                        let base = i * DISPATCH_BATCH_STRIDE;
+                        if base + layout_size <= arg_data.len() {
+                            let layout: &PushLayout =
+                                bytemuck::from_bytes(&arg_data[base..base + layout_size]);
+                            for (slot_i, &idx) in layout.bindless.iter().enumerate() {
+                                if let Some(Some(cat)) =
+                                    p.push_constant_categories.get(slot_i).copied()
+                                {
+                                    if let Some(key) = slot_key_from_category(cat, idx as u32) {
+                                        slots.push(key);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    slots
+}
+
+fn collect_slot_keys_from_graph_commands(
+    commands: &[GraphCommand],
+    compute_pipelines: &HashMap<ComputePipelineHandle, ComputePipelineState>,
+    pipelines: &HashMap<PipelineHandle, PipelineState>,
+    buffers: &HashMap<BufferHandle, super::types::BufferState>,
+) -> Vec<SlotKey> {
+    let mut slots = Vec::new();
+    let mut current_compute_pipeline = None;
+    let mut current_render_pipeline = None;
+    for gc in commands {
+        match gc {
+            GraphCommand::Compute(cmd) => match cmd {
+                GpuCommand::SetPipeline(p) => current_compute_pipeline = Some(*p),
+                GpuCommand::BindResources {
+                    buffers: buf_handles,
+                } => {
+                    for h in buf_handles {
+                        if let Some(idx) = buffers.get(h).and_then(|b| b.bindless_index) {
+                            slots.push(SlotKey::StorageBuffer(idx));
+                        }
+                    }
+                }
+                GpuCommand::BindResourcesRaw { indices, .. } => {
+                    if let Some(p) =
+                        current_compute_pipeline.and_then(|h| compute_pipelines.get(&h))
+                    {
+                        slots.extend(collect_slots_from_raw_bind(
+                            indices,
+                            &p.push_constant_categories,
+                        ));
+                    }
+                }
+                GpuCommand::BindResourcesTyped { handles } => {
+                    for h in handles {
+                        if let Some(key) = slot_key_from_category(h.category(), h.index()) {
+                            slots.push(key);
+                        }
+                    }
+                }
+                GpuCommand::DispatchBatch {
+                    arg_data, count, ..
+                } => {
+                    if let Some(p) =
+                        current_compute_pipeline.and_then(|h| compute_pipelines.get(&h))
+                    {
+                        let layout_size = std::mem::size_of::<PushLayout>();
+                        for i in 0..*count as usize {
+                            let base = i * DISPATCH_BATCH_STRIDE;
+                            if base + layout_size <= arg_data.len() {
+                                let layout: &PushLayout =
+                                    bytemuck::from_bytes(&arg_data[base..base + layout_size]);
+                                for (slot_i, &idx) in layout.bindless.iter().enumerate() {
+                                    if let Some(Some(cat)) =
+                                        p.push_constant_categories.get(slot_i).copied()
+                                    {
+                                        if let Some(key) = slot_key_from_category(cat, idx as u32) {
+                                            slots.push(key);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
+            GraphCommand::Render {
+                commands: render_cmds,
+                ..
+            } => {
+                for rc in render_cmds {
+                    match rc {
+                        RenderCommand::SetPipeline(p) => current_render_pipeline = Some(*p),
+                        RenderCommand::BindResources {
+                            buffers: buf_handles,
+                        } => {
+                            for h in buf_handles {
+                                if let Some(idx) = buffers.get(h).and_then(|b| b.bindless_index) {
+                                    slots.push(SlotKey::StorageBuffer(idx));
+                                }
+                            }
+                        }
+                        RenderCommand::BindResourcesRaw { indices, .. } => {
+                            if let Some(p) = current_render_pipeline.and_then(|h| pipelines.get(&h))
+                            {
+                                slots.extend(collect_slots_from_raw_bind(
+                                    indices,
+                                    &p.push_constant_categories,
+                                ));
+                            }
+                        }
+                        RenderCommand::BindResourcesTyped { handles } => {
+                            for h in handles {
+                                if let Some(key) = slot_key_from_category(h.category(), h.index()) {
+                                    slots.push(key);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    slots
+}
 
 /// Map a Koubaa producer/consumer usage set to Vulkan pipeline stage flags.
 fn slot_usage_to_vk_stage(usage: &SlotUsageSet) -> vk::PipelineStageFlags2 {
@@ -1171,6 +1370,12 @@ pub(super) fn submit(
         ld.timeline_next
     };
 
+    let used_slots =
+        collect_slot_keys_from_gpu_commands(commands, &state.compute_pipelines, &state.buffers);
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.record_slot_usage(ctx, signal_value, used_slots);
+    }
+
     let timeline_sem = state
         .contexts
         .get(&ctx)
@@ -1286,6 +1491,7 @@ pub(super) fn submit(
         let retired = super::context::device_retired(state, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
+            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
 
@@ -2136,6 +2342,16 @@ fn submit_graph_impl(
         ld.timeline_next
     };
 
+    let used_slots = collect_slot_keys_from_graph_commands(
+        commands,
+        &state.compute_pipelines,
+        &state.pipelines,
+        &state.buffers,
+    );
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.record_slot_usage(ctx, signal_value, used_slots.iter().copied());
+    }
+
     let timeline_sem = state
         .contexts
         .get(&ctx)
@@ -2193,6 +2409,7 @@ fn submit_graph_impl(
             sc.retained_compute_cb = Some(super::types::RetainedVkCb {
                 fingerprint: key,
                 command_buffer: cmd,
+                used_slots,
             });
         } else {
             sc.timeline_cmd_buffers
@@ -2257,6 +2474,7 @@ fn submit_graph_impl(
         let retired = super::context::device_retired(state, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
+            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
 
@@ -2299,15 +2517,15 @@ pub(super) fn try_resubmit_retained(
         .get(&ctx)
         .context("Invalid context handle")?
         .device;
-    let retained_cb = {
+    let retained = {
         let sc = state.contexts.get(&ctx).context("Invalid context handle")?;
         match sc.retained_compute_cb.as_ref() {
-            Some(r) if r.fingerprint == key => Some(r.command_buffer),
+            Some(r) if r.fingerprint == key => Some((r.command_buffer, r.used_slots.clone())),
             _ => None,
         }
     };
 
-    let Some(cmd) = retained_cb else {
+    let Some((cmd, used_slots)) = retained else {
         return Ok(None);
     };
 
@@ -2349,11 +2567,16 @@ pub(super) fn try_resubmit_retained(
         .context("Failed to queue_submit2 retained dispatch CB")?;
     }
 
+    if let Some(ld) = state.devices.get_mut(&device_handle) {
+        ld.record_slot_usage(ctx, signal_value, used_slots);
+    }
+
     {
         let retired = super::context::device_retired(state, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
             ld.timeline_next = signal_value.saturating_add(1);
             ld.process_deletion_queue_up_to(retired);
+            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
     if let Some(sc) = state.contexts.get_mut(&ctx) {

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -6,6 +6,7 @@ use crate::backend::{AdapterInfo, BackendType, DeviceType};
 use anyhow::{Context, Result};
 use ash::vk;
 use ash::{ext, khr};
+use std::collections::HashMap;
 use std::ffi::CStr;
 
 /// Enumerate available physical devices/adapters.
@@ -485,6 +486,8 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             bindless_pipeline_layout,
             resource_registry: types::ResourceRegistry::new(),
             deletion_queue: types::DeletionQueue::new(),
+            slot_last_seen: HashMap::new(),
+            pending_slot_reclamations: Vec::new(),
             timeline_next: 1,
             retired_floor: 0,
             pipeline_cache,

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1213,6 +1213,7 @@ impl GpuBackend for VulkanBackend {
                 for r in drained {
                     types::destroy_pending_deletion(ld, r);
                 }
+                ld.drain_ready_slot_reclamations(&self.state.contexts);
             }
         }
         Ok(())
@@ -1245,6 +1246,7 @@ impl GpuBackend for VulkanBackend {
                     for r in drained {
                         types::destroy_pending_deletion(ld, r);
                     }
+                    ld.drain_ready_slot_reclamations(&self.state.contexts);
                 }
                 Ok(true)
             }
@@ -1353,6 +1355,7 @@ impl GpuBackend for VulkanBackend {
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
+            ld.drain_ready_slot_reclamations(&self.state.contexts);
         }
     }
 

--- a/src/backend/vulkan/sampler.rs
+++ b/src/backend/vulkan/sampler.rs
@@ -97,10 +97,9 @@ pub(super) fn destroy(
 ) {
     if let Some(sampler) = samplers.remove(&sampler_handle) {
         if let Some(logical_device) = devices.get_mut(&sampler.device_handle) {
-            // Unregister from bindless registry
-            logical_device
-                .resource_registry
-                .unregister_sampler(sampler_handle);
+            // Defer reclamation: sampler slot must not be reused until all
+            // in-flight submissions that referenced it have retired.
+            logical_device.reclaim_sampler_slots(sampler_handle);
 
             unsafe {
                 logical_device.device.device_wait_idle().ok();

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -2473,9 +2473,7 @@ fn unregister_swapchain_texture_with_device(
     tex_handle: TextureHandle,
 ) {
     if let Some(tex_state) = textures.remove(&tex_handle) {
-        logical_device
-            .resource_registry
-            .unregister_texture(tex_handle);
+        logical_device.reclaim_texture_slots(tex_handle);
         unsafe {
             logical_device
                 .device
@@ -2494,7 +2492,7 @@ fn unregister_swapchain_texture(
 ) {
     if let Some(tex_state) = textures.remove(&tex_handle) {
         if let Some(device) = devices.get_mut(&tex_state.device_handle) {
-            device.resource_registry.unregister_texture(tex_handle);
+            device.reclaim_texture_slots(tex_handle);
             unsafe {
                 device.device.destroy_image_view(tex_state.view, None);
             }

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -1009,9 +1009,7 @@ pub(super) fn destroy(
     if let Some(texture) = textures.remove(&texture_handle) {
         if let Some(logical_device) = devices.get_mut(&texture.device_handle) {
             if texture.transient_heap_suballoc {
-                logical_device
-                    .resource_registry
-                    .unregister_texture(texture_handle);
+                logical_device.reclaim_texture_slots(texture_handle);
                 unsafe {
                     logical_device.device.destroy_image_view(texture.view, None);
                     logical_device.device.destroy_image(texture.image, None);

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -22,6 +22,23 @@ use std::collections::HashMap;
 /// Maximum number of descriptors per resource type in the global bindless set
 pub const MAX_BINDLESS_RESOURCES: u32 = 16384;
 
+/// Identifies a bindless slot within one of the category-specific allocators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SlotKey {
+    StorageBuffer(u32),
+    UniformBuffer(u32),
+    SampledTexture(u32),
+    StorageImage(u32),
+    Sampler(u32),
+}
+
+/// One deferred descriptor-slot reclamation.
+pub(crate) struct PendingSlotReclamation {
+    pub slot: SlotKey,
+    /// `(context_handle, min_seq_that_must_retire)`
+    pub requirements: Vec<(super::ContextHandle, u64)>,
+}
+
 /// Binding indices within the global bindless descriptor set
 /// Organized by ACCESS PATTERN:
 ///
@@ -124,26 +141,52 @@ impl ResourceRegistry {
         index
     }
 
-    pub fn unregister_buffer(&mut self, handle: BufferHandle) {
+    /// Remove a buffer's handle mapping and return its slot key without recycling.
+    pub fn extract_buffer_slots(&mut self, handle: BufferHandle) -> Vec<SlotKey> {
+        let mut slots = Vec::new();
         if let Some((index, is_storage)) = self.buffer_indices.remove(&handle) {
-            if is_storage {
-                self.storage_buffer.free(index);
+            slots.push(if is_storage {
+                SlotKey::StorageBuffer(index)
             } else {
-                self.uniform_buffer.free(index);
-            }
+                SlotKey::UniformBuffer(index)
+            });
         }
+        slots
     }
 
-    pub fn unregister_texture(&mut self, handle: TextureHandle) {
+    /// Remove a texture's handle mapping and return its slot key without recycling.
+    pub fn extract_texture_slots(&mut self, handle: TextureHandle) -> Vec<SlotKey> {
+        let mut slots = Vec::new();
         if let Some((index, is_storage_image)) = self.texture_indices.remove(&handle) {
-            if is_storage_image {
-                self.storage_image.free(index);
+            slots.push(if is_storage_image {
+                SlotKey::StorageImage(index)
             } else {
-                self.sampled_texture.free(index);
-            }
+                SlotKey::SampledTexture(index)
+            });
+        }
+        slots
+    }
+
+    pub fn free_slot(&mut self, key: SlotKey) {
+        match key {
+            SlotKey::StorageBuffer(i) => self.storage_buffer.free(i),
+            SlotKey::UniformBuffer(i) => self.uniform_buffer.free(i),
+            SlotKey::SampledTexture(i) => self.sampled_texture.free(i),
+            SlotKey::StorageImage(i) => self.storage_image.free(i),
+            SlotKey::Sampler(i) => self.sampler.free(i),
         }
     }
 
+    /// Remove a sampler's handle mapping and return its slot key without recycling.
+    pub fn extract_sampler_slots(&mut self, handle: SamplerHandle) -> Vec<SlotKey> {
+        if let Some(index) = self.sampler_indices.remove(&handle) {
+            vec![SlotKey::Sampler(index)]
+        } else {
+            Vec::new()
+        }
+    }
+
+    #[cfg(test)]
     pub fn unregister_sampler(&mut self, handle: SamplerHandle) {
         if let Some(index) = self.sampler_indices.remove(&handle) {
             self.sampler.free(index);
@@ -167,6 +210,18 @@ impl ResourceRegistry {
 mod registry_tests {
     use super::*;
 
+    fn free_buffer_slots(reg: &mut ResourceRegistry, handle: BufferHandle) {
+        for key in reg.extract_buffer_slots(handle) {
+            reg.free_slot(key);
+        }
+    }
+
+    fn free_texture_slots(reg: &mut ResourceRegistry, handle: TextureHandle) {
+        for key in reg.extract_texture_slots(handle) {
+            reg.free_slot(key);
+        }
+    }
+
     /// Simulate the per-frame create/destroy churn that ekrano generates for transient
     /// pool-view storage buffers. The counter must stay bounded — well below
     /// MAX_BINDLESS_RESOURCES — even after far more iterations than the heap limit.
@@ -176,7 +231,7 @@ mod registry_tests {
         for i in 0..50_000u64 {
             let handle = i as BufferHandle;
             reg.register_buffer(handle, true);
-            reg.unregister_buffer(handle);
+            free_buffer_slots(&mut reg, handle);
         }
         assert_eq!(
             reg.storage_buffer.next_fresh(),
@@ -193,7 +248,7 @@ mod registry_tests {
         for i in 0..50_000u64 {
             let handle = i as BufferHandle;
             reg.register_buffer(handle, false);
-            reg.unregister_buffer(handle);
+            free_buffer_slots(&mut reg, handle);
         }
         assert_eq!(
             reg.uniform_buffer.next_fresh(),
@@ -209,7 +264,7 @@ mod registry_tests {
         for i in 0..50_000u64 {
             let handle = i as TextureHandle;
             reg.register_texture(handle, false);
-            reg.unregister_texture(handle);
+            free_texture_slots(&mut reg, handle);
         }
         assert_eq!(reg.sampled_texture.next_fresh(), 1);
         assert_eq!(reg.sampled_texture.free_count(), 1);
@@ -222,7 +277,7 @@ mod registry_tests {
         for i in 0..50_000u64 {
             let handle = i as TextureHandle;
             reg.register_texture(handle, true);
-            reg.unregister_texture(handle);
+            free_texture_slots(&mut reg, handle);
         }
         assert_eq!(reg.storage_image.next_fresh(), 1);
         assert_eq!(reg.storage_image.free_count(), 1);
@@ -270,7 +325,7 @@ mod registry_tests {
             reg.register_buffer(i as BufferHandle, true);
         }
         for i in LIVE..LIVE + ROUNDS {
-            reg.unregister_buffer((i - LIVE) as BufferHandle);
+            free_buffer_slots(&mut reg, (i - LIVE) as BufferHandle);
             reg.register_buffer(i as BufferHandle, true);
         }
         assert!(
@@ -278,6 +333,106 @@ mod registry_tests {
             "counter ({}) exceeded live count ({LIVE}); slot recycling broken",
             reg.storage_buffer.next_fresh()
         );
+    }
+
+    #[test]
+    fn slot_deferred_until_context_retires() {
+        use crate::backend::ContextHandle;
+        let mut reg = ResourceRegistry::new();
+        let handle = 1u64 as BufferHandle;
+        let slot = reg.register_buffer(handle, true);
+        const CTX_A: ContextHandle = 10;
+        const SEQ: u64 = 5;
+
+        let slots = reg.extract_buffer_slots(handle);
+        assert_eq!(slots, vec![SlotKey::StorageBuffer(slot)]);
+
+        let mut pending = vec![PendingSlotReclamation {
+            slot: SlotKey::StorageBuffer(slot),
+            requirements: vec![(CTX_A, SEQ)],
+        }];
+
+        assert_eq!(reg.storage_buffer.free_count(), 0);
+
+        let mut retired = HashMap::from([(CTX_A, 4u64)]);
+        let mut i = 0;
+        while i < pending.len() {
+            let ready = pending[i]
+                .requirements
+                .iter()
+                .all(|(ctx, seq)| retired.get(ctx).copied().unwrap_or(0) >= *seq);
+            if ready {
+                let entry = pending.swap_remove(i);
+                reg.free_slot(entry.slot);
+            } else {
+                i += 1;
+            }
+        }
+        assert_eq!(reg.storage_buffer.free_count(), 0);
+
+        retired.insert(CTX_A, SEQ);
+        i = 0;
+        while i < pending.len() {
+            let ready = pending[i]
+                .requirements
+                .iter()
+                .all(|(ctx, seq)| retired.get(ctx).copied().unwrap_or(0) >= *seq);
+            if ready {
+                let entry = pending.swap_remove(i);
+                reg.free_slot(entry.slot);
+            } else {
+                i += 1;
+            }
+        }
+        assert_eq!(reg.storage_buffer.free_count(), 1);
+    }
+
+    #[test]
+    fn slot_waits_for_all_referencing_contexts() {
+        use crate::backend::ContextHandle;
+        let mut reg = ResourceRegistry::new();
+        let handle = 2u64 as BufferHandle;
+        let slot = reg.register_buffer(handle, true);
+        const CTX_A: ContextHandle = 1;
+        const CTX_B: ContextHandle = 2;
+
+        let mut pending = vec![PendingSlotReclamation {
+            slot: SlotKey::StorageBuffer(slot),
+            requirements: vec![(CTX_A, 3), (CTX_B, 7)],
+        }];
+        reg.extract_buffer_slots(handle);
+
+        let mut retired = HashMap::from([(CTX_A, 0u64), (CTX_B, 0u64)]);
+
+        let mut drain_pending =
+            |retired: &HashMap<ContextHandle, u64>,
+             reg: &mut ResourceRegistry,
+             pending: &mut Vec<PendingSlotReclamation>| {
+                let mut i = 0;
+                while i < pending.len() {
+                    let ready = pending[i]
+                        .requirements
+                        .iter()
+                        .all(|(ctx, seq)| retired.get(ctx).copied().unwrap_or(0) >= *seq);
+                    if ready {
+                        let entry = pending.swap_remove(i);
+                        reg.free_slot(entry.slot);
+                    } else {
+                        i += 1;
+                    }
+                }
+            };
+
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.storage_buffer.free_count(), 0);
+
+        retired.insert(CTX_A, 3);
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.storage_buffer.free_count(), 0);
+
+        retired.insert(CTX_B, 7);
+        drain_pending(&retired, &mut reg, &mut pending);
+        assert_eq!(reg.storage_buffer.free_count(), 1);
     }
 }
 
@@ -347,6 +502,10 @@ pub(crate) struct LogicalDevice {
     pub resource_registry: ResourceRegistry,
     /// Deferred deletion queue for resources that are still in-flight
     pub deletion_queue: DeletionQueue,
+    /// Maps bindless slot → per-context last-submitted seq that referenced it.
+    pub slot_last_seen: HashMap<SlotKey, HashMap<super::ContextHandle, u64>>,
+    /// Slots waiting for referencing contexts to retire before returning to free lists.
+    pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
     /// Device-global submission sequence (shared value space; contexts signal their own semaphores).
     pub timeline_next: u64,
     /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
@@ -366,6 +525,8 @@ pub(crate) struct RetainedVkCb {
     pub fingerprint: u64,
     /// The retained `VkCommandBuffer` (in executable state when GPU has completed).
     pub command_buffer: vk::CommandBuffer,
+    /// Bindless slots baked into this command buffer (for slot retirement on resubmit).
+    pub used_slots: Vec<SlotKey>,
 }
 
 impl LogicalDevice {
@@ -765,21 +926,30 @@ impl DeletionQueue {
 
 /// Deferred-delete one entry ([`SparseBufferTeardown`] needs [`LogicalDevice`] for the page pool).
 pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: PendingDeletion) {
+    match &resource {
+        PendingDeletion::Buffer { buffer_handle, .. }
+        | PendingDeletion::BufferView { buffer_handle } => {
+            ld.reclaim_buffer_slots(*buffer_handle);
+        }
+        PendingDeletion::Texture { texture_handle, .. } => {
+            ld.reclaim_texture_slots(*texture_handle);
+        }
+        _ => {}
+    }
+
     let device = &ld.device;
-    let registry = &mut ld.resource_registry;
     let bind_queue = ld.sparse_binding_queue;
 
     unsafe {
         match resource {
             PendingDeletion::Buffer {
-                buffer_handle,
+                buffer_handle: _,
                 buffer,
                 memory,
                 staging_buffer,
                 staging_memory,
                 sparse_teardown,
             } => {
-                registry.unregister_buffer(buffer_handle);
                 if let Some(td) = sparse_teardown {
                     if !td.binds.is_empty() {
                         let mut sparse_binds = Vec::with_capacity(td.binds.len());
@@ -819,9 +989,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
                     device.free_memory(mem, None);
                 }
             }
-            PendingDeletion::BufferView { buffer_handle } => {
-                registry.unregister_buffer(buffer_handle);
-            }
+            PendingDeletion::BufferView { buffer_handle: _ } => {}
             PendingDeletion::ReplacedBufferGpu {
                 buffer,
                 memory,
@@ -880,14 +1048,13 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
                 }
             }
             PendingDeletion::Texture {
-                texture_handle,
+                texture_handle: _,
                 image,
                 view,
                 memory,
                 staging_buffer,
                 staging_memory,
             } => {
-                registry.unregister_texture(texture_handle);
                 device.destroy_image_view(view, None);
                 device.destroy_image(image, None);
                 device.free_memory(memory, None);
@@ -906,6 +1073,83 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
 }
 
 impl LogicalDevice {
+    pub(crate) fn record_slot_usage(
+        &mut self,
+        ctx: super::ContextHandle,
+        seq: u64,
+        slots: impl IntoIterator<Item = SlotKey>,
+    ) {
+        for slot in slots {
+            self.slot_last_seen
+                .entry(slot)
+                .or_default()
+                .entry(ctx)
+                .and_modify(|v| *v = (*v).max(seq))
+                .or_insert(seq);
+        }
+    }
+
+    pub(crate) fn queue_slot_reclamation(&mut self, slot: SlotKey) {
+        let requirements: Vec<_> = self
+            .slot_last_seen
+            .remove(&slot)
+            .map(|m| m.into_iter().collect())
+            .unwrap_or_default();
+        if requirements.is_empty() {
+            self.resource_registry.free_slot(slot);
+        } else {
+            self.pending_slot_reclamations
+                .push(PendingSlotReclamation { slot, requirements });
+        }
+    }
+
+    pub(crate) fn reclaim_buffer_slots(&mut self, handle: BufferHandle) {
+        let slots = self.resource_registry.extract_buffer_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    pub(crate) fn reclaim_texture_slots(&mut self, handle: TextureHandle) {
+        let slots = self.resource_registry.extract_texture_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed sampler handle.
+    pub(crate) fn reclaim_sampler_slots(&mut self, handle: SamplerHandle) {
+        let slots = self.resource_registry.extract_sampler_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    pub(crate) fn drain_ready_slot_reclamations(
+        &mut self,
+        contexts: &HashMap<super::ContextHandle, SubmissionContext>,
+    ) {
+        let mut i = 0;
+        while i < self.pending_slot_reclamations.len() {
+            let ready = self.pending_slot_reclamations[i].requirements.iter().all(
+                |(ctx_id, required_seq)| {
+                    contexts.get(ctx_id).is_none_or(|ctx| unsafe {
+                        self.device
+                            .get_semaphore_counter_value(ctx.timeline_semaphore)
+                            .unwrap_or(0)
+                            >= *required_seq
+                    })
+                },
+            );
+            if ready {
+                let entry = self.pending_slot_reclamations.swap_remove(i);
+                self.resource_registry.free_slot(entry.slot);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
     /// Drop deferred resources whose barrier is `<= completed` (device-global retirement horizon).
     pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
         let drained = self.deletion_queue.drain_up_to(completed);


### PR DESCRIPTION
Updated the resource management logic to replace unregister methods with reclaim methods for buffers, textures, and samplers. This change defers the reclamation of slots until all in-flight submissions referencing them have retired, improving memory management and preventing premature slot reuse. Additionally, introduced new functions for extracting and freeing slots, enhancing the clarity and efficiency of resource handling across the backends.