### PR TITLE
Refactor timeline management in DX12 backend to use atomic operations

### DIFF
--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -523,14 +523,14 @@ pub(super) fn resize(
         let lists: [Option<ID3D12CommandList>; 1] = [Some(cmd.cast()?)];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next + 1;
+        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("resize_buffer: Signal")?;
         wait_for_fence(&device.fence, fence_value)?;
         deletion_fence_marker = fence_value;
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next = fence_value + 1;
+            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
     } else if !old.is_storage && preserve_contents && copy_len > 0 {
         let mut src: *mut std::ffi::c_void = std::ptr::null_mut();
@@ -1263,7 +1263,7 @@ pub(super) fn set_logical_size(
 pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
     if let Some(buffer) = state.buffers.remove(&buffer_handle) {
         if let Some(device) = state.devices.get_mut(&buffer.device_handle) {
-            let last_fence = device.timeline_next.saturating_sub(1);
+            let last_fence = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
 
             if buffer.is_view {
                 device.deletion_queue.queue(
@@ -1768,12 +1768,12 @@ pub(super) fn write(
         let lists: [Option<ID3D12CommandList>; 1] = [Some(cmd.cast()?)];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next + 1;
+        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next = fence_value + 1;
+            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
 
         written += this_chunk;
@@ -1896,13 +1896,13 @@ fn standalone_copy_coherent_readback(
     )];
     unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-    let fence_value = device.timeline_next + 1;
+    let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence (coherent readback)")?;
     wait_for_fence(&device.fence, fence_value)?;
 
     if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next = fence_value + 1;
+        dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
     }
     Ok(())
 }
@@ -2064,13 +2064,13 @@ pub(super) fn read_to_cpu(
         )];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next + 1;
+        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next = fence_value + 1;
+            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
 
         // Map readback buffer and copy to output
@@ -2201,7 +2201,7 @@ pub(super) fn clear(
         )];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next + 1;
+        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
@@ -2212,7 +2212,7 @@ pub(super) fn clear(
         }
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next = fence_value + 1;
+            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
     } else {
         // UPLOAD heap: CPU-accessible, just memset

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -810,7 +810,12 @@ pub(super) fn create(
             let num_elements = (logical_size as u32) / stride;
 
             // Register UAV to get the next available descriptor offset
-            let uav_offset = logical_device.resource_registry.register_buffer_uav(handle);
+            let uav_offset = logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .resource_registry
+                .register_buffer_uav(handle);
 
             // Create UAV descriptor for RWStructuredBuffer (compute write access)
             let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
@@ -846,7 +851,12 @@ pub(super) fn create(
             }
 
             // Also register and create SRV for read-only graphics access (StructuredBuffer)
-            let srv_offset = logical_device.resource_registry.register_buffer_srv(handle);
+            let srv_offset = logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .resource_registry
+                .register_buffer_srv(handle);
 
             let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
                 Format: DXGI_FORMAT_UNKNOWN, // Required for structured buffers
@@ -888,7 +898,12 @@ pub(super) fn create(
             (Some(uav_offset), Some(srv_offset))
         } else {
             // For uniform buffers, create a CBV (ConstantBuffer pattern)
-            let cbv_offset = logical_device.resource_registry.register_buffer_cbv(handle);
+            let cbv_offset = logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .resource_registry
+                .register_buffer_cbv(handle);
 
             // CBV size must be 256-byte aligned
             let aligned_size = (logical_size + 255) & !255;
@@ -1037,7 +1052,12 @@ pub(super) fn create_reserved_with_capacity(
             .devices
             .get_mut(&device_handle)
             .context("Invalid device handle")?;
-        let uav_offset = ld.resource_registry.register_buffer_uav(handle);
+        let uav_offset = ld
+            .ledger
+            .lock()
+            .unwrap()
+            .resource_registry
+            .register_buffer_uav(handle);
         let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
             Format: DXGI_FORMAT_UNKNOWN,
             ViewDimension: D3D12_UAV_DIMENSION_BUFFER,
@@ -1061,7 +1081,12 @@ pub(super) fn create_reserved_with_capacity(
                 .CreateUnorderedAccessView(&resource, None, Some(&uav_desc), uav_cpu_handle);
         }
 
-        let srv_offset = ld.resource_registry.register_buffer_srv(handle);
+        let srv_offset = ld
+            .ledger
+            .lock()
+            .unwrap()
+            .resource_registry
+            .register_buffer_srv(handle);
         let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
             Format: DXGI_FORMAT_UNKNOWN,
             ViewDimension: D3D12_SRV_DIMENSION_BUFFER,
@@ -1281,7 +1306,11 @@ pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
             }
 
             if buffer.transient_placed {
-                device.reclaim_buffer_slots(buffer_handle);
+                device
+                    .ledger
+                    .lock()
+                    .unwrap()
+                    .reclaim_buffer_slots(buffer_handle);
                 return;
             }
             if buffer.coherent_readback_mapped.is_some() {
@@ -1423,7 +1452,12 @@ pub(super) fn create_view(
             (None, None)
         } else {
             // UAV descriptor
-            let uav_offset = logical_device.resource_registry.register_buffer_uav(handle);
+            let uav_offset = logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .resource_registry
+                .register_buffer_uav(handle);
 
             let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
                 Format: DXGI_FORMAT_UNKNOWN,
@@ -1457,7 +1491,12 @@ pub(super) fn create_view(
             }
 
             // SRV descriptor
-            let srv_offset = logical_device.resource_registry.register_buffer_srv(handle);
+            let srv_offset = logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .resource_registry
+                .register_buffer_srv(handle);
 
             let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
                 Format: DXGI_FORMAT_UNKNOWN,

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -275,7 +275,7 @@ fn patch_buffer_views_after_parent_resize(
             if num_elements > 0 {
                 let logical_device = state
                     .devices
-                    .get_mut(&device_handle)
+                    .get(&device_handle)
                     .context("patch_buffer_views: device")?;
 
                 let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
@@ -532,7 +532,7 @@ pub(super) fn resize(
         wait_for_fence(&device.fence, fence_value)?;
         deletion_fence_marker = fence_value;
 
-        if let Some(dev) = state.devices.get_mut(&device_handle) {
+        if let Some(dev) = state.devices.get(&device_handle) {
             dev.timeline_next
                 .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
@@ -569,7 +569,7 @@ pub(super) fn resize(
 
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("resize_buffer: device for descriptors")?;
     rewrite_root_buffer_descriptors(logical_device, &new_resource, new_size, &old)?;
 
@@ -600,12 +600,12 @@ pub(super) fn resize(
 
     patch_buffer_views_after_parent_resize(state, buffer_handle)?;
 
-    let dev_mut = state
+    let dev = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("resize_buffer: queue deletion")?;
     if old.is_reserved {
-        dev_mut.deletion_queue.queue(
+        dev.deletion_queue.lock().unwrap().queue(
             deletion_fence_marker,
             super::types::PendingDeletion::ReplacedReservedBufferGpu {
                 resource: old_resource,
@@ -615,7 +615,7 @@ pub(super) fn resize(
             },
         );
     } else {
-        dev_mut.deletion_queue.queue(
+        dev.deletion_queue.lock().unwrap().queue(
             deletion_fence_marker,
             super::types::PendingDeletion::ReplacedBufferGpu {
                 resource: old_resource,
@@ -795,7 +795,7 @@ pub(super) fn create(
     let (bindless_offset, bindless_srv_offset) = if is_storage || is_uniform {
         let logical_device = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
 
         if is_storage {
@@ -1005,10 +1005,10 @@ pub(super) fn create_reserved_with_capacity(
     let (resource, reserved_tiles) = {
         let ld = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
-        let pool = ld
-            .tile_heap_pool
+        let mut pool_guard = ld.tile_heap_pool.lock().unwrap();
+        let pool = pool_guard
             .as_mut()
             .context("internal: tile heap pool missing")?;
         let queue = ld.command_queue.clone();
@@ -1050,7 +1050,7 @@ pub(super) fn create_reserved_with_capacity(
     let (bindless_offset, bindless_srv_offset) = {
         let ld = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
         let uav_offset = ld
             .ledger
@@ -1153,7 +1153,7 @@ pub(super) fn create_with_capacity(
     let use_reserved = !super::env_disable_reserved_buffers()
         && state.devices.get(&device_handle).is_some_and(|d| {
             d.supports_reserved_buffers
-                && d.tile_heap_pool.is_some()
+                && d.tile_heap_pool.lock().unwrap().is_some()
                 && cap > initial_size
                 && access == BufferKind::Scattered
                 && !flags.contains(BufferFlags::CPU_READABLE)
@@ -1234,10 +1234,10 @@ pub(super) fn set_logical_size(
         {
             let ld = state
                 .devices
-                .get_mut(&device_handle)
+                .get(&device_handle)
                 .context("set_logical_size: device")?;
-            let pool = ld
-                .tile_heap_pool
+            let mut pool_guard = ld.tile_heap_pool.lock().unwrap();
+            let pool = pool_guard
                 .as_mut()
                 .context("set_logical_size: tile heap pool")?;
             let queue = ld.command_queue.clone();
@@ -1291,14 +1291,14 @@ pub(super) fn set_logical_size(
 /// For views, only the descriptor slots are deferred.
 pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
     if let Some(buffer) = state.buffers.remove(&buffer_handle) {
-        if let Some(device) = state.devices.get_mut(&buffer.device_handle) {
+        if let Some(device) = state.devices.get(&buffer.device_handle) {
             let last_fence = device
                 .timeline_next
                 .load(std::sync::atomic::Ordering::Relaxed)
                 .saturating_sub(1);
 
             if buffer.is_view {
-                device.deletion_queue.queue(
+                device.deletion_queue.lock().unwrap().queue(
                     last_fence,
                     super::types::PendingDeletion::BufferView { buffer_handle },
                 );
@@ -1319,7 +1319,7 @@ pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
                     unsafe { rb.Unmap(0, Some(&no_write)) };
                 }
             }
-            device.deletion_queue.queue(
+            device.deletion_queue.lock().unwrap().queue(
                 last_fence,
                 super::types::PendingDeletion::Buffer {
                     buffer_handle,
@@ -1356,15 +1356,15 @@ pub(super) fn hint_unused_above(state: &mut Dx12State, buffer_handle: BufferHand
         }
         (buf.device_handle, ft)
     };
-    let (devices, buffers) = (&mut state.devices, &mut state.buffers);
-    let Some(ld) = devices.get_mut(&device_handle) else {
+    let Some(ld) = state.devices.get(&device_handle) else {
         return;
     };
-    let Some(pool) = ld.tile_heap_pool.as_mut() else {
+    let mut pool_guard = ld.tile_heap_pool.lock().unwrap();
+    let Some(pool) = pool_guard.as_mut() else {
         return;
     };
     let queue = &ld.command_queue;
-    let Some(buf_mut) = buffers.get_mut(&buffer_handle) else {
+    let Some(buf_mut) = state.buffers.get_mut(&buffer_handle) else {
         return;
     };
     let mut i = first_tile;
@@ -1445,7 +1445,7 @@ pub(super) fn create_view(
     let (bindless_offset, bindless_srv_offset) = {
         let logical_device = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
 
         if num_elements == 0 {
@@ -1821,7 +1821,7 @@ pub(super) fn write(
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
-        if let Some(dev) = state.devices.get_mut(&device_handle) {
+        if let Some(dev) = state.devices.get(&device_handle) {
             dev.timeline_next
                 .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
@@ -1954,7 +1954,7 @@ fn standalone_copy_coherent_readback(
         .context("Failed to signal fence (coherent readback)")?;
     wait_for_fence(&device.fence, fence_value)?;
 
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
+    if let Some(dev) = state.devices.get(&device_handle) {
         dev.timeline_next
             .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
     }
@@ -2126,7 +2126,7 @@ pub(super) fn read_to_cpu(
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
 
-        if let Some(dev) = state.devices.get_mut(&device_handle) {
+        if let Some(dev) = state.devices.get(&device_handle) {
             dev.timeline_next
                 .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
@@ -2272,7 +2272,7 @@ pub(super) fn clear(
             anyhow::bail!("Device removed during buffer clear: {:?}", removed_reason);
         }
 
-        if let Some(dev) = state.devices.get_mut(&device_handle) {
+        if let Some(dev) = state.devices.get(&device_handle) {
             dev.timeline_next
                 .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -523,14 +523,18 @@ pub(super) fn resize(
         let lists: [Option<ID3D12CommandList>; 1] = [Some(cmd.cast()?)];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
+        let fence_value = device
+            .timeline_next
+            .load(std::sync::atomic::Ordering::Relaxed)
+            + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("resize_buffer: Signal")?;
         wait_for_fence(&device.fence, fence_value)?;
         deletion_fence_marker = fence_value;
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
+            dev.timeline_next
+                .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
     } else if !old.is_storage && preserve_contents && copy_len > 0 {
         let mut src: *mut std::ffi::c_void = std::ptr::null_mut();
@@ -1263,7 +1267,10 @@ pub(super) fn set_logical_size(
 pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
     if let Some(buffer) = state.buffers.remove(&buffer_handle) {
         if let Some(device) = state.devices.get_mut(&buffer.device_handle) {
-            let last_fence = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
+            let last_fence = device
+                .timeline_next
+                .load(std::sync::atomic::Ordering::Relaxed)
+                .saturating_sub(1);
 
             if buffer.is_view {
                 device.deletion_queue.queue(
@@ -1768,12 +1775,16 @@ pub(super) fn write(
         let lists: [Option<ID3D12CommandList>; 1] = [Some(cmd.cast()?)];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
+        let fence_value = device
+            .timeline_next
+            .load(std::sync::atomic::Ordering::Relaxed)
+            + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
+            dev.timeline_next
+                .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
 
         written += this_chunk;
@@ -1896,13 +1907,17 @@ fn standalone_copy_coherent_readback(
     )];
     unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-    let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
+    let fence_value = device
+        .timeline_next
+        .load(std::sync::atomic::Ordering::Relaxed)
+        + 1;
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence (coherent readback)")?;
     wait_for_fence(&device.fence, fence_value)?;
 
     if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
+        dev.timeline_next
+            .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
     }
     Ok(())
 }
@@ -2064,13 +2079,17 @@ pub(super) fn read_to_cpu(
         )];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
+        let fence_value = device
+            .timeline_next
+            .load(std::sync::atomic::Ordering::Relaxed)
+            + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
+            dev.timeline_next
+                .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
 
         // Map readback buffer and copy to output
@@ -2201,7 +2220,10 @@ pub(super) fn clear(
         )];
         unsafe { device.command_queue.ExecuteCommandLists(&lists) };
 
-        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed) + 1;
+        let fence_value = device
+            .timeline_next
+            .load(std::sync::atomic::Ordering::Relaxed)
+            + 1;
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         wait_for_fence(&device.fence, fence_value)?;
@@ -2212,7 +2234,8 @@ pub(super) fn clear(
         }
 
         if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next.store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
+            dev.timeline_next
+                .store(fence_value + 1, std::sync::atomic::Ordering::Relaxed);
         }
     } else {
         // UPLOAD heap: CPU-accessible, just memset

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -623,6 +623,8 @@ fn acquire_allocator_slot(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let logical_device = state
         .devices
@@ -630,17 +632,20 @@ fn acquire_allocator_slot(
         .context("Invalid device handle")?;
 
     let ctx_fence = state
+        .context_fences
+        .get(&ctx)
+        .context("Invalid context handle")?
+        .1
+        .clone();
+    let completed = unsafe { ctx_fence.GetCompletedValue() };
+
+    let sc_arc = state
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
-        .fence
         .clone();
-    let completed = unsafe { ctx_fence.GetCompletedValue() };
-    let pool = &mut state
-        .contexts
-        .get_mut(&ctx)
-        .context("Invalid context handle")?
-        .compute_allocator_pool;
+    let mut sc = sc_arc.lock().unwrap();
+    let pool = &mut sc.compute_allocator_pool;
     // Skip retained slots — their allocator must not be reset until evict_retained is called.
     let slot_idx = pool
         .iter()
@@ -1001,8 +1006,8 @@ fn record_gpu_command(
                     .timeline_next
                     .load(std::sync::atomic::Ordering::Relaxed)
                     .saturating_sub(1);
-                if let Some(sc) = state.contexts.get_mut(&ctx_handle) {
-                    sc.deletion_queue.queue(
+                if let Some(sc_arc) = state.contexts.get(&ctx_handle) {
+                    sc_arc.lock().unwrap().deletion_queue.queue(
                         fence_val,
                         super::types::PendingDeletion::StandaloneResource(arg_resource),
                     );
@@ -1478,10 +1483,10 @@ fn execute_signal_and_finish(
 
     let logical_device = state.devices.get(&device_handle).unwrap();
     let ctx_fence = state
-        .contexts
+        .context_fences
         .get(&ctx)
         .context("Invalid context handle")?
-        .fence
+        .1
         .clone();
     {
         let _tz = tracy_zone!("dx12.execute_and_signal");
@@ -1502,7 +1507,8 @@ fn execute_signal_and_finish(
         }
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         if let Some(slot) = sc.compute_allocator_pool.get_mut(slot_idx) {
             slot.fence_value = fence_value;
         }
@@ -1532,8 +1538,14 @@ fn execute_signal_and_finish(
     let ctx_completed = unsafe { ctx_fence.GetCompletedValue() };
     let ctx_del_batch: Vec<_> = state
         .contexts
-        .get_mut(&ctx)
-        .map(|sc| sc.deletion_queue.drain_up_to_completed(ctx_completed))
+        .get(&ctx)
+        .map(|sc_arc| {
+            sc_arc
+                .lock()
+                .unwrap()
+                .deletion_queue
+                .drain_up_to_completed(ctx_completed)
+        })
         .unwrap_or_default();
     if let Some(dev) = state.devices.get(&device_handle) {
         let ledger_arc = std::sync::Arc::clone(&dev.ledger);
@@ -1541,21 +1553,25 @@ fn execute_signal_and_finish(
         for resource in ctx_del_batch {
             types::destroy_pending_deletion(dev, &mut ledger, resource);
         }
-        ledger.drain_ready_slot_reclamations(&state.contexts);
+        ledger.drain_ready_slot_reclamations(&state.context_fences);
     }
 
     state
         .contexts
-        .get_mut(&ctx)
-        .map(|sc| sc.staging_belt.finish(fence_value));
+        .get(&ctx)
+        .map(|sc_arc| sc_arc.lock().unwrap().staging_belt.finish(fence_value));
 
     if !staged_texture_uploads.is_empty() {
         let entries = staged_texture_uploads
             .into_iter()
             .map(|u| u.staging_entry)
             .collect::<Vec<_>>();
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.texture_staging_pool.release(fence_value, entries);
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc
+                .lock()
+                .unwrap()
+                .texture_staging_pool
+                .release(fence_value, entries);
         }
     }
 
@@ -1576,6 +1592,8 @@ pub(super) fn submit(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let _tz = tracy_zone!("dx12.submit");
     let (command_list, fence_value, slot_idx) = {
@@ -1589,10 +1607,10 @@ pub(super) fn submit(
             .get(&device_handle)
             .context("Invalid device handle")?;
         let ctx_fence = state
-            .contexts
+            .context_fences
             .get(&ctx)
             .context("Invalid context handle")?
-            .fence
+            .1
             .clone();
         (ctx_fence, dev.adapter_id == super::WARP_ADAPTER_ID)
     };
@@ -1608,10 +1626,12 @@ pub(super) fn submit(
     if has_upload {
         let _tz_reclaim = tracy_zone!("dx12.submit.staging_reclaim");
         let completed = super::context::device_retired(state, device_handle);
-        let sc = state
+        let sc_arc = state
             .contexts
-            .get_mut(&ctx)
-            .context("Invalid context handle")?;
+            .get(&ctx)
+            .context("Invalid context handle")?
+            .clone();
+        let mut sc = sc_arc.lock().unwrap();
         sc.staging_belt.reclaim(&ctx_fence_clone)?;
         sc.texture_staging_pool.reclaim(completed);
     }
@@ -1624,10 +1644,12 @@ pub(super) fn submit(
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
     if has_upload {
         let mut pool = {
-            let sc = state
+            let sc_arc = state
                 .contexts
-                .get_mut(&ctx)
-                .context("Invalid context handle")?;
+                .get(&ctx)
+                .context("Invalid context handle")?
+                .clone();
+            let mut sc = sc_arc.lock().unwrap();
             std::mem::replace(
                 &mut sc.texture_staging_pool,
                 super::staging::TextureStagingPool::new(),
@@ -1652,10 +1674,12 @@ pub(super) fn submit(
                             .devices
                             .get(&buf_dev)
                             .context("WriteBuffer pre-pass: device missing")?;
-                        let sc = state
+                        let sc_arc = state
                             .contexts
-                            .get_mut(&ctx)
-                            .context("WriteBuffer pre-pass: context missing")?;
+                            .get(&ctx)
+                            .context("WriteBuffer pre-pass: context missing")?
+                            .clone();
+                        let mut sc = sc_arc.lock().unwrap();
                         let (res, off) = sc.staging_belt.write(ld, data)?;
                         belt_slices.push((res, off));
                     }
@@ -1702,8 +1726,8 @@ pub(super) fn submit(
             }
         }
 
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.texture_staging_pool = pool;
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc.lock().unwrap().texture_staging_pool = pool;
         }
     }
 
@@ -1829,6 +1853,8 @@ pub(super) fn submit_graph(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let _tz = tracy_zone!("dx12.submit_graph");
     let (command_list, fence_value, slot_idx) = acquire_allocator_slot(state, ctx)?;
@@ -1839,10 +1865,10 @@ pub(super) fn submit_graph(
             .get(&device_handle)
             .context("Invalid device handle")?;
         let ctx_fence = state
-            .contexts
+            .context_fences
             .get(&ctx)
             .context("Invalid context handle")?
-            .fence
+            .1
             .clone();
         (ctx_fence, dev.adapter_id == super::WARP_ADAPTER_ID)
     };
@@ -1859,10 +1885,12 @@ pub(super) fn submit_graph(
     });
     if has_upload {
         let completed = super::context::device_retired(state, device_handle);
-        let sc = state
+        let sc_arc = state
             .contexts
-            .get_mut(&ctx)
-            .context("Invalid context handle")?;
+            .get(&ctx)
+            .context("Invalid context handle")?
+            .clone();
+        let mut sc = sc_arc.lock().unwrap();
         sc.staging_belt.reclaim(&ctx_fence_clone)?;
         sc.texture_staging_pool.reclaim(completed);
     }
@@ -1875,10 +1903,12 @@ pub(super) fn submit_graph(
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
     if has_upload {
         let mut pool = {
-            let sc = state
+            let sc_arc = state
                 .contexts
-                .get_mut(&ctx)
-                .context("Invalid context handle")?;
+                .get(&ctx)
+                .context("Invalid context handle")?
+                .clone();
+            let mut sc = sc_arc.lock().unwrap();
             std::mem::replace(
                 &mut sc.texture_staging_pool,
                 super::staging::TextureStagingPool::new(),
@@ -1904,10 +1934,12 @@ pub(super) fn submit_graph(
                                 .devices
                                 .get(&buf_dev)
                                 .context("WriteBuffer pre-pass: device missing")?;
-                            let sc = state
+                            let sc_arc = state
                                 .contexts
-                                .get_mut(&ctx)
-                                .context("WriteBuffer pre-pass: context missing")?;
+                                .get(&ctx)
+                                .context("WriteBuffer pre-pass: context missing")?
+                                .clone();
+                            let mut sc = sc_arc.lock().unwrap();
                             let (res, off) = sc.staging_belt.write(ld, data)?;
                             belt_slices.push((res, off));
                         }
@@ -1955,8 +1987,8 @@ pub(super) fn submit_graph(
             }
         }
 
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.texture_staging_pool = pool;
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc.lock().unwrap().texture_staging_pool = pool;
         }
     }
 
@@ -2151,9 +2183,16 @@ pub(super) fn try_resubmit_retained(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let retained = {
-        let sc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let sc_arc = state
+            .contexts
+            .get(&ctx)
+            .context("Invalid context handle")?
+            .clone();
+        let sc = sc_arc.lock().unwrap();
         match sc.retained_graph.as_ref() {
             Some(r) if r.fingerprint == key => {
                 Some((r.command_list.clone(), r.slot_idx, r.used_slots.clone()))
@@ -2178,12 +2217,17 @@ pub(super) fn try_resubmit_retained(
         .context("Failed to cast retained command list")?;
 
     let (ctx_fence, command_queue) = {
-        let sc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let ctx_fence = state
+            .context_fences
+            .get(&ctx)
+            .context("Invalid context handle")?
+            .1
+            .clone();
         let ld = state
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        (sc.fence.clone(), ld.command_queue.clone())
+        (ctx_fence, ld.command_queue.clone())
     };
     {
         let _tz = tracy_zone!("dx12.resubmit_retained");
@@ -2201,7 +2245,8 @@ pub(super) fn try_resubmit_retained(
             .record_slot_usage(ctx, fence_value, used_slots.iter().copied());
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         if let Some(slot) = sc.compute_allocator_pool.get_mut(slot_idx) {
             slot.fence_value = fence_value;
         }
@@ -2211,9 +2256,12 @@ pub(super) fn try_resubmit_retained(
     let retired_ctx_completed = unsafe { ctx_fence.GetCompletedValue() };
     let retained_del_batch: Vec<_> = state
         .contexts
-        .get_mut(&ctx)
-        .map(|sc| {
-            sc.deletion_queue
+        .get(&ctx)
+        .map(|sc_arc| {
+            sc_arc
+                .lock()
+                .unwrap()
+                .deletion_queue
                 .drain_up_to_completed(retired_ctx_completed)
         })
         .unwrap_or_default();
@@ -2223,7 +2271,7 @@ pub(super) fn try_resubmit_retained(
         for resource in retained_del_batch {
             types::destroy_pending_deletion(dev, &mut ledger, resource);
         }
-        ledger.drain_ready_slot_reclamations(&state.contexts);
+        ledger.drain_ready_slot_reclamations(&state.context_fences);
     }
 
     Ok(Some(fence_value))
@@ -2231,7 +2279,8 @@ pub(super) fn try_resubmit_retained(
 
 /// Drop the retained command list for `key`, marking its pool slot as reusable.
 pub(super) fn evict_retained(state: &mut Dx12State, ctx: ContextHandle) {
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         if let Some(old) = sc.retained_graph.take() {
             if let Some(slot) = sc.compute_allocator_pool.get_mut(old.slot_idx) {
                 slot.retained = false;

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -5,7 +5,6 @@ use super::super::shared::{PushLayout, DISPATCH_BATCH_STRIDE};
 use super::barriers;
 use super::pso_cache;
 use super::shader;
-use super::staging;
 use super::types::{self, ComputeAllocatorSlot, ComputePipelineState, DeferredSlot, Dx12State};
 use super::{ComputePipelineHandle, ContextHandle, DeviceHandle, RenderTargetHandle, ShaderHandle};
 use crate::backend::{GpuCommand, GraphCommand, RenderCommand};
@@ -683,12 +682,8 @@ fn acquire_allocator_slot(
         .devices
         .get(&device_handle)
         .context("Invalid device handle")?
-        .timeline_next;
-    state
-        .devices
-        .get_mut(&device_handle)
-        .context("Invalid device handle")?
-        .timeline_next += 1;
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     Ok((cmd_list, token, slot_idx))
 }
 
@@ -989,7 +984,7 @@ fn record_gpu_command(
                     cl.ExecuteIndirect(&batch_sig, *count, &arg_resource, 0, None, 0);
                 }
 
-                let fence_val = logical_device.timeline_next.saturating_sub(1);
+                let fence_val = logical_device.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
                 let dev = state
                     .devices
                     .get_mut(&device_handle)
@@ -1524,21 +1519,18 @@ fn execute_signal_and_finish(
     }
 
     state
-        .staging_belts
-        .entry(device_handle)
-        .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-        .finish(fence_value);
+        .contexts
+        .get_mut(&ctx)
+        .map(|sc| sc.staging_belt.finish(fence_value));
 
     if !staged_texture_uploads.is_empty() {
         let entries = staged_texture_uploads
             .into_iter()
             .map(|u| u.staging_entry)
             .collect::<Vec<_>>();
-        state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(super::staging::TextureStagingPool::new)
-            .release(fence_value, entries);
+        if let Some(sc) = state.contexts.get_mut(&ctx) {
+            sc.texture_staging_pool.release(fence_value, entries);
+        }
     }
 
     Ok(fence_value)
@@ -1589,15 +1581,13 @@ pub(super) fn submit(
     });
     if has_upload {
         let _tz_reclaim = tracy_zone!("dx12.submit.staging_reclaim");
-        state
-            .staging_belts
-            .entry(device_handle)
-            .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-            .reclaim(&ctx_fence_clone)?;
         let completed = super::context::device_retired(state, device_handle);
-        if let Some(pool) = state.texture_staging_pools.get_mut(&device_handle) {
-            pool.reclaim(completed);
-        }
+        let sc = state
+            .contexts
+            .get_mut(&ctx)
+            .context("Invalid context handle")?;
+        sc.staging_belt.reclaim(&ctx_fence_clone)?;
+        sc.texture_staging_pool.reclaim(completed);
     }
 
     let command_list7: ID3D12GraphicsCommandList7 = command_list
@@ -1607,10 +1597,16 @@ pub(super) fn submit(
     let mut belt_slices: Vec<(ID3D12Resource, u64)> = Vec::new();
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
     if has_upload {
-        let mut pool = state
-            .texture_staging_pools
-            .remove(&device_handle)
-            .unwrap_or_else(super::staging::TextureStagingPool::new);
+        let mut pool = {
+            let sc = state
+                .contexts
+                .get_mut(&ctx)
+                .context("Invalid context handle")?;
+            std::mem::replace(
+                &mut sc.texture_staging_pool,
+                super::staging::TextureStagingPool::new(),
+            )
+        };
 
         let _tz_prepass = tracy_zone!("dx12.submit.upload_prepass");
         for command in commands {
@@ -1630,10 +1626,11 @@ pub(super) fn submit(
                             .devices
                             .get(&buf_dev)
                             .context("WriteBuffer pre-pass: device missing")?;
-                        let belt = state.staging_belts.entry(buf_dev).or_insert_with(|| {
-                            staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                        });
-                        let (res, off) = belt.write(ld, data)?;
+                        let sc = state
+                            .contexts
+                            .get_mut(&ctx)
+                            .context("WriteBuffer pre-pass: context missing")?;
+                        let (res, off) = sc.staging_belt.write(ld, data)?;
                         belt_slices.push((res, off));
                     }
                 }
@@ -1679,7 +1676,9 @@ pub(super) fn submit(
             }
         }
 
-        state.texture_staging_pools.insert(device_handle, pool);
+        if let Some(sc) = state.contexts.get_mut(&ctx) {
+            sc.texture_staging_pool = pool;
+        }
     }
 
     let mut dx_gpu_profile = {
@@ -1833,15 +1832,13 @@ pub(super) fn submit_graph(
         )
     });
     if has_upload {
-        state
-            .staging_belts
-            .entry(device_handle)
-            .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-            .reclaim(&ctx_fence_clone)?;
         let completed = super::context::device_retired(state, device_handle);
-        if let Some(pool) = state.texture_staging_pools.get_mut(&device_handle) {
-            pool.reclaim(completed);
-        }
+        let sc = state
+            .contexts
+            .get_mut(&ctx)
+            .context("Invalid context handle")?;
+        sc.staging_belt.reclaim(&ctx_fence_clone)?;
+        sc.texture_staging_pool.reclaim(completed);
     }
 
     let command_list7: ID3D12GraphicsCommandList7 = command_list
@@ -1851,10 +1848,16 @@ pub(super) fn submit_graph(
     let mut belt_slices: Vec<(ID3D12Resource, u64)> = Vec::new();
     let mut staged_texture_uploads: Vec<super::texture::StagedTextureUpload> = Vec::new();
     if has_upload {
-        let mut pool = state
-            .texture_staging_pools
-            .remove(&device_handle)
-            .unwrap_or_else(super::staging::TextureStagingPool::new);
+        let mut pool = {
+            let sc = state
+                .contexts
+                .get_mut(&ctx)
+                .context("Invalid context handle")?;
+            std::mem::replace(
+                &mut sc.texture_staging_pool,
+                super::staging::TextureStagingPool::new(),
+            )
+        };
 
         let _tz_prepass = tracy_zone!("dx12.submit_graph.upload_prepass");
         for graph_cmd in commands {
@@ -1875,10 +1878,11 @@ pub(super) fn submit_graph(
                                 .devices
                                 .get(&buf_dev)
                                 .context("WriteBuffer pre-pass: device missing")?;
-                            let belt = state.staging_belts.entry(buf_dev).or_insert_with(|| {
-                                staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                            });
-                            let (res, off) = belt.write(ld, data)?;
+                            let sc = state
+                                .contexts
+                                .get_mut(&ctx)
+                                .context("WriteBuffer pre-pass: context missing")?;
+                            let (res, off) = sc.staging_belt.write(ld, data)?;
                             belt_slices.push((res, off));
                         }
                     }
@@ -1925,7 +1929,9 @@ pub(super) fn submit_graph(
             }
         }
 
-        state.texture_staging_pools.insert(device_handle, pool);
+        if let Some(sc) = state.contexts.get_mut(&ctx) {
+            sc.texture_staging_pool = pool;
+        }
     }
 
     let mut dx_gpu_profile = {
@@ -2130,15 +2136,12 @@ pub(super) fn try_resubmit_retained(
         return Ok(None);
     };
 
-    let fence_value = {
-        let dev = state
-            .devices
-            .get_mut(&device_handle)
-            .context("Invalid device handle")?;
-        let token = dev.timeline_next;
-        dev.timeline_next += 1;
-        token
-    };
+    let fence_value = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     let cmd_list: ID3D12CommandList = command_list
         .cast()

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -706,6 +706,7 @@ struct CmdCtx<'a> {
 fn record_gpu_command(
     state: &mut Dx12State,
     device_handle: DeviceHandle,
+    ctx_handle: super::ContextHandle,
     ctx: &mut CmdCtx<'_>,
     cmd: &GpuCommand,
 ) -> Result<()> {
@@ -984,15 +985,16 @@ fn record_gpu_command(
                     cl.ExecuteIndirect(&batch_sig, *count, &arg_resource, 0, None, 0);
                 }
 
-                let fence_val = logical_device.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
-                let dev = state
-                    .devices
-                    .get_mut(&device_handle)
-                    .context("DispatchBatch: device gone")?;
-                dev.deletion_queue.queue(
-                    fence_val,
-                    super::types::PendingDeletion::StandaloneResource(arg_resource),
-                );
+                let fence_val = logical_device
+                    .timeline_next
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    .saturating_sub(1);
+                if let Some(sc) = state.contexts.get_mut(&ctx_handle) {
+                    sc.deletion_queue.queue(
+                        fence_val,
+                        super::types::PendingDeletion::StandaloneResource(arg_resource),
+                    );
+                }
             } else {
                 use crate::backend::shared::{PushLayout, DISPATCH_BATCH_STRIDE};
                 let stride = DISPATCH_BATCH_STRIDE;
@@ -1512,9 +1514,16 @@ fn execute_signal_and_finish(
         sc.last_submitted_seq = fence_value;
     }
 
-    let retired = super::context::device_retired(state, device_handle);
+    let ctx_completed = unsafe { ctx_fence.GetCompletedValue() };
+    let ctx_del_batch: Vec<_> = state
+        .contexts
+        .get_mut(&ctx)
+        .map(|sc| sc.deletion_queue.drain_up_to_completed(ctx_completed))
+        .unwrap_or_default();
     if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.process_deletion_queue_up_to(retired);
+        for resource in ctx_del_batch {
+            types::destroy_pending_deletion(dev, resource);
+        }
         dev.drain_ready_slot_reclamations(&state.contexts);
     }
 
@@ -1713,7 +1722,7 @@ pub(super) fn submit(
 
     let belt_idx_final = {
         let _tz_cmds = tracy_zone!("dx12.submit.record_commands");
-        let mut ctx = CmdCtx {
+        let mut cmd_ctx = CmdCtx {
             command_list: &command_list,
             command_list7: &command_list7,
             use_global_buffer_barriers,
@@ -1726,14 +1735,14 @@ pub(super) fn submit(
             current_compute_pipeline: None,
         };
         for cmd in commands {
-            record_gpu_command(state, device_handle, &mut ctx, cmd)?;
+            record_gpu_command(state, device_handle, ctx, &mut cmd_ctx, cmd)?;
         }
         debug_assert_eq!(
-            ctx.texture_upload_idx,
+            cmd_ctx.texture_upload_idx,
             staged_texture_uploads.len(),
             "WriteTexture command count mismatch vs staging pre-pass"
         );
-        ctx.belt_idx
+        cmd_ctx.belt_idx
     };
 
     // Tail barrier: make UAV and copy writes visible to subsequent operations.
@@ -1968,7 +1977,7 @@ pub(super) fn submit_graph(
     let belt_idx_final;
     {
         let _tz_cmds = tracy_zone!("dx12.submit_graph.record_commands");
-        let mut ctx = CmdCtx {
+        let mut cmd_ctx = CmdCtx {
             command_list: &command_list,
             command_list7: &command_list7,
             use_global_buffer_barriers,
@@ -1984,7 +1993,7 @@ pub(super) fn submit_graph(
         for graph_cmd in commands {
             match graph_cmd {
                 GraphCommand::Compute(gpu_cmd) => {
-                    record_gpu_command(state, device_handle, &mut ctx, gpu_cmd)?;
+                    record_gpu_command(state, device_handle, ctx, &mut cmd_ctx, gpu_cmd)?;
                 }
                 GraphCommand::Render {
                     target,
@@ -2011,7 +2020,9 @@ pub(super) fn submit_graph(
                                 | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
                         ),
                     };
-                    unsafe { barriers::barrier_globals(ctx.command_list7, &[compute_to_render]) };
+                    unsafe {
+                        barriers::barrier_globals(cmd_ctx.command_list7, &[compute_to_render])
+                    };
 
                     super::render_target::record_render_pass_to_list(
                         state,
@@ -2039,18 +2050,20 @@ pub(super) fn submit_graph(
                                 | D3D12_BARRIER_ACCESS_SHADER_RESOURCE.0,
                         ),
                     };
-                    unsafe { barriers::barrier_globals(ctx.command_list7, &[render_to_compute]) };
+                    unsafe {
+                        barriers::barrier_globals(cmd_ctx.command_list7, &[render_to_compute])
+                    };
                 }
             }
         }
 
         debug_assert_eq!(
-            ctx.texture_upload_idx,
+            cmd_ctx.texture_upload_idx,
             staged_texture_uploads.len(),
             "WriteTexture command count mismatch vs staging pre-pass"
         );
-        belt_idx_final = ctx.belt_idx;
-    } // drop ctx → release borrows on command_list / command_list7
+        belt_idx_final = cmd_ctx.belt_idx;
+    } // drop cmd_ctx → release borrows on command_list / command_list7
 
     let tail = D3D12_GLOBAL_BARRIER {
         SyncBefore: D3D12_BARRIER_SYNC(
@@ -2175,9 +2188,19 @@ pub(super) fn try_resubmit_retained(
         sc.last_submitted_seq = fence_value;
     }
 
-    let retired = super::context::device_retired(state, device_handle);
+    let retired_ctx_completed = unsafe { ctx_fence.GetCompletedValue() };
+    let retained_del_batch: Vec<_> = state
+        .contexts
+        .get_mut(&ctx)
+        .map(|sc| {
+            sc.deletion_queue
+                .drain_up_to_completed(retired_ctx_completed)
+        })
+        .unwrap_or_default();
     if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.process_deletion_queue_up_to(retired);
+        for resource in retained_del_batch {
+            types::destroy_pending_deletion(dev, resource);
+        }
         dev.drain_ready_slot_reclamations(&state.contexts);
     }
 

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -492,7 +492,7 @@ pub(super) fn create(
 
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     // Use the shared bindless root signature from the device
@@ -1469,7 +1469,7 @@ fn execute_signal_and_finish(
 
     let cmd_list: ID3D12CommandList = command_list.cast().context("Failed to cast command list")?;
 
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
+    if let Some(ld) = state.devices.get(&device_handle) {
         ld.ledger
             .lock()
             .unwrap()
@@ -1535,7 +1535,7 @@ fn execute_signal_and_finish(
         .get_mut(&ctx)
         .map(|sc| sc.deletion_queue.drain_up_to_completed(ctx_completed))
         .unwrap_or_default();
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
+    if let Some(dev) = state.devices.get(&device_handle) {
         let ledger_arc = std::sync::Arc::clone(&dev.ledger);
         let mut ledger = ledger_arc.lock().unwrap();
         for resource in ctx_del_batch {
@@ -2194,7 +2194,7 @@ pub(super) fn try_resubmit_retained(
             .context("Failed to signal context fence after retained resubmit")?;
     }
 
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
+    if let Some(ld) = state.devices.get(&device_handle) {
         ld.ledger
             .lock()
             .unwrap()
@@ -2217,7 +2217,7 @@ pub(super) fn try_resubmit_retained(
                 .drain_up_to_completed(retired_ctx_completed)
         })
         .unwrap_or_default();
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
+    if let Some(dev) = state.devices.get(&device_handle) {
         let ledger_arc = std::sync::Arc::clone(&dev.ledger);
         let mut ledger = ledger_arc.lock().unwrap();
         for resource in retained_del_batch {

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -504,9 +504,16 @@ pub(super) fn create(
 
     tracing::debug!("Using shared bindless root signature for compute pipeline");
 
-    let disk_blob = logical_device.compute_pso_blobs.get(&key);
-    let mut try_drop_stale_cached_blob = disk_blob.is_some();
-    let cached_pso = disk_blob
+    let pso_cache_arc = std::sync::Arc::clone(&logical_device.pso_cache);
+    let disk_blob_bytes: Option<Vec<u8>> = pso_cache_arc
+        .read()
+        .unwrap()
+        .compute_blobs
+        .get(&key)
+        .cloned();
+    let mut try_drop_stale_cached_blob = disk_blob_bytes.is_some();
+    let cached_pso = disk_blob_bytes
+        .as_ref()
         .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
         .unwrap_or_default();
 
@@ -533,8 +540,10 @@ pub(super) fn create(
                         error = ?e,
                         "discarding stale DX12 compute PSO blob; rebuilding without cache entry"
                     );
-                    logical_device.compute_pso_blobs.remove(&key);
-                    logical_device.pso_disk_cache_dirty = true;
+                    let mut cache = pso_cache_arc.write().unwrap();
+                    cache.compute_blobs.remove(&key);
+                    cache.dirty = true;
+                    drop(cache);
                     pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
                     try_drop_stale_cached_blob = false;
                 }
@@ -550,11 +559,14 @@ pub(super) fn create(
     };
     let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
 
-    match logical_device.compute_pso_blobs.get(&key) {
-        Some(prev) if *prev == new_blob => {}
-        _ => {
-            logical_device.compute_pso_blobs.insert(key, new_blob);
-            logical_device.pso_disk_cache_dirty = true;
+    {
+        let mut cache = pso_cache_arc.write().unwrap();
+        match cache.compute_blobs.get(&key) {
+            Some(prev) if *prev == new_blob => {}
+            _ => {
+                cache.compute_blobs.insert(key, new_blob);
+                cache.dirty = true;
+            }
         }
     }
 
@@ -1458,7 +1470,10 @@ fn execute_signal_and_finish(
     let cmd_list: ID3D12CommandList = command_list.cast().context("Failed to cast command list")?;
 
     if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.record_slot_usage(ctx, fence_value, used_slots.iter().copied());
+        ld.ledger
+            .lock()
+            .unwrap()
+            .record_slot_usage(ctx, fence_value, used_slots.iter().copied());
     }
 
     let logical_device = state.devices.get(&device_handle).unwrap();
@@ -1521,10 +1536,12 @@ fn execute_signal_and_finish(
         .map(|sc| sc.deletion_queue.drain_up_to_completed(ctx_completed))
         .unwrap_or_default();
     if let Some(dev) = state.devices.get_mut(&device_handle) {
+        let ledger_arc = std::sync::Arc::clone(&dev.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for resource in ctx_del_batch {
-            types::destroy_pending_deletion(dev, resource);
+            types::destroy_pending_deletion(dev, &mut ledger, resource);
         }
-        dev.drain_ready_slot_reclamations(&state.contexts);
+        ledger.drain_ready_slot_reclamations(&state.contexts);
     }
 
     state
@@ -2178,7 +2195,10 @@ pub(super) fn try_resubmit_retained(
     }
 
     if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.record_slot_usage(ctx, fence_value, used_slots.iter().copied());
+        ld.ledger
+            .lock()
+            .unwrap()
+            .record_slot_usage(ctx, fence_value, used_slots.iter().copied());
     }
 
     if let Some(sc) = state.contexts.get_mut(&ctx) {
@@ -2198,10 +2218,12 @@ pub(super) fn try_resubmit_retained(
         })
         .unwrap_or_default();
     if let Some(dev) = state.devices.get_mut(&device_handle) {
+        let ledger_arc = std::sync::Arc::clone(&dev.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for resource in retained_del_batch {
-            types::destroy_pending_deletion(dev, resource);
+            types::destroy_pending_deletion(dev, &mut ledger, resource);
         }
-        dev.drain_ready_slot_reclamations(&state.contexts);
+        ledger.drain_ready_slot_reclamations(&state.contexts);
     }
 
     Ok(Some(fence_value))

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -77,6 +77,10 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
             fence_thread,
             compute_allocator_pool,
             retained_graph: None,
+            staging_belt: super::staging::StagingBelt::new(
+                super::staging::DEFAULT_STAGING_CHUNK_SIZE,
+            ),
+            texture_staging_pool: super::staging::TextureStagingPool::new(),
         },
     );
     Ok(id)
@@ -105,6 +109,10 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
             slot.retained = false;
         }
     }
+
+    // GPU is idle for this context (waited above); destroy per-context staging resources.
+    unsafe { sc.staging_belt.destroy_all() };
+    unsafe { sc.texture_staging_pool.destroy_all() };
 }
 
 pub(super) fn context_device(state: &Dx12State, ctx: ContextHandle) -> DeviceHandle {

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -119,8 +119,10 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
     let batch = sc.deletion_queue.drain_everything();
     if !batch.is_empty() {
         if let Some(ld) = state.devices.get_mut(&device) {
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            let mut ledger = ledger_arc.lock().unwrap();
             for resource in batch {
-                super::types::destroy_pending_deletion(ld, resource);
+                super::types::destroy_pending_deletion(ld, &mut ledger, resource);
             }
         }
     }

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -81,6 +81,7 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
                 super::staging::DEFAULT_STAGING_CHUNK_SIZE,
             ),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
+            deletion_queue: super::types::DeletionQueue::new(),
         },
     );
     Ok(id)
@@ -113,6 +114,16 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
     // GPU is idle for this context (waited above); destroy per-context staging resources.
     unsafe { sc.staging_belt.destroy_all() };
     unsafe { sc.texture_staging_pool.destroy_all() };
+
+    // Drain any remaining per-context pending deletions now that the GPU is idle.
+    let batch = sc.deletion_queue.drain_everything();
+    if !batch.is_empty() {
+        if let Some(ld) = state.devices.get_mut(&device) {
+            for resource in batch {
+                super::types::destroy_pending_deletion(ld, resource);
+            }
+        }
+    }
 }
 
 pub(super) fn context_device(state: &Dx12State, ctx: ContextHandle) -> DeviceHandle {

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -10,7 +10,7 @@ pub(super) fn device_retired(state: &Dx12State, device: DeviceHandle) -> u64 {
     let floor = state
         .devices
         .get(&device)
-        .map(|d| d.retired_floor)
+        .map(|d| d.retired_floor.load(std::sync::atomic::Ordering::Relaxed))
         .unwrap_or(0);
     let max_ctx = state
         .contexts
@@ -99,8 +99,9 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
     }
 
     let completed = unsafe { sc.fence.GetCompletedValue() };
-    if let Some(ld) = state.devices.get_mut(&device) {
-        ld.retired_floor = ld.retired_floor.max(completed);
+    if let Some(ld) = state.devices.get(&device) {
+        ld.retired_floor
+            .fetch_max(completed, std::sync::atomic::Ordering::Relaxed);
     }
 
     crate::backend::signal_fence::join_fence_poller(&sc.fence_shutdown, sc.fence_thread.take());
@@ -118,7 +119,7 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
     // Drain any remaining per-context pending deletions now that the GPU is idle.
     let batch = sc.deletion_queue.drain_everything();
     if !batch.is_empty() {
-        if let Some(ld) = state.devices.get_mut(&device) {
+        if let Some(ld) = state.devices.get(&device) {
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             let mut ledger = ledger_arc.lock().unwrap();
             for resource in batch {

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -12,11 +12,12 @@ pub(super) fn device_retired(state: &Dx12State, device: DeviceHandle) -> u64 {
         .get(&device)
         .map(|d| d.retired_floor.load(std::sync::atomic::Ordering::Relaxed))
         .unwrap_or(0);
+    // Use context_fences for a lock-free scan over per-context fence completion values.
     let max_ctx = state
-        .contexts
+        .context_fences
         .values()
-        .filter(|c| c.device == device)
-        .map(|c| unsafe { c.fence.GetCompletedValue() })
+        .filter(|(dev, _)| *dev == device)
+        .map(|(_, fence)| unsafe { fence.GetCompletedValue() })
         .max()
         .unwrap_or(0);
     let device_sync = state
@@ -66,9 +67,14 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
 
     let id = state.next_context_id;
     state.next_context_id = state.next_context_id.saturating_add(1);
+
+    // Register the fence in the lock-free index before inserting the context so that
+    // any concurrent drain_ready_slot_reclamations sees a consistent view.
+    state.context_fences.insert(id, (device, fence.clone()));
+
     state.contexts.insert(
         id,
-        Dx12SubmissionContext {
+        std::sync::Arc::new(std::sync::Mutex::new(Dx12SubmissionContext {
             device,
             fence,
             last_submitted_seq: 0,
@@ -82,15 +88,24 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
             ),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
             deletion_queue: super::types::DeletionQueue::new(),
-        },
+        })),
     );
     Ok(id)
 }
 
 pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
-    let Some(mut sc) = state.contexts.remove(&ctx) else {
+    // Remove from both maps first; the fence index must not outlive the context.
+    let Some(sc_arc) = state.contexts.remove(&ctx) else {
         return;
     };
+    state.context_fences.remove(&ctx);
+
+    // We are the sole owner at this point (no Phase-5c clone is outstanding yet),
+    // so try_unwrap should always succeed.
+    let sc_mutex = std::sync::Arc::try_unwrap(sc_arc)
+        .unwrap_or_else(|_| panic!("context {ctx} Arc still has extra owners at destroy"));
+    let mut sc = sc_mutex.into_inner().expect("context Mutex poisoned");
+
     let device = sc.device;
 
     // Drain in-flight GPU work before releasing command allocators / retained CLs.
@@ -134,5 +149,7 @@ pub(super) fn context_device(state: &Dx12State, ctx: ContextHandle) -> DeviceHan
         .contexts
         .get(&ctx)
         .expect("invalid context handle")
+        .lock()
+        .expect("context Mutex poisoned")
         .device
 }

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -413,7 +413,7 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
 
     state.devices.insert(
         handle,
-        LogicalDevice {
+        std::sync::Arc::new(LogicalDevice {
             device,
             adapter_id,
             command_queue,
@@ -428,24 +428,24 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             sampler_descriptor_size,
             fence,
             timeline_next: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(1)),
-            retired_floor: 0,
+            retired_floor: std::sync::atomic::AtomicU64::new(0),
             supports_reserved_buffers,
-            tile_heap_pool: if supports_reserved_buffers {
+            tile_heap_pool: std::sync::Mutex::new(if supports_reserved_buffers {
                 Some(super::tiles::TileHeapPool::new())
             } else {
                 None
-            },
+            }),
             bindless_root_signature,
             compute_dispatch_indirect_signature,
             compute_batch_dispatch_signature,
             zero_buffer,
-            deletion_queue: super::types::DeletionQueue::new(),
+            deletion_queue: std::sync::Mutex::new(super::types::DeletionQueue::new()),
             ledger: std::sync::Arc::new(std::sync::Mutex::new(super::types::DeviceLedger::new())),
             pso_cache: std::sync::Arc::new(std::sync::RwLock::new(super::types::PsoCache::new(
                 graphics_pso_blobs,
                 compute_pso_blobs,
             ))),
-        },
+        }),
     );
 
     tracing::info!("Created DX12 device {} for adapter {}", handle, adapter_id);

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -429,7 +429,7 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             sampler_heap,
             sampler_descriptor_size,
             fence,
-            timeline_next: 1,
+            timeline_next: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(1)),
             retired_floor: 0,
             supports_reserved_buffers,
             tile_heap_pool: if supports_reserved_buffers {

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -400,8 +400,6 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
     let handle = state.next_device_handle;
     state.next_device_handle += 1;
 
-    let resource_registry = types::ResourceRegistry::new();
-
     let (graphics_pso_blobs, compute_pso_blobs) = dirs::cache_dir().map_or_else(
         || (HashMap::new(), HashMap::new()),
         |cache_root| {
@@ -440,14 +438,13 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             bindless_root_signature,
             compute_dispatch_indirect_signature,
             compute_batch_dispatch_signature,
-            resource_registry,
             zero_buffer,
             deletion_queue: super::types::DeletionQueue::new(),
-            slot_last_seen: HashMap::new(),
-            pending_slot_reclamations: Vec::new(),
-            graphics_pso_blobs,
-            compute_pso_blobs,
-            pso_disk_cache_dirty: false,
+            ledger: std::sync::Arc::new(std::sync::Mutex::new(super::types::DeviceLedger::new())),
+            pso_cache: std::sync::Arc::new(std::sync::RwLock::new(super::types::PsoCache::new(
+                graphics_pso_blobs,
+                compute_pso_blobs,
+            ))),
         },
     );
 

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -373,15 +373,16 @@ impl Dx12Backend {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             logical_device.flush_deletion_queue();
 
-            if logical_device.pso_disk_cache_dirty {
+            let pso_cache = logical_device.pso_cache.read().unwrap();
+            if pso_cache.dirty {
                 if let Some(cache_root) = dirs::cache_dir() {
                     let path = cache_root
                         .join("goldy")
                         .join(format!("dx12_pso_{}.bin", logical_device.adapter_id));
                     if let Err(e) = pso_cache::save_maps(
                         &path,
-                        &logical_device.graphics_pso_blobs,
-                        &logical_device.compute_pso_blobs,
+                        &pso_cache.graphics_blobs,
+                        &pso_cache.compute_blobs,
                     ) {
                         tracing::warn!(
                             error = ?e,
@@ -954,7 +955,11 @@ impl GpuBackend for Dx12Backend {
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(value.min(retired));
-            ld.drain_ready_slot_reclamations(&self.state.contexts);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            ledger_arc
+                .lock()
+                .unwrap()
+                .drain_ready_slot_reclamations(&self.state.contexts);
         }
         Ok(())
     }
@@ -990,7 +995,11 @@ impl GpuBackend for Dx12Backend {
             let retired = context::device_retired(&self.state, device_handle);
             if let Some(dev) = self.state.devices.get_mut(&device_handle) {
                 dev.process_deletion_queue_up_to(value.min(retired));
-                dev.drain_ready_slot_reclamations(&self.state.contexts);
+                let ledger_arc = std::sync::Arc::clone(&dev.ledger);
+                ledger_arc
+                    .lock()
+                    .unwrap()
+                    .drain_ready_slot_reclamations(&self.state.contexts);
             }
         }
         Ok(ok)
@@ -1213,7 +1222,13 @@ impl GpuBackend for Dx12Backend {
         self.state
             .devices
             .get(&device_handle)
-            .map(|ld| ld.resource_registry.available_slots(category))
+            .map(|ld| {
+                ld.ledger
+                    .lock()
+                    .unwrap()
+                    .resource_registry
+                    .available_slots(category)
+            })
             .unwrap_or(0)
     }
 
@@ -1230,7 +1245,11 @@ impl GpuBackend for Dx12Backend {
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
-            ld.drain_ready_slot_reclamations(&self.state.contexts);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            ledger_arc
+                .lock()
+                .unwrap()
+                .drain_ready_slot_reclamations(&self.state.contexts);
         }
     }
 

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -361,7 +361,7 @@ impl Dx12Backend {
 
 impl Dx12Backend {
     fn destroy_device_inner(&mut self, device_handle: DeviceHandle) {
-        if let Some(mut logical_device) = self.state.devices.remove(&device_handle) {
+        if let Some(logical_device) = self.state.devices.remove(&device_handle) {
             let _ = self.wait_for_gpu(&logical_device);
             // Advance timeline_next past the value consumed by wait_for_gpu so that
             // flush_deletion_queue's per-buffer Signal calls use fresh, strictly-increasing
@@ -953,7 +953,7 @@ impl GpuBackend for Dx12Backend {
             anyhow::bail!("GPU device removed (TDR)");
         }
         let retired = context::device_retired(&self.state, device_handle);
-        if let Some(ld) = self.state.devices.get_mut(&device_handle) {
+        if let Some(ld) = self.state.devices.get(&device_handle) {
             ld.process_deletion_queue_up_to(value.min(retired));
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             ledger_arc
@@ -993,7 +993,7 @@ impl GpuBackend for Dx12Backend {
                 anyhow::bail!("GPU device removed (TDR)");
             }
             let retired = context::device_retired(&self.state, device_handle);
-            if let Some(dev) = self.state.devices.get_mut(&device_handle) {
+            if let Some(dev) = self.state.devices.get(&device_handle) {
                 dev.process_deletion_queue_up_to(value.min(retired));
                 let ledger_arc = std::sync::Arc::clone(&dev.ledger);
                 ledger_arc
@@ -1243,7 +1243,7 @@ impl GpuBackend for Dx12Backend {
     fn flush_deferred_deletions(&mut self, ctx: ContextHandle) {
         let device_handle = self.context_device(ctx);
         let retired = context::device_retired(&self.state, device_handle);
-        if let Some(ld) = self.state.devices.get_mut(&device_handle) {
+        if let Some(ld) = self.state.devices.get(&device_handle) {
             ld.process_deletion_queue_up_to(retired);
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             ledger_arc
@@ -1258,7 +1258,7 @@ impl GpuBackend for Dx12Backend {
         self.state
             .devices
             .get(&device_handle)
-            .map(|d| d.deletion_queue.pending_len())
+            .map(|d| d.deletion_queue.lock().unwrap().pending_len())
             .unwrap_or(0)
     }
 }

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -342,8 +342,6 @@ impl Dx12Backend {
             next_dsv_offset: 0,
             free_dsv_offsets: Vec::new(),
             slang_compiler,
-            staging_belts: HashMap::new(),
-            texture_staging_pools: HashMap::new(),
             device_removed: std::sync::atomic::AtomicBool::new(false),
         };
 
@@ -352,7 +350,7 @@ impl Dx12Backend {
 
     /// Wait for the GPU to finish all work on a device (sync fence path).
     fn wait_for_gpu(&self, device: &LogicalDevice) -> Result<()> {
-        let fence_value = device.timeline_next;
+        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         utils::wait_for_fence(&device.fence, fence_value)
@@ -368,7 +366,7 @@ impl Dx12Backend {
             // fence values. Without this, PendingDeletion::Buffer re-signals the same value
             // that wait_for_gpu already used, violating D3D12's monotonic fence requirement
             // and causing an abnormal process exit (exit code 2173) on teardown.
-            logical_device.timeline_next += 1;
+            logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             logical_device.flush_deletion_queue();
 
             if logical_device.pso_disk_cache_dirty {
@@ -387,18 +385,6 @@ impl Dx12Backend {
                             "failed to save DX12 PSO disk cache"
                         );
                     }
-                }
-            }
-
-            if let Some(mut belt) = self.state.staging_belts.remove(&device_handle) {
-                unsafe {
-                    belt.destroy_all();
-                }
-            }
-
-            if let Some(mut pool) = self.state.texture_staging_pools.remove(&device_handle) {
-                unsafe {
-                    pool.destroy_all();
                 }
             }
 
@@ -1208,8 +1194,10 @@ impl GpuBackend for Dx12Backend {
     }
 
     fn reset_buffer_heaps(&mut self, device_handle: DeviceHandle) {
-        if let Some(belt) = self.state.staging_belts.get_mut(&device_handle) {
-            belt.trim();
+        for sc in self.state.contexts.values_mut() {
+            if sc.device == device_handle {
+                sc.staging_belt.trim();
+            }
         }
     }
 

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -321,6 +321,7 @@ impl Dx12Backend {
             next_device_handle: 1,
             contexts: HashMap::new(),
             next_context_id: 1,
+            context_fences: HashMap::new(),
             buffers: HashMap::new(),
             next_buffer_handle: 1,
             shaders: HashMap::new(),
@@ -508,7 +509,7 @@ impl GpuBackend for Dx12Backend {
             .state
             .contexts
             .iter()
-            .filter(|(_, sc)| sc.device == device_handle)
+            .filter(|(_, sc_arc)| sc_arc.lock().unwrap().device == device_handle)
             .map(|(k, _)| *k)
             .collect();
         for ctx in ctxs {
@@ -844,10 +845,10 @@ impl GpuBackend for Dx12Backend {
     }
 
     fn gpu_progress(&self, ctx: ContextHandle) -> crate::timeline::TimelineValue {
-        let Some(sc) = self.state.contexts.get(&ctx) else {
+        let Some(sc_arc) = self.state.contexts.get(&ctx) else {
             return 0;
         };
-        unsafe { sc.fence.GetCompletedValue() }
+        unsafe { sc_arc.lock().unwrap().fence.GetCompletedValue() }
     }
 
     fn device_timeline_retired(&self, device: DeviceHandle) -> crate::timeline::TimelineValue {
@@ -867,8 +868,15 @@ impl GpuBackend for Dx12Backend {
             .state
             .contexts
             .values()
-            .find(|c| c.device == device && c.last_submitted_seq >= value)
-            .map(|c| c.fence.clone());
+            .filter_map(|sc_arc| {
+                let sc = sc_arc.lock().unwrap();
+                if sc.device == device && sc.last_submitted_seq >= value {
+                    Some(sc.fence.clone())
+                } else {
+                    None
+                }
+            })
+            .next();
         if let Some(fence) = fence {
             utils::wait_for_fence(&fence, value)?;
         }
@@ -886,7 +894,7 @@ impl GpuBackend for Dx12Backend {
             .state
             .contexts
             .get(&ctx)
-            .map(|sc| std::sync::Arc::clone(&sc.signal_queue));
+            .map(|sc_arc| std::sync::Arc::clone(&sc_arc.lock().unwrap().signal_queue));
         let Some(signal_queue) = signal_queue else {
             return Vec::new();
         };
@@ -909,8 +917,9 @@ impl GpuBackend for Dx12Backend {
     }
 
     fn peek_oldest_in_flight(&self, ctx: ContextHandle) -> Option<crate::timeline::TimelineValue> {
-        let sc = self.state.contexts.get(&ctx)?;
-        let progress = self.gpu_progress(ctx);
+        let sc_arc = self.state.contexts.get(&ctx)?;
+        let sc = sc_arc.lock().unwrap();
+        let progress = unsafe { sc.fence.GetCompletedValue() };
         if progress < sc.last_submitted_seq {
             Some(progress.saturating_add(1))
         } else {
@@ -934,10 +943,10 @@ impl GpuBackend for Dx12Backend {
         let device_handle = self.context_device(ctx);
         let fence = self
             .state
-            .contexts
+            .context_fences
             .get(&ctx)
             .context("Invalid context handle")?
-            .fence
+            .1
             .clone();
         utils::wait_for_fence(&fence, value)?;
         // Detect TDR: device removal signals all fences with u64::MAX.
@@ -959,7 +968,7 @@ impl GpuBackend for Dx12Backend {
             ledger_arc
                 .lock()
                 .unwrap()
-                .drain_ready_slot_reclamations(&self.state.contexts);
+                .drain_ready_slot_reclamations(&self.state.context_fences);
         }
         Ok(())
     }
@@ -973,10 +982,10 @@ impl GpuBackend for Dx12Backend {
         let device_handle = self.context_device(ctx);
         let fence = self
             .state
-            .contexts
+            .context_fences
             .get(&ctx)
             .context("Invalid context handle")?
-            .fence
+            .1
             .clone();
         let ok = utils::wait_for_fence_timeout(&fence, value, timeout_ms)?;
         if ok {
@@ -999,7 +1008,7 @@ impl GpuBackend for Dx12Backend {
                 ledger_arc
                     .lock()
                     .unwrap()
-                    .drain_ready_slot_reclamations(&self.state.contexts);
+                    .drain_ready_slot_reclamations(&self.state.context_fences);
             }
         }
         Ok(ok)
@@ -1207,7 +1216,8 @@ impl GpuBackend for Dx12Backend {
     }
 
     fn reset_buffer_heaps(&mut self, device_handle: DeviceHandle) {
-        for sc in self.state.contexts.values_mut() {
+        for sc_arc in self.state.contexts.values() {
+            let mut sc = sc_arc.lock().unwrap();
             if sc.device == device_handle {
                 sc.staging_belt.trim();
             }
@@ -1249,7 +1259,7 @@ impl GpuBackend for Dx12Backend {
             ledger_arc
                 .lock()
                 .unwrap()
-                .drain_ready_slot_reclamations(&self.state.contexts);
+                .drain_ready_slot_reclamations(&self.state.context_fences);
         }
     }
 

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -350,7 +350,9 @@ impl Dx12Backend {
 
     /// Wait for the GPU to finish all work on a device (sync fence path).
     fn wait_for_gpu(&self, device: &LogicalDevice) -> Result<()> {
-        let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
+        let fence_value = device
+            .timeline_next
+            .load(std::sync::atomic::Ordering::Relaxed);
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }
             .context("Failed to signal fence")?;
         utils::wait_for_fence(&device.fence, fence_value)
@@ -366,7 +368,9 @@ impl Dx12Backend {
             // fence values. Without this, PendingDeletion::Buffer re-signals the same value
             // that wait_for_gpu already used, violating D3D12's monotonic fence requirement
             // and causing an abnormal process exit (exit code 2173) on teardown.
-            logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            logical_device
+                .timeline_next
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             logical_device.flush_deletion_queue();
 
             if logical_device.pso_disk_cache_dirty {

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -35,7 +35,7 @@ pub(super) fn create(
 
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     // Use the shared bindless root signature from the device
@@ -287,7 +287,7 @@ pub(super) fn create_with_depth(
 
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     let root_signature = logical_device

--- a/src/backend/dx12/pipeline.rs
+++ b/src/backend/dx12/pipeline.rs
@@ -92,9 +92,16 @@ pub(super) fn create(
         })
         .collect();
 
-    let disk_blob = logical_device.graphics_pso_blobs.get(&key);
-    let mut try_drop_stale_cached_blob = disk_blob.is_some();
-    let cached_pso = disk_blob
+    let pso_cache_arc = std::sync::Arc::clone(&logical_device.pso_cache);
+    let disk_blob_bytes: Option<Vec<u8>> = pso_cache_arc
+        .read()
+        .unwrap()
+        .graphics_blobs
+        .get(&key)
+        .cloned();
+    let mut try_drop_stale_cached_blob = disk_blob_bytes.is_some();
+    let cached_pso = disk_blob_bytes
+        .as_ref()
         .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
         .unwrap_or_default();
 
@@ -180,8 +187,10 @@ pub(super) fn create(
                     error = ?e,
                     "discarding stale DX12 graphics PSO blob; rebuilding without cache entry"
                 );
-                logical_device.graphics_pso_blobs.remove(&key);
-                logical_device.pso_disk_cache_dirty = true;
+                let mut cache = pso_cache_arc.write().unwrap();
+                cache.graphics_blobs.remove(&key);
+                cache.dirty = true;
+                drop(cache);
                 pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
                 try_drop_stale_cached_blob = false;
             }
@@ -196,11 +205,14 @@ pub(super) fn create(
     };
     let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
 
-    match logical_device.graphics_pso_blobs.get(&key) {
-        Some(prev) if *prev == new_blob => {}
-        _ => {
-            logical_device.graphics_pso_blobs.insert(key, new_blob);
-            logical_device.pso_disk_cache_dirty = true;
+    {
+        let mut cache = pso_cache_arc.write().unwrap();
+        match cache.graphics_blobs.get(&key) {
+            Some(prev) if *prev == new_blob => {}
+            _ => {
+                cache.graphics_blobs.insert(key, new_blob);
+                cache.dirty = true;
+            }
         }
     }
 
@@ -343,9 +355,16 @@ pub(super) fn create_with_depth(
         )
     };
 
-    let disk_blob = logical_device.graphics_pso_blobs.get(&key);
-    let mut try_drop_stale_cached_blob = disk_blob.is_some();
-    let cached_pso = disk_blob
+    let pso_cache_arc = std::sync::Arc::clone(&logical_device.pso_cache);
+    let disk_blob_bytes: Option<Vec<u8>> = pso_cache_arc
+        .read()
+        .unwrap()
+        .graphics_blobs
+        .get(&key)
+        .cloned();
+    let mut try_drop_stale_cached_blob = disk_blob_bytes.is_some();
+    let cached_pso = disk_blob_bytes
+        .as_ref()
         .map(|b| pso_cache::d3d12_cached_pso(b.as_slice()))
         .unwrap_or_default();
 
@@ -433,8 +452,10 @@ pub(super) fn create_with_depth(
                     error = ?e,
                     "discarding stale DX12 graphics depth-PSO blob; rebuilding without cache entry"
                 );
-                logical_device.graphics_pso_blobs.remove(&key);
-                logical_device.pso_disk_cache_dirty = true;
+                let mut cache = pso_cache_arc.write().unwrap();
+                cache.graphics_blobs.remove(&key);
+                cache.dirty = true;
+                drop(cache);
                 pso_desc.CachedPSO = D3D12_CACHED_PIPELINE_STATE::default();
                 try_drop_stale_cached_blob = false;
             }
@@ -452,11 +473,14 @@ pub(super) fn create_with_depth(
     };
     let new_blob = unsafe { pso_cache::id3dblob_to_vec(&blob) };
 
-    match logical_device.graphics_pso_blobs.get(&key) {
-        Some(prev) if *prev == new_blob => {}
-        _ => {
-            logical_device.graphics_pso_blobs.insert(key, new_blob);
-            logical_device.pso_disk_cache_dirty = true;
+    {
+        let mut cache = pso_cache_arc.write().unwrap();
+        match cache.graphics_blobs.get(&key) {
+            Some(prev) if *prev == new_blob => {}
+            _ => {
+                cache.graphics_blobs.insert(key, new_blob);
+                cache.dirty = true;
+            }
         }
     }
 

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -427,7 +427,9 @@ pub(super) fn render(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -583,7 +585,9 @@ pub(super) fn read_to_cpu(
     }
 
     // Wait for copy to complete
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -427,7 +427,7 @@ pub(super) fn render(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -437,10 +437,6 @@ pub(super) fn render(
     // Blocking wait — required so the shared command_allocator can be safely
     // Reset() before the next render_to_target call (see comment above Reset()).
     wait_for_fence(&logical_device.fence, fence_value)?;
-
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
-    }
 
     if let Some(rt) = state.render_targets.get_mut(&target) {
         rt.has_rendered = true;
@@ -587,7 +583,7 @@ pub(super) fn read_to_cpu(
     }
 
     // Wait for copy to complete
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -595,11 +591,6 @@ pub(super) fn read_to_cpu(
     }
     .context("Failed to signal fence")?;
     wait_for_fence(&logical_device.fence, fence_value)?;
-
-    // Increment fence value
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
-    }
 
     // Map and copy data
     let mut mapped_data: *mut u8 = std::ptr::null_mut();

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -40,7 +40,7 @@ pub(super) fn create_with_depth(
 ) -> Result<RenderTargetHandle> {
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     // Create color render target texture
@@ -383,7 +383,7 @@ pub(super) fn render(
 ) -> Result<()> {
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     // Reset the single shared command allocator. This is safe only because we do

--- a/src/backend/dx12/sampler.rs
+++ b/src/backend/dx12/sampler.rs
@@ -21,8 +21,12 @@ pub(super) fn create(
         .get_mut(&device_handle)
         .context("Invalid device handle")?;
 
-    // Use ResourceRegistry for sampler offset tracking
-    let sampler_offset = logical_device.resource_registry.register_sampler(handle);
+    let sampler_offset = logical_device
+        .ledger
+        .lock()
+        .unwrap()
+        .resource_registry
+        .register_sampler(handle);
 
     let sampler_desc = D3D12_SAMPLER_DESC {
         Filter: utils::filter_to_d3d12(desc.min_filter, desc.mag_filter, desc.mipmap_filter),
@@ -71,7 +75,10 @@ pub(super) fn create(
 pub(super) fn destroy(state: &mut Dx12State, sampler_handle: SamplerHandle) {
     if let Some(sampler) = state.samplers.remove(&sampler_handle) {
         if let Some(ld) = state.devices.get_mut(&sampler.device_handle) {
-            ld.reclaim_sampler_slots(sampler_handle);
+            ld.ledger
+                .lock()
+                .unwrap()
+                .reclaim_sampler_slots(sampler_handle);
         }
     }
 }

--- a/src/backend/dx12/sampler.rs
+++ b/src/backend/dx12/sampler.rs
@@ -18,7 +18,7 @@ pub(super) fn create(
 
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     let sampler_offset = logical_device
@@ -74,7 +74,7 @@ pub(super) fn create(
 /// Destroy a sampler.
 pub(super) fn destroy(state: &mut Dx12State, sampler_handle: SamplerHandle) {
     if let Some(sampler) = state.samplers.remove(&sampler_handle) {
-        if let Some(ld) = state.devices.get_mut(&sampler.device_handle) {
+        if let Some(ld) = state.devices.get(&sampler.device_handle) {
             ld.ledger
                 .lock()
                 .unwrap()

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -493,7 +493,7 @@ pub(super) fn submit_frame(state: &mut Dx12State, frame: &FrameToken) -> Result<
         .devices
         .get(&device_handle)
         .context("Surface's device is invalid")?;
-    Ok(dev.timeline_next.saturating_sub(1))
+    Ok(dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1))
 }
 
 pub(super) fn present_frame(
@@ -511,7 +511,7 @@ pub(super) fn present_frame(
         .devices
         .get(&device_handle)
         .context("Surface's device is invalid")?;
-    Ok(dev.timeline_next.saturating_sub(1))
+    Ok(dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1))
 }
 
 /// Get the texture handle for the currently acquired surface frame.
@@ -709,7 +709,7 @@ pub(super) fn render(
     }
 
     // Signal fence for this frame
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -718,9 +718,6 @@ pub(super) fn render(
     .context("Failed to signal fence")?;
 
     // Update fence value for next operation
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
-    }
 
     if let Some(surf) = state.surfaces.get_mut(&surface_handle) {
         surf.frame_sync[current_frame].fence_value = fence_value;
@@ -871,17 +868,13 @@ pub(super) fn present(
                 .ExecuteCommandLists(&[Some(cmd_list)]);
         }
 
-        let fence_value = logical_device.timeline_next;
+        let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         unsafe {
             logical_device
                 .command_queue
                 .Signal(&logical_device.fence, fence_value)
         }
         .context("Failed to signal fence after present copy")?;
-
-        if let Some(dev) = state.devices.get_mut(&device_handle) {
-            dev.timeline_next += 1;
-        }
 
         // Record the fence so acquire() can wait for it before reusing this slot.
         if let Some(surf) = state.surfaces.get_mut(&surface_handle) {
@@ -1215,7 +1208,7 @@ fn wait_for_fence(fence: &ID3D12Fence, value: u64) -> Result<()> {
 }
 
 fn wait_for_gpu(device: &LogicalDevice) -> Result<()> {
-    let fence_value = device.timeline_next;
+    let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence")?;
     wait_for_fence(&device.fence, fence_value)

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -449,8 +449,11 @@ pub(super) fn acquire(
         surface.pending_acquire_count = surface.pending_acquire_count.saturating_add(1);
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
-        sc.signal_queue
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        sc_arc
+            .lock()
+            .unwrap()
+            .signal_queue
             .push(crate::signal::Signal::SwapchainAcquired { image_index });
     }
 
@@ -920,8 +923,11 @@ pub(super) fn present(
         }
     } else if let Some(surf) = state.surfaces.get_mut(&surface_handle) {
         surf.pending_acquire_count = surf.pending_acquire_count.saturating_sub(1);
-        if let Some(sc) = state.contexts.get(&ctx) {
-            sc.signal_queue
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc
+                .lock()
+                .unwrap()
+                .signal_queue
                 .push(crate::signal::Signal::SwapchainReturned {
                     image_index: return_image,
                 });

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -493,7 +493,10 @@ pub(super) fn submit_frame(state: &mut Dx12State, frame: &FrameToken) -> Result<
         .devices
         .get(&device_handle)
         .context("Surface's device is invalid")?;
-    Ok(dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1))
+    Ok(dev
+        .timeline_next
+        .load(std::sync::atomic::Ordering::Relaxed)
+        .saturating_sub(1))
 }
 
 pub(super) fn present_frame(
@@ -511,7 +514,10 @@ pub(super) fn present_frame(
         .devices
         .get(&device_handle)
         .context("Surface's device is invalid")?;
-    Ok(dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1))
+    Ok(dev
+        .timeline_next
+        .load(std::sync::atomic::Ordering::Relaxed)
+        .saturating_sub(1))
 }
 
 /// Get the texture handle for the currently acquired surface frame.
@@ -709,7 +715,9 @@ pub(super) fn render(
     }
 
     // Signal fence for this frame
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -868,7 +876,9 @@ pub(super) fn present(
                 .ExecuteCommandLists(&[Some(cmd_list)]);
         }
 
-        let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let fence_value = logical_device
+            .timeline_next
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         unsafe {
             logical_device
                 .command_queue
@@ -1208,7 +1218,9 @@ fn wait_for_fence(fence: &ID3D12Fence, value: u64) -> Result<()> {
 }
 
 fn wait_for_gpu(device: &LogicalDevice) -> Result<()> {
-    let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
+    let fence_value = device
+        .timeline_next
+        .load(std::sync::atomic::Ordering::Relaxed);
     unsafe { device.command_queue.Signal(&device.fence, fence_value) }
         .context("Failed to signal fence")?;
     wait_for_fence(&device.fence, fence_value)

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -411,7 +411,7 @@ pub(super) fn acquire(
 
     // Process deferred deletions now that the fence wait has completed.
     let retired = super::context::device_retired(state, device_handle);
-    if let Some(device) = state.devices.get_mut(&device_handle) {
+    if let Some(device) = state.devices.get(&device_handle) {
         let _tz = crate::tracy_zone!("surface.acquire.deletion_queue");
         device.process_deletion_queue_up_to(retired);
     }
@@ -1052,7 +1052,7 @@ pub(super) fn resize(
     if let Some(df) = depth_format {
         let logical_device = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Surface's device is invalid")?;
 
         let heap_properties = D3D12_HEAP_PROPERTIES {

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -195,7 +195,7 @@ pub(super) fn create(
     // (textures and buffers share the same CBV/SRV/UAV heap)
     let logical_device = state
         .devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
     let srv_offset = logical_device
         .ledger
@@ -274,7 +274,7 @@ pub(super) fn create(
     let sampled_bindless_offset = if is_dual_access {
         let logical_device = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
         let srv2_offset = logical_device
             .ledger
@@ -352,7 +352,7 @@ pub(super) fn create(
 /// Build a staged full-texture upload (caller runs GPU copy via task graph or
 /// [`execute_staged_uploads_sync`]).
 pub(super) fn stage_texture_upload_full(
-    devices: &std::collections::HashMap<DeviceHandle, super::types::LogicalDevice>,
+    devices: &std::collections::HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     textures: &std::collections::HashMap<TextureHandle, super::types::TextureState>,
     pool: &mut super::staging::TextureStagingPool,
     texture_handle: TextureHandle,
@@ -424,7 +424,7 @@ pub(super) fn stage_texture_upload_full(
 
 /// Build a staged subregion texture upload.
 pub(super) fn stage_texture_upload_region(
-    devices: &std::collections::HashMap<DeviceHandle, super::types::LogicalDevice>,
+    devices: &std::collections::HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     textures: &std::collections::HashMap<TextureHandle, super::types::TextureState>,
     pool: &mut super::staging::TextureStagingPool,
     region: TextureUploadRegion<'_>,
@@ -1009,7 +1009,7 @@ pub(super) fn read_to_cpu(
     .context("Failed to signal fence")?;
     wait_for_fence(&logical_device.fence, fence_value)?;
 
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
+    if let Some(dev) = state.devices.get(&device_handle) {
         // Check for device removal (compute passes may have caused TDR)
         let removed = unsafe { dev.device.GetDeviceRemovedReason() };
         if removed.is_err() {
@@ -1050,7 +1050,7 @@ pub(super) fn read_to_cpu(
 /// for deferred deletion after in-flight GPU work completes.
 pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
     if let Some(tex) = state.textures.remove(&texture_handle) {
-        if let Some(dev) = state.devices.get_mut(&tex.device_handle) {
+        if let Some(dev) = state.devices.get(&tex.device_handle) {
             if tex.transient_placed {
                 dev.ledger
                     .lock()
@@ -1062,7 +1062,7 @@ pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
                 .timeline_next
                 .load(std::sync::atomic::Ordering::Relaxed)
                 .saturating_sub(1);
-            dev.deletion_queue.queue(
+            dev.deletion_queue.lock().unwrap().queue(
                 last_fence,
                 PendingDeletion::Texture {
                     texture_handle,

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -197,7 +197,12 @@ pub(super) fn create(
         .devices
         .get_mut(&device_handle)
         .context("Invalid device handle")?;
-    let srv_offset = logical_device.resource_registry.register_texture(handle);
+    let srv_offset = logical_device
+        .ledger
+        .lock()
+        .unwrap()
+        .resource_registry
+        .register_texture(handle);
 
     let srv_desc = D3D12_SHADER_RESOURCE_VIEW_DESC {
         Format: format_to_dxgi(format),
@@ -230,6 +235,9 @@ pub(super) fn create(
     // bindless_offset must point to UAV for goldy_direct_spatial.
     let bindless_offset = if is_storage {
         let uav_offset = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_texture_uav(handle);
         let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
@@ -269,6 +277,9 @@ pub(super) fn create(
             .get_mut(&device_handle)
             .context("Invalid device handle")?;
         let srv2_offset = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_texture_srv(handle);
         let srv2_cpu_handle = unsafe {
@@ -1041,7 +1052,10 @@ pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
     if let Some(tex) = state.textures.remove(&texture_handle) {
         if let Some(dev) = state.devices.get_mut(&tex.device_handle) {
             if tex.transient_placed {
-                dev.reclaim_texture_slots(texture_handle);
+                dev.ledger
+                    .lock()
+                    .unwrap()
+                    .reclaim_texture_slots(texture_handle);
                 return;
             }
             let last_fence = dev

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -100,7 +100,9 @@ pub(super) fn init_storage_texture_uav_layout(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -791,7 +793,9 @@ pub(super) fn execute_staged_uploads_sync(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -983,7 +987,9 @@ pub(super) fn read_to_cpu(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let fence_value = logical_device
+        .timeline_next
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -1038,7 +1044,10 @@ pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
                 dev.reclaim_texture_slots(texture_handle);
                 return;
             }
-            let last_fence = dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
+            let last_fence = dev
+                .timeline_next
+                .load(std::sync::atomic::Ordering::Relaxed)
+                .saturating_sub(1);
             dev.deletion_queue.queue(
                 last_fence,
                 PendingDeletion::Texture {

--- a/src/backend/dx12/texture.rs
+++ b/src/backend/dx12/texture.rs
@@ -100,7 +100,7 @@ pub(super) fn init_storage_texture_uav_layout(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -108,10 +108,6 @@ pub(super) fn init_storage_texture_uav_layout(
     }
     .context("Failed to signal fence for init barrier")?;
     super::utils::wait_for_fence(&logical_device.fence, fence_value)?;
-
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
-    }
 
     Ok(D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_UNORDERED_ACCESS)
 }
@@ -603,20 +599,12 @@ pub(super) fn write(
     width: u32,
     height: u32,
 ) -> Result<()> {
-    let texture = state
-        .textures
-        .get(&texture_handle)
-        .context("Invalid texture")?;
-    let device_handle = texture.device_handle;
     let staged = {
-        let pool = state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(super::staging::TextureStagingPool::new);
+        let mut pool = super::staging::TextureStagingPool::new();
         stage_texture_upload_full(
             &state.devices,
             &state.textures,
-            pool,
+            &mut pool,
             texture_handle,
             data,
             width,
@@ -638,20 +626,12 @@ pub(super) fn write_region(
     height: u32,
     data: &[u8],
 ) -> Result<()> {
-    let texture = state
-        .textures
-        .get(&texture_handle)
-        .context("Invalid texture")?;
-    let device_handle = texture.device_handle;
     let staged = {
-        let pool = state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(super::staging::TextureStagingPool::new);
+        let mut pool = super::staging::TextureStagingPool::new();
         stage_texture_upload_region(
             &state.devices,
             &state.textures,
-            pool,
+            &mut pool,
             TextureUploadRegion {
                 texture_handle,
                 x,
@@ -811,7 +791,7 @@ pub(super) fn execute_staged_uploads_sync(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -820,16 +800,10 @@ pub(super) fn execute_staged_uploads_sync(
     .context("flush_pending_copies: failed to signal fence")?;
     wait_for_fence(&logical_device.fence, fence_value)?;
 
-    if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
-    }
-
     // Release and reclaim the staging entries back to the pool immediately.
-    if let Some(pool) = state.texture_staging_pools.get_mut(&device_handle) {
-        let entries: Vec<super::staging::TextureStagingEntry> =
-            copies.into_iter().map(|c| c.staging_entry).collect();
-        pool.release(fence_value, entries);
-        pool.reclaim(fence_value);
+    // The GPU is idle for this submission (we just waited), so we can safely destroy them.
+    for copy in copies {
+        unsafe { copy.staging_entry.destroy() };
     }
 
     tracing::debug!("Flushed {} pending texture copies in one submission", count);
@@ -1009,7 +983,7 @@ pub(super) fn read_to_cpu(
             .ExecuteCommandLists(&[Some(cmd_list)]);
     }
 
-    let fence_value = logical_device.timeline_next;
+    let fence_value = logical_device.timeline_next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         logical_device
             .command_queue
@@ -1019,7 +993,6 @@ pub(super) fn read_to_cpu(
     wait_for_fence(&logical_device.fence, fence_value)?;
 
     if let Some(dev) = state.devices.get_mut(&device_handle) {
-        dev.timeline_next += 1;
         // Check for device removal (compute passes may have caused TDR)
         let removed = unsafe { dev.device.GetDeviceRemovedReason() };
         if removed.is_err() {
@@ -1065,7 +1038,7 @@ pub(super) fn destroy(state: &mut Dx12State, texture_handle: TextureHandle) {
                 dev.reclaim_texture_slots(texture_handle);
                 return;
             }
-            let last_fence = dev.timeline_next.saturating_sub(1);
+            let last_fence = dev.timeline_next.load(std::sync::atomic::Ordering::Relaxed).saturating_sub(1);
             dev.deletion_queue.queue(
                 last_fence,
                 PendingDeletion::Texture {

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -18,7 +18,7 @@ use crate::types::{DepthFormat, SamplerDesc, TextureFormat};
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Arc,
+    Arc, Mutex, RwLock,
 };
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Graphics::{Direct3D12, Dxgi};
@@ -600,67 +600,32 @@ impl DeletionQueue {
     }
 }
 
-/// A logical D3D12 device with associated resources.
-#[allow(dead_code)]
-pub(crate) struct LogicalDevice {
-    pub device: Direct3D12::ID3D12Device10,
-    pub adapter_id: u32,
-    pub command_queue: Direct3D12::ID3D12CommandQueue,
-    /// Legacy single allocator for non-compute paths (e.g. render target). Compute uses the pool.
-    pub command_allocator: Direct3D12::ID3D12CommandAllocator,
-    pub rtv_heap: Direct3D12::ID3D12DescriptorHeap,
-    pub rtv_descriptor_size: u32,
-    pub dsv_heap: Direct3D12::ID3D12DescriptorHeap,
-    pub dsv_descriptor_size: u32,
-    pub cbv_srv_uav_heap: Direct3D12::ID3D12DescriptorHeap,
-    pub cbv_srv_uav_descriptor_size: u32,
-    pub sampler_heap: Direct3D12::ID3D12DescriptorHeap,
-    pub sampler_descriptor_size: u32,
-    /// Device fence for synchronous Signal+wait paths only (not per-submit timeline).
-    pub fence: Direct3D12::ID3D12Fence,
-    /// Device-global submission sequence (shared value space; contexts signal their own fences).
-    pub timeline_next: Arc<AtomicU64>,
-    /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
-    pub retired_floor: u64,
-
-    // Bindless infrastructure
-    /// `true` when adapter reports tiled resources tier >= 1 (buffer reserved resources).
-    pub supports_reserved_buffers: bool,
-    pub tile_heap_pool: Option<super::tiles::TileHeapPool>,
-    /// Shared root signature for all bindless pipelines (graphics and compute)
-    pub bindless_root_signature: Option<Direct3D12::ID3D12RootSignature>,
-    /// Command signature for indirect compute dispatch (ExecuteIndirect, dispatch-only)
-    pub compute_dispatch_indirect_signature: Option<Direct3D12::ID3D12CommandSignature>,
-    /// Command signature for batched dispatch: sets push constants then dispatches.
-    /// Each argument entry contains `[PushLayout (TOTAL_PUSH_BYTES)] [wg_x] [wg_y] [wg_z]`.
-    /// Requires the shared `bindless_root_signature` to be non-None.
-    pub compute_batch_dispatch_signature: Option<Direct3D12::ID3D12CommandSignature>,
-    /// Registry tracking resource offsets in descriptor heaps
+/// Device-shared descriptor-heap ledger.
+///
+/// Contains the irreducible shared state for bindless slot allocation: the
+/// `ResourceRegistry` (descriptor slot allocator), the per-context
+/// `slot_last_seen` reference table, and the `pending_slot_reclamations`
+/// list.  Wrapped in `Arc<Mutex<>>` on `LogicalDevice` so that future phases
+/// can lock it independently of the global backend mutex.
+pub(crate) struct DeviceLedger {
+    /// Registry tracking resource offsets in descriptor heaps.
     pub resource_registry: ResourceRegistry,
-    /// Device-lifetime zero-filled UPLOAD-heap buffer used as the source for
-    /// `CopyBufferRegion` clears. One buffer per device; clears of any size are
-    /// handled by chunking `CopyBufferRegion` calls. Using a copy instead of
-    /// `ClearUnorderedAccessViewUint` avoids the shared-descriptor aliasing hazard
-    /// that caused silent corruption on WARP when multiple buffers were cleared in
-    /// the same wave (all clears rewrote the same single-slot descriptor heap).
-    pub zero_buffer: Direct3D12::ID3D12Resource,
-    /// Deferred deletion queue — resources are dropped only after the GPU finishes
-    /// the command list that was last submitted when the resource was queued.
-    pub deletion_queue: DeletionQueue,
     /// Maps bindless slot → per-context last-submitted seq that referenced it.
     /// Updated at every submit. Entry removed when the slot is queued for reclamation.
     pub slot_last_seen: HashMap<DeferredSlot, HashMap<super::ContextHandle, u64>>,
     /// Slots waiting for referencing contexts to retire before returning to the free list.
     pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
-    /// Cached graphics PSO blobs from `ID3D12PipelineState::GetCachedBlob` (cold-load via `CachedPSO`).
-    pub graphics_pso_blobs: HashMap<u64, Vec<u8>>,
-    /// Cached compute PSO blobs.
-    pub compute_pso_blobs: HashMap<u64, Vec<u8>>,
-    /// `true` if either blob map changed since loading from [`super::pso_cache`] disk file.
-    pub pso_disk_cache_dirty: bool,
 }
 
-impl LogicalDevice {
+impl DeviceLedger {
+    pub(crate) fn new() -> Self {
+        Self {
+            resource_registry: ResourceRegistry::new(),
+            slot_last_seen: HashMap::new(),
+            pending_slot_reclamations: Vec::new(),
+        }
+    }
+
     /// Record that `ctx` submitted `seq` referencing each bindless slot in `slots`.
     pub(crate) fn record_slot_usage(
         &mut self,
@@ -739,11 +704,98 @@ impl LogicalDevice {
             }
         }
     }
+}
 
+/// Cached PSO blobs and disk-dirty flag for a logical device.
+///
+/// Wrapped in `Arc<RwLock<>>` on `LogicalDevice` so that PSO creation (which
+/// is write-rare after warmup) does not need the global backend lock.
+pub(crate) struct PsoCache {
+    /// Cached graphics PSO blobs from `ID3D12PipelineState::GetCachedBlob`.
+    pub graphics_blobs: HashMap<u64, Vec<u8>>,
+    /// Cached compute PSO blobs.
+    pub compute_blobs: HashMap<u64, Vec<u8>>,
+    /// `true` if either blob map changed since loading from the disk file.
+    pub dirty: bool,
+}
+
+impl PsoCache {
+    pub(crate) fn new(
+        graphics_blobs: HashMap<u64, Vec<u8>>,
+        compute_blobs: HashMap<u64, Vec<u8>>,
+    ) -> Self {
+        Self {
+            graphics_blobs,
+            compute_blobs,
+            dirty: false,
+        }
+    }
+}
+
+/// A logical D3D12 device with associated resources.
+#[allow(dead_code)]
+pub(crate) struct LogicalDevice {
+    pub device: Direct3D12::ID3D12Device10,
+    pub adapter_id: u32,
+    pub command_queue: Direct3D12::ID3D12CommandQueue,
+    /// Legacy single allocator for non-compute paths (e.g. render target). Compute uses the pool.
+    pub command_allocator: Direct3D12::ID3D12CommandAllocator,
+    pub rtv_heap: Direct3D12::ID3D12DescriptorHeap,
+    pub rtv_descriptor_size: u32,
+    pub dsv_heap: Direct3D12::ID3D12DescriptorHeap,
+    pub dsv_descriptor_size: u32,
+    pub cbv_srv_uav_heap: Direct3D12::ID3D12DescriptorHeap,
+    pub cbv_srv_uav_descriptor_size: u32,
+    pub sampler_heap: Direct3D12::ID3D12DescriptorHeap,
+    pub sampler_descriptor_size: u32,
+    /// Device fence for synchronous Signal+wait paths only (not per-submit timeline).
+    pub fence: Direct3D12::ID3D12Fence,
+    /// Device-global submission sequence (shared value space; contexts signal their own fences).
+    pub timeline_next: Arc<AtomicU64>,
+    /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
+    pub retired_floor: u64,
+
+    // Bindless infrastructure
+    /// `true` when adapter reports tiled resources tier >= 1 (buffer reserved resources).
+    pub supports_reserved_buffers: bool,
+    pub tile_heap_pool: Option<super::tiles::TileHeapPool>,
+    /// Shared root signature for all bindless pipelines (graphics and compute)
+    pub bindless_root_signature: Option<Direct3D12::ID3D12RootSignature>,
+    /// Command signature for indirect compute dispatch (ExecuteIndirect, dispatch-only)
+    pub compute_dispatch_indirect_signature: Option<Direct3D12::ID3D12CommandSignature>,
+    /// Command signature for batched dispatch: sets push constants then dispatches.
+    /// Each argument entry contains `[PushLayout (TOTAL_PUSH_BYTES)] [wg_x] [wg_y] [wg_z]`.
+    /// Requires the shared `bindless_root_signature` to be non-None.
+    pub compute_batch_dispatch_signature: Option<Direct3D12::ID3D12CommandSignature>,
+    /// Device-lifetime zero-filled UPLOAD-heap buffer used as the source for
+    /// `CopyBufferRegion` clears. One buffer per device; clears of any size are
+    /// handled by chunking `CopyBufferRegion` calls. Using a copy instead of
+    /// `ClearUnorderedAccessViewUint` avoids the shared-descriptor aliasing hazard
+    /// that caused silent corruption on WARP when multiple buffers were cleared in
+    /// the same wave (all clears rewrote the same single-slot descriptor heap).
+    pub zero_buffer: Direct3D12::ID3D12Resource,
+    /// Deferred deletion queue — resources are dropped only after the GPU finishes
+    /// the command list that was last submitted when the resource was queued.
+    pub deletion_queue: DeletionQueue,
+    /// Descriptor-heap ledger: `ResourceRegistry` + slot reference-tracking.
+    /// `Arc` so Phase 5 can clone it out of `LogicalDevice` before dropping the
+    /// global backend lock.
+    pub ledger: Arc<Mutex<DeviceLedger>>,
+    /// Cached PSO blobs (graphics + compute) and disk-dirty flag.
+    /// `RwLock` because reads dominate after warmup; `Arc` for Phase 5 cloning.
+    pub pso_cache: Arc<RwLock<PsoCache>>,
+}
+
+impl LogicalDevice {
     pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
         let batch = self.deletion_queue.drain_up_to_completed(completed);
+        if batch.is_empty() {
+            return;
+        }
+        let ledger_arc = Arc::clone(&self.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for resource in batch {
-            destroy_pending_deletion(self, resource);
+            destroy_pending_deletion(self, &mut ledger, resource);
         }
     }
 
@@ -755,13 +807,22 @@ impl LogicalDevice {
         // have requirements are just dropped with the LogicalDevice — the whole allocator
         // is discarded at this point, so skipping drain_ready_slot_reclamations is safe.
         let batch = self.deletion_queue.drain_everything();
+        if batch.is_empty() {
+            return;
+        }
+        let ledger_arc = Arc::clone(&self.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for resource in batch {
-            destroy_pending_deletion(self, resource);
+            destroy_pending_deletion(self, &mut ledger, resource);
         }
     }
 }
 
-pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: PendingDeletion) {
+pub(crate) fn destroy_pending_deletion(
+    ld: &mut LogicalDevice,
+    ledger: &mut DeviceLedger,
+    resource: PendingDeletion,
+) {
     match resource {
         PendingDeletion::Buffer {
             buffer_handle,
@@ -770,7 +831,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             coherent_readback,
             reserved_tiles,
         } => {
-            ld.reclaim_buffer_slots(buffer_handle);
+            ledger.reclaim_buffer_slots(buffer_handle);
             if let Some(tiles) = reserved_tiles {
                 super::tiles::teardown_reserved_mappings(
                     &ld.command_queue,
@@ -790,7 +851,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             drop(coherent_readback);
         }
         PendingDeletion::BufferView { buffer_handle } => {
-            ld.reclaim_buffer_slots(buffer_handle);
+            ledger.reclaim_buffer_slots(buffer_handle);
         }
         PendingDeletion::ReplacedBufferGpu {
             resource,
@@ -827,7 +888,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             texture_handle,
             resource,
         } => {
-            ld.reclaim_texture_slots(texture_handle);
+            ledger.reclaim_texture_slots(texture_handle);
             drop(resource);
         }
         PendingDeletion::StandaloneResource(resource) => {

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -17,8 +17,8 @@ use super::super::{
 use crate::types::{DepthFormat, SamplerDesc, TextureFormat};
 use std::collections::HashMap;
 use std::sync::{
-    Arc,
     atomic::{AtomicU64, Ordering},
+    Arc,
 };
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Graphics::{Direct3D12, Dxgi};
@@ -493,6 +493,10 @@ pub(crate) struct Dx12SubmissionContext {
     pub staging_belt: super::staging::StagingBelt,
     /// Pool that recycles texture-upload staging buffers across frames on this context.
     pub texture_staging_pool: super::staging::TextureStagingPool,
+    /// Per-context deferred deletion queue — only resources exclusively bound to this
+    /// context's timeline (e.g. temporary dispatch-batch arg buffers).  Drained at each
+    /// submit by this context's own completed fence value, never by `device_retired`.
+    pub deletion_queue: DeletionQueue,
 }
 
 /// A retained (closed but not reset) command list available for re-execution.

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -753,12 +753,12 @@ pub(crate) struct LogicalDevice {
     /// Device-global submission sequence (shared value space; contexts signal their own fences).
     pub timeline_next: Arc<AtomicU64>,
     /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
-    pub retired_floor: u64,
+    pub retired_floor: AtomicU64,
 
     // Bindless infrastructure
     /// `true` when adapter reports tiled resources tier >= 1 (buffer reserved resources).
     pub supports_reserved_buffers: bool,
-    pub tile_heap_pool: Option<super::tiles::TileHeapPool>,
+    pub tile_heap_pool: Mutex<Option<super::tiles::TileHeapPool>>,
     /// Shared root signature for all bindless pipelines (graphics and compute)
     pub bindless_root_signature: Option<Direct3D12::ID3D12RootSignature>,
     /// Command signature for indirect compute dispatch (ExecuteIndirect, dispatch-only)
@@ -776,7 +776,7 @@ pub(crate) struct LogicalDevice {
     pub zero_buffer: Direct3D12::ID3D12Resource,
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
-    pub deletion_queue: DeletionQueue,
+    pub deletion_queue: Mutex<DeletionQueue>,
     /// Descriptor-heap ledger: `ResourceRegistry` + slot reference-tracking.
     /// `Arc` so Phase 5 can clone it out of `LogicalDevice` before dropping the
     /// global backend lock.
@@ -786,9 +786,16 @@ pub(crate) struct LogicalDevice {
     pub pso_cache: Arc<RwLock<PsoCache>>,
 }
 
+/// Shared logical device handle — cloned out of `Dx12State` before dropping the global lock.
+pub(crate) type SharedLogicalDevice = Arc<LogicalDevice>;
+
 impl LogicalDevice {
-    pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
-        let batch = self.deletion_queue.drain_up_to_completed(completed);
+    pub(crate) fn process_deletion_queue_up_to(&self, completed: u64) {
+        let batch = self
+            .deletion_queue
+            .lock()
+            .unwrap()
+            .drain_up_to_completed(completed);
         if batch.is_empty() {
             return;
         }
@@ -799,14 +806,14 @@ impl LogicalDevice {
         }
     }
 
-    pub(crate) fn flush_deletion_queue(&mut self) {
+    pub(crate) fn flush_deletion_queue(&self) {
         // Called only at device teardown, after wait_for_gpu ensures all GPU work has
         // completed. Slots queued here via reclaim_*_slots will have empty requirements
         // (slot_last_seen was cleared as contexts were destroyed before the device) and
         // are freed immediately in queue_slot_reclamation. Any slots that somehow still
         // have requirements are just dropped with the LogicalDevice — the whole allocator
         // is discarded at this point, so skipping drain_ready_slot_reclamations is safe.
-        let batch = self.deletion_queue.drain_everything();
+        let batch = self.deletion_queue.lock().unwrap().drain_everything();
         if batch.is_empty() {
             return;
         }
@@ -819,7 +826,7 @@ impl LogicalDevice {
 }
 
 pub(crate) fn destroy_pending_deletion(
-    ld: &mut LogicalDevice,
+    ld: &LogicalDevice,
     ledger: &mut DeviceLedger,
     resource: PendingDeletion,
 ) {
@@ -833,9 +840,10 @@ pub(crate) fn destroy_pending_deletion(
         } => {
             ledger.reclaim_buffer_slots(buffer_handle);
             if let Some(tiles) = reserved_tiles {
+                let mut pool = ld.tile_heap_pool.lock().unwrap();
                 super::tiles::teardown_reserved_mappings(
                     &ld.command_queue,
-                    &mut ld.tile_heap_pool,
+                    &mut *pool,
                     &resource,
                     &tiles,
                 );
@@ -868,12 +876,15 @@ pub(crate) fn destroy_pending_deletion(
             upload_buffer,
             coherent_readback,
         } => {
-            super::tiles::teardown_reserved_mappings(
-                &ld.command_queue,
-                &mut ld.tile_heap_pool,
-                &resource,
-                &tiles,
-            );
+            {
+                let mut pool = ld.tile_heap_pool.lock().unwrap();
+                super::tiles::teardown_reserved_mappings(
+                    &ld.command_queue,
+                    &mut *pool,
+                    &resource,
+                    &tiles,
+                );
+            }
             // Flush the queue so the unmap is processed before releasing the resource.
             // Without this, the driver can crash (device removal) on Release.
             let fv = ld.timeline_next.fetch_add(1, Ordering::Relaxed);
@@ -1115,7 +1126,7 @@ pub(super) struct Dx12State {
     /// (needed for tear-free immediate presentation in windowed mode).
     pub allow_tearing: bool,
     pub adapters: Vec<DxgiAdapterInfo>,
-    pub devices: HashMap<DeviceHandle, LogicalDevice>,
+    pub devices: HashMap<DeviceHandle, SharedLogicalDevice>,
     pub next_device_handle: DeviceHandle,
     pub contexts: HashMap<super::ContextHandle, Dx12SubmissionContext>,
     pub next_context_id: super::ContextHandle,

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -370,7 +370,7 @@ mod registry_tests {
         );
 
         let mut retired = HashMap::from([(CTX_A, 4u64)]);
-        let mut drain_pending =
+        let drain_pending =
             |retired: &HashMap<ContextHandle, u64>,
              reg: &mut ResourceRegistry,
              pending: &mut Vec<PendingSlotReclamation>| {
@@ -419,7 +419,7 @@ mod registry_tests {
 
         let mut retired = HashMap::from([(CTX_A, 0u64), (CTX_B, 0u64)]);
 
-        let mut drain_pending =
+        let drain_pending =
             |retired: &HashMap<ContextHandle, u64>,
              reg: &mut ResourceRegistry,
              pending: &mut Vec<PendingSlotReclamation>| {

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -11,8 +11,8 @@
 //! - Shaders access resources by indexing into the descriptor heaps
 
 use super::super::{
-    BufferHandle, ComputePipelineHandle, DeviceHandle, PipelineHandle, RenderTargetHandle,
-    SamplerHandle, ShaderHandle, SurfaceHandle, TextureHandle,
+    BufferHandle, ComputePipelineHandle, ContextHandle, DeviceHandle, PipelineHandle,
+    RenderTargetHandle, SamplerHandle, ShaderHandle, SurfaceHandle, TextureHandle,
 };
 use crate::types::{DepthFormat, SamplerDesc, TextureFormat};
 use std::collections::HashMap;
@@ -683,17 +683,21 @@ impl DeviceLedger {
     }
 
     /// Return pending slots to the free list once every referencing context has retired.
+    ///
+    /// Takes the per-state `context_fences` index (not the full context map) so this
+    /// method can be called while holding the ledger lock without risking a lock-ordering
+    /// deadlock with per-context `Mutex<Dx12SubmissionContext>`.
     pub(crate) fn drain_ready_slot_reclamations(
         &mut self,
-        contexts: &HashMap<super::ContextHandle, Dx12SubmissionContext>,
+        context_fences: &HashMap<ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
     ) {
         let mut i = 0;
         while i < self.pending_slot_reclamations.len() {
             let ready = self.pending_slot_reclamations[i].requirements.iter().all(
                 |(ctx_id, required_seq)| {
-                    contexts
-                        .get(ctx_id)
-                        .is_none_or(|ctx| unsafe { ctx.fence.GetCompletedValue() >= *required_seq })
+                    context_fences.get(ctx_id).is_none_or(|(_, fence)| unsafe {
+                        fence.GetCompletedValue() >= *required_seq
+                    })
                 },
             );
             if ready {
@@ -788,6 +792,10 @@ pub(crate) struct LogicalDevice {
 
 /// Shared logical device handle — cloned out of `Dx12State` before dropping the global lock.
 pub(crate) type SharedLogicalDevice = Arc<LogicalDevice>;
+
+/// Shared submission context handle — allows cloning a context reference out of `Dx12State`
+/// before dropping the global backend lock, enabling fine-grained per-context locking.
+pub(crate) type SharedSubmissionContext = Arc<Mutex<Dx12SubmissionContext>>;
 
 impl LogicalDevice {
     pub(crate) fn process_deletion_queue_up_to(&self, completed: u64) {
@@ -1128,8 +1136,15 @@ pub(super) struct Dx12State {
     pub adapters: Vec<DxgiAdapterInfo>,
     pub devices: HashMap<DeviceHandle, SharedLogicalDevice>,
     pub next_device_handle: DeviceHandle,
-    pub contexts: HashMap<super::ContextHandle, Dx12SubmissionContext>,
+    pub contexts: HashMap<ContextHandle, SharedSubmissionContext>,
     pub next_context_id: super::ContextHandle,
+    /// Fence handles for every live context, keyed by context ID.
+    ///
+    /// Maintained in sync with `contexts` (inserted on create, removed on destroy).
+    /// Used by [`DeviceLedger::drain_ready_slot_reclamations`] and [`device_retired`] so
+    /// those paths can query fence completion without acquiring any per-context lock,
+    /// avoiding a ledger-lock → context-lock ordering hazard.
+    pub context_fences: HashMap<ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
     pub buffers: HashMap<BufferHandle, BufferState>,
     pub next_buffer_handle: BufferHandle,
     pub shaders: HashMap<ShaderHandle, ShaderState>,

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -16,6 +16,10 @@ use super::super::{
 };
 use crate::types::{DepthFormat, SamplerDesc, TextureFormat};
 use std::collections::HashMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Graphics::{Direct3D12, Dxgi};
 
@@ -485,6 +489,10 @@ pub(crate) struct Dx12SubmissionContext {
     pub compute_allocator_pool: Vec<ComputeAllocatorSlot>,
     /// A single retained command list for zero-recording-cost re-submission.
     pub retained_graph: Option<RetainedGraph>,
+    /// Upload belt for `GpuCommand::WriteBuffer` on this context.
+    pub staging_belt: super::staging::StagingBelt,
+    /// Pool that recycles texture-upload staging buffers across frames on this context.
+    pub texture_staging_pool: super::staging::TextureStagingPool,
 }
 
 /// A retained (closed but not reset) command list available for re-execution.
@@ -607,7 +615,7 @@ pub(crate) struct LogicalDevice {
     /// Device fence for synchronous Signal+wait paths only (not per-submit timeline).
     pub fence: Direct3D12::ID3D12Fence,
     /// Device-global submission sequence (shared value space; contexts signal their own fences).
-    pub timeline_next: u64,
+    pub timeline_next: Arc<AtomicU64>,
     /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
     pub retired_floor: u64,
 
@@ -769,8 +777,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             }
             // Flush the queue so the unmap is processed before releasing the resource.
             // Without this, the driver can crash (device removal) on Release.
-            let fv = ld.timeline_next;
-            ld.timeline_next += 1;
+            let fv = ld.timeline_next.fetch_add(1, Ordering::Relaxed);
             if unsafe { ld.command_queue.Signal(&ld.fence, fv) }.is_ok() {
                 let _ = super::utils::wait_for_fence(&ld.fence, fv);
             }
@@ -804,8 +811,7 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
             );
             // Flush the queue so the unmap is processed before releasing the resource.
             // Without this, the driver can crash (device removal) on Release.
-            let fv = ld.timeline_next;
-            ld.timeline_next += 1;
+            let fv = ld.timeline_next.fetch_add(1, Ordering::Relaxed);
             if unsafe { ld.command_queue.Signal(&ld.fence, fv) }.is_ok() {
                 let _ = super::utils::wait_for_fence(&ld.fence, fv);
             }
@@ -1074,10 +1080,6 @@ pub(super) struct Dx12State {
     pub free_dsv_offsets: Vec<u32>,
     /// Per-backend Slang compiler instance
     pub slang_compiler: crate::slang::SlangCompiler,
-    /// Per-device upload belts for `GpuCommand::WriteBuffer`.
-    pub(super) staging_belts: HashMap<DeviceHandle, super::staging::StagingBelt>,
-    /// Per-device pools that recycle texture-upload staging buffers across frames.
-    pub(super) texture_staging_pools: HashMap<DeviceHandle, super::staging::TextureStagingPool>,
     /// Set to `true` when a TDR / device-removal is detected (fence completed with `u64::MAX`
     /// or `GetDeviceRemovedReason` returns a non-ok HRESULT).
     /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -404,7 +404,7 @@ mod registry_tests {
 
         let mut retired = HashMap::from([(CTX_A, 0u64), (CTX_B, 0u64)]);
 
-        let mut drain_pending =
+        let drain_pending =
             |retired: &HashMap<ContextHandle, u64>,
              reg: &mut ResourceRegistry,
              pending: &mut Vec<PendingSlotReclamation>| {

--- a/tests/common/render_fixtures.rs
+++ b/tests/common/render_fixtures.rs
@@ -1,7 +1,7 @@
 //! Shared offscreen rendering helpers for FLIP screenshot tests and the `update-screenshots` tool.
 
 use goldy::{
-    Buffer, BufferKind, Color, CommandEncoder, CompareFunction, ComputeEncoder, ComputePipeline,
+    BufferKind, Color, CommandEncoder, CompareFunction, ComputeEncoder, ComputePipeline,
     DepthFormat, DepthStencilState, Device, DeviceDescriptor, Instance, PrimitiveTopology,
     RenderPipeline, RenderPipelineDesc, RenderTarget, RequestAdapterOptions, ShaderModule,
     TextureFormat, Vertex2D, VertexAttribute, VertexBufferLayout, VertexFormat,

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -3436,3 +3436,99 @@ void cs_main(Interpolated<float4> src, Filter smp, Scattered<uint> out, ThreadId
         }
     }
 }
+
+// ── multi-context ─────────────────────────────────────────────────────────────
+
+/// Two contexts on one device can both submit work and the deferred deletion
+/// queue on context A drains when A's timeline retires — without requiring
+/// context B to have made any progress.
+///
+/// This guards against reintroducing a device-global retirement horizon
+/// (`device_retired`) as the reclaim gate, which would stall context A's
+/// cleanup if context B is idle (Phase 5b regression test).
+#[test]
+fn two_contexts_reclaim_independently() {
+    let instance = Instance::new().expect("instance");
+    let device = request_default_device(&instance);
+    let ctx_a = submission_context(&device);
+    let ctx_b = submission_context(&device);
+
+    // Allocate a buffer and do some work on ctx_a.
+    let buf = device
+        .alloc_buffer(256, BufferKind::Scattered, None, BufferFlags::empty())
+        .expect("buffer");
+    let tv_a = ComputeEncoder::new().submit(&ctx_a).expect("ctx_a submit");
+
+    // Drop the buffer — its descriptor slot enters ctx_a's deferred queue.
+    drop(buf);
+
+    // ctx_b has never submitted; its timeline is still at seq 0.
+    // With a correct per-context reclaim gate, waiting for ctx_a's timeline
+    // must be sufficient to drain ctx_a's queue.
+    ctx_a.wait_until(tv_a).expect("ctx_a wait_until");
+    ctx_a.flush_deferred_deletions();
+
+    assert_eq!(
+        ctx_a.deferred_deletion_pending_count(),
+        0,
+        "ctx_a must reclaim without waiting for ctx_b (no device-global horizon)"
+    );
+}
+
+/// Both contexts on one device can complete a roundtrip dispatch independently
+/// and in sequence, exercising allocator-slot reuse across both.
+#[test]
+fn two_contexts_both_submit_and_complete() {
+    let instance = Instance::new().expect("instance");
+    let device = request_default_device(&instance);
+    let ctx_a = submission_context(&device);
+    let ctx_b = submission_context(&device);
+
+    let shader = ShaderModule::from_slang(&device, DOUBLE_SHADER).expect("compile shader");
+    let pipeline = ComputePipeline::new(&device, &shader).expect("compute pipeline");
+
+    let data_a: Vec<u32> = (0..64).collect();
+    let buf_a = device
+        .alloc_buffer_with_data(&data_a, BufferKind::Scattered)
+        .expect("buf_a");
+    let data_b: Vec<u32> = (100..164).collect();
+    let buf_b = device
+        .alloc_buffer_with_data(&data_b, BufferKind::Scattered)
+        .expect("buf_b");
+
+    // Submit from both contexts.
+    let mut enc_a = ComputeEncoder::new();
+    {
+        let mut pass = enc_a.begin_compute_pass();
+        pass.set_pipeline(&pipeline);
+        pass.bind_resources(&[&buf_a]);
+        pass.dispatch(1, 1, 1);
+    }
+    let tv_a = enc_a.submit(&ctx_a).expect("ctx_a submit");
+
+    let mut enc_b = ComputeEncoder::new();
+    {
+        let mut pass = enc_b.begin_compute_pass();
+        pass.set_pipeline(&pipeline);
+        pass.bind_resources(&[&buf_b]);
+        pass.dispatch(1, 1, 1);
+    }
+    let tv_b = enc_b.submit(&ctx_b).expect("ctx_b submit");
+
+    ctx_a.wait_until(tv_a).expect("ctx_a wait");
+    ctx_b.wait_until(tv_b).expect("ctx_b wait");
+
+    // Both buffers should have been doubled.
+    let mut raw_a = vec![0u8; 64 * 4];
+    buf_a.read_to_cpu(&device, &mut raw_a).expect("read buf_a");
+    let result_a: &[u32] = bytemuck::cast_slice(&raw_a);
+
+    let mut raw_b = vec![0u8; 64 * 4];
+    buf_b.read_to_cpu(&device, &mut raw_b).expect("read buf_b");
+    let result_b: &[u32] = bytemuck::cast_slice(&raw_b);
+
+    for i in 0..64 {
+        assert_eq!(result_a[i], i as u32 * 2, "buf_a[{i}]");
+        assert_eq!(result_b[i], (100 + i as u32) * 2, "buf_b[{i}]");
+    }
+}

--- a/tests/render_target_integration.rs
+++ b/tests/render_target_integration.rs
@@ -4,7 +4,7 @@
 #![cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
 
 use goldy::{
-    Buffer, BufferKind, Color, CommandEncoder, CompareFunction, DepthFormat, DepthStencilState,
+    BufferKind, Color, CommandEncoder, CompareFunction, DepthFormat, DepthStencilState,
     DeviceDescriptor, IndexFormat, Instance, PrimitiveTopology, RenderPipeline, RenderPipelineDesc,
     RenderTarget, RequestAdapterOptions, ShaderModule, TextureFormat, Vertex2D, VertexAttribute,
     VertexBufferLayout, VertexFormat,


### PR DESCRIPTION
Updated the handling of the timeline_next field across various functions to utilize atomic operations for thread safety. This change ensures correct synchronization when managing command submission and resource reclamation, enhancing the stability and performance of the DX12 backend.