### PR TITLE
Fine grained locking for the vulkan backend

### DIFF
--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -1556,10 +1556,9 @@ fn execute_signal_and_finish(
         ledger.drain_ready_slot_reclamations(&state.context_fences);
     }
 
-    state
-        .contexts
-        .get(&ctx)
-        .map(|sc_arc| sc_arc.lock().unwrap().staging_belt.finish(fence_value));
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        sc_arc.lock().unwrap().staging_belt.finish(fence_value);
+    }
 
     if !staged_texture_uploads.is_empty() {
         let entries = staged_texture_uploads

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -851,7 +851,7 @@ pub(crate) fn destroy_pending_deletion(
                 let mut pool = ld.tile_heap_pool.lock().unwrap();
                 super::tiles::teardown_reserved_mappings(
                     &ld.command_queue,
-                    &mut *pool,
+                    &mut pool,
                     &resource,
                     &tiles,
                 );
@@ -888,7 +888,7 @@ pub(crate) fn destroy_pending_deletion(
                 let mut pool = ld.tile_heap_pool.lock().unwrap();
                 super::tiles::teardown_reserved_mappings(
                     &ld.command_queue,
-                    &mut *pool,
+                    &mut pool,
                     &resource,
                     &tiles,
                 );

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -79,7 +79,7 @@ fn submit_copy(
 /// Create a buffer with the given size and access pattern.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     next_buffer_handle: &mut BufferHandle,
     instance: &ash::Instance,
@@ -197,7 +197,7 @@ pub(super) fn create(
 
     // Register buffer in bindless descriptor set (UNIFORM or STORAGE)
     let bindless_index = {
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let index = logical_device
             .ledger
             .lock()
@@ -289,7 +289,7 @@ fn align_sparse_capacity(cap: u64, block: u64) -> u64 {
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create_sparse_with_capacity(
     _instance: &ash::Instance,
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     next_buffer_handle: &mut BufferHandle,
     device_handle: DeviceHandle,
@@ -299,12 +299,8 @@ pub(super) fn create_sparse_with_capacity(
     flags: BufferFlags,
 ) -> Result<BufferHandle> {
     let ld = devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
-    let pool = ld
-        .sparse_page_pool
-        .as_mut()
-        .context("internal: sparse page pool missing")?;
     let block = ld.sparse_buffer_block_size;
     anyhow::ensure!(block > 0, "sparse block size not initialized");
 
@@ -337,6 +333,11 @@ pub(super) fn create_sparse_with_capacity(
     let bind_queue = ld.sparse_binding_queue;
     let dev = &ld.device;
 
+    let mut pool_guard = ld.sparse_page_pool.lock().unwrap();
+    let pool = pool_guard
+        .as_mut()
+        .context("internal: sparse page pool missing")?;
+
     for (i, sparse_page) in sparse_pages.iter_mut().enumerate().take(initial_pages) {
         let (mem, mem_off) = pool.alloc_page(dev)?;
         let resource_offset = (i as u64).saturating_mul(block);
@@ -352,6 +353,7 @@ pub(super) fn create_sparse_with_capacity(
     }
 
     sparse::queue_bind_sparse_sync(dev, bind_queue, buffer, &binds)?;
+    drop(pool_guard);
 
     let bindless_descriptor_set = ld.bindless_descriptor_set;
     let handle = *next_buffer_handle;
@@ -413,7 +415,7 @@ pub(super) fn create_sparse_with_capacity(
 
 /// Hint unused sparse pages at and above `offset` (bytes).
 pub(super) fn hint_unused_above(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     buffer_handle: BufferHandle,
     offset: u64,
@@ -438,10 +440,7 @@ pub(super) fn hint_unused_above(
     }
 
     {
-        let Some(ld) = devices.get_mut(&device_handle) else {
-            return;
-        };
-        let Some(pool) = ld.sparse_page_pool.as_mut() else {
+        let Some(ld) = devices.get(&device_handle) else {
             return;
         };
         let bind_queue = ld.sparse_binding_queue;
@@ -474,8 +473,11 @@ pub(super) fn hint_unused_above(
             tracing::warn!(?e, "hint_unused_above sparse unbind failed");
             return;
         }
-        for (mem, off) in to_free {
-            pool.free_page(mem, off);
+        let mut pool_guard = ld.sparse_page_pool.lock().unwrap();
+        if let Some(pool) = pool_guard.as_mut() {
+            for (mem, off) in to_free {
+                pool.free_page(mem, off);
+            }
         }
     }
 }
@@ -492,7 +494,7 @@ pub(super) fn capacity(
 }
 
 pub(super) fn set_logical_size(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
@@ -548,9 +550,9 @@ pub(super) fn set_logical_size(
             (buf.staging_buffer.take(), buf.staging_memory.take())
         };
         if let (Some(stg_buf), Some(stg_mem)) = (old_stg_buf, old_stg_mem) {
-            let ld = devices.get_mut(&device_handle).unwrap();
+            let ld = devices.get(&device_handle).unwrap();
             let barrier = ld.timeline_next.load(Ordering::Relaxed).saturating_sub(1);
-            ld.deletion_queue.queue(
+            ld.deletion_queue.lock().unwrap().queue(
                 barrier,
                 types::PendingDeletion::ReplacedBufferGpu {
                     buffer: stg_buf,
@@ -586,7 +588,7 @@ pub(super) fn set_logical_size(
             vk::DescriptorType::UNIFORM_BUFFER
         };
 
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let write = vk::WriteDescriptorSet::default()
             .dst_set(descriptor_set)
             .dst_binding(binding)
@@ -604,7 +606,7 @@ pub(super) fn set_logical_size(
 }
 
 fn set_logical_size_sparse(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
@@ -647,12 +649,8 @@ fn set_logical_size_sparse(
 
     {
         let ld = devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Invalid device handle")?;
-        let pool = ld
-            .sparse_page_pool
-            .as_mut()
-            .context("internal: sparse pool missing")?;
         let bind_queue = ld.sparse_binding_queue;
         let dev: &ash::Device = &ld.device;
 
@@ -660,6 +658,11 @@ fn set_logical_size_sparse(
             .get_mut(&buffer_handle)
             .context("buffer disappeared")?
             .sparse_pages;
+
+        let mut pool_guard = ld.sparse_page_pool.lock().unwrap();
+        let pool = pool_guard
+            .as_mut()
+            .context("internal: sparse pool missing")?;
 
         if new_pages > old_pages {
             let mut binds = Vec::with_capacity(new_pages - old_pages);
@@ -716,9 +719,9 @@ fn set_logical_size_sparse(
             (buf.staging_buffer.take(), buf.staging_memory.take())
         };
         if let (Some(stg_buf), Some(stg_mem)) = (old_stg_buf, old_stg_mem) {
-            let ld = devices.get_mut(&device_handle).unwrap();
+            let ld = devices.get(&device_handle).unwrap();
             let barrier = ld.timeline_next.load(Ordering::Relaxed).saturating_sub(1);
-            ld.deletion_queue.queue(
+            ld.deletion_queue.lock().unwrap().queue(
                 barrier,
                 types::PendingDeletion::ReplacedBufferGpu {
                     buffer: stg_buf,
@@ -754,7 +757,7 @@ fn set_logical_size_sparse(
             vk::DescriptorType::UNIFORM_BUFFER
         };
 
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let write = vk::WriteDescriptorSet::default()
             .dst_set(descriptor_set)
             .dst_binding(binding)
@@ -774,7 +777,7 @@ fn set_logical_size_sparse(
 /// Allocate VkBuffer + memory (no bindless registration). Matches [`create`] rules.
 fn allocate_vk_buffer_memory(
     instance: &ash::Instance,
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     device_handle: DeviceHandle,
     size: u64,
     is_storage: bool,
@@ -989,7 +992,7 @@ fn submit_resize_transfer(
 /// Resize a root buffer in place. [`BufferHandle`] and bindless slot stay stable.
 pub(super) fn resize(
     instance: &ash::Instance,
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
@@ -1084,7 +1087,7 @@ pub(super) fn resize(
             vk::DescriptorType::UNIFORM_BUFFER
         };
 
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let write = vk::WriteDescriptorSet::default()
             .dst_set(descriptor_set)
             .dst_binding(binding)
@@ -1099,7 +1102,7 @@ pub(super) fn resize(
     }
 
     if old_state.host_mapped.is_some() && !old_state.is_sparse {
-        let dev = devices.get_mut(&device_handle).unwrap();
+        let dev = devices.get(&device_handle).unwrap();
         if let Err(e) = unsafe { dev.unmap_memory2(old_state.memory) } {
             tracing::warn!(?e, "unmap_memory2 failed for old buffer during resize");
         }
@@ -1133,9 +1136,11 @@ pub(super) fn resize(
         }
     };
     devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .unwrap()
         .deletion_queue
+        .lock()
+        .unwrap()
         .queue(barrier, pending);
 
     let old_parent_vk = old_state.buffer;
@@ -1182,7 +1187,7 @@ pub(super) fn resize(
                 .buffer(new_buffer)
                 .offset(off)
                 .range(range);
-            let logical_device = devices.get_mut(&device_handle).unwrap();
+            let logical_device = devices.get(&device_handle).unwrap();
             let write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_set)
                 .dst_binding(types::bindless_bindings::STORAGE_BUFFERS)
@@ -1210,19 +1215,19 @@ pub(super) fn resize(
 /// For views, only the descriptor index is deferred — the underlying VkBuffer/memory
 /// belongs to the parent and is not freed.
 pub(super) fn destroy(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     buffer_handle: BufferHandle,
 ) {
     if let Some(buffer) = buffers.remove(&buffer_handle) {
-        if let Some(device) = devices.get_mut(&buffer.device_handle) {
+        if let Some(device) = devices.get(&buffer.device_handle) {
             let barrier = device
                 .timeline_next
                 .load(Ordering::Relaxed)
                 .saturating_sub(1);
 
             if buffer.is_view {
-                device.deletion_queue.queue(
+                device.deletion_queue.lock().unwrap().queue(
                     barrier,
                     types::PendingDeletion::BufferView { buffer_handle },
                 );
@@ -1260,7 +1265,7 @@ pub(super) fn destroy(
             } else {
                 None
             };
-            device.deletion_queue.queue(
+            device.deletion_queue.lock().unwrap().queue(
                 barrier,
                 types::PendingDeletion::Buffer {
                     buffer_handle,
@@ -1284,7 +1289,7 @@ pub(super) fn destroy(
 /// The view gets its own bindless descriptor at `[offset, offset+size)` of the parent.
 /// It shares the parent's VkBuffer and staging resources.
 pub(super) fn create_view(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     next_buffer_handle: &mut BufferHandle,
     parent_handle: BufferHandle,
@@ -1315,7 +1320,7 @@ pub(super) fn create_view(
     let parent_flags = parent.flags;
 
     let logical_device = devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     let bindless_descriptor_set = logical_device.bindless_descriptor_set;
@@ -1400,7 +1405,7 @@ pub(super) fn create_view(
 /// Lazily create the HOST_VISIBLE staging buffer for a DEVICE_LOCAL storage buffer.
 pub(super) fn ensure_staging(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     buffer_handle: BufferHandle,
 ) -> Result<()> {
@@ -1459,7 +1464,7 @@ pub(super) fn ensure_staging(
 /// copies via GPU. For HOST_VISIBLE uniform buffers, maps directly.
 pub(super) fn write(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     buffer_handle: BufferHandle,
     offset: u64,
@@ -1561,7 +1566,7 @@ pub(super) fn bindless_index(
 /// a GPU copy and maps. For HOST_VISIBLE uniform buffers, maps directly.
 pub(super) fn read_to_cpu(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &mut HashMap<BufferHandle, BufferState>,
     device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
@@ -1652,7 +1657,7 @@ pub(super) fn read_to_cpu(
 
 /// Fill buffer region with zeros. If size is 0, clears from offset to end of buffer.
 pub(super) fn clear(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     buffers: &HashMap<BufferHandle, BufferState>,
     device_handle: DeviceHandle,
     buffer_handle: BufferHandle,
@@ -1664,7 +1669,7 @@ pub(super) fn clear(
         .context("Invalid buffer handle")?;
 
     let device = devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Invalid device handle")?;
 
     if buffer.device_handle != device_handle {

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -199,6 +199,9 @@ pub(super) fn create(
     let bindless_index = {
         let logical_device = devices.get_mut(&device_handle).unwrap();
         let index = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_buffer(handle, is_storage);
 
@@ -355,7 +358,12 @@ pub(super) fn create_sparse_with_capacity(
     *next_buffer_handle += 1;
 
     let bindless_index = {
-        let index = ld.resource_registry.register_buffer(handle, true);
+        let index = ld
+            .ledger
+            .lock()
+            .unwrap()
+            .resource_registry
+            .register_buffer(handle, true);
         if let Some(descriptor_set) = bindless_descriptor_set {
             let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(buffer)
@@ -1222,7 +1230,11 @@ pub(super) fn destroy(
             }
 
             if buffer.transient_heap_suballoc {
-                device.reclaim_buffer_slots(buffer_handle);
+                device
+                    .ledger
+                    .lock()
+                    .unwrap()
+                    .reclaim_buffer_slots(buffer_handle);
                 unsafe {
                     device.device.destroy_buffer(buffer.buffer, None);
                 }
@@ -1317,6 +1329,9 @@ pub(super) fn create_view(
     } else {
         let handle_for_registry = *next_buffer_handle;
         let index = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_buffer(handle_for_registry, is_storage);
 

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
+use std::sync::atomic::Ordering;
 
 /// Submit a one-shot vkCmdCopyBuffer between two buffers and wait for completion.
 fn submit_copy(
@@ -540,7 +541,7 @@ pub(super) fn set_logical_size(
         };
         if let (Some(stg_buf), Some(stg_mem)) = (old_stg_buf, old_stg_mem) {
             let ld = devices.get_mut(&device_handle).unwrap();
-            let barrier = ld.timeline_next.saturating_sub(1);
+            let barrier = ld.timeline_next.load(Ordering::Relaxed).saturating_sub(1);
             ld.deletion_queue.queue(
                 barrier,
                 types::PendingDeletion::ReplacedBufferGpu {
@@ -708,7 +709,7 @@ fn set_logical_size_sparse(
         };
         if let (Some(stg_buf), Some(stg_mem)) = (old_stg_buf, old_stg_mem) {
             let ld = devices.get_mut(&device_handle).unwrap();
-            let barrier = ld.timeline_next.saturating_sub(1);
+            let barrier = ld.timeline_next.load(Ordering::Relaxed).saturating_sub(1);
             ld.deletion_queue.queue(
                 barrier,
                 types::PendingDeletion::ReplacedBufferGpu {
@@ -1100,6 +1101,7 @@ pub(super) fn resize(
         .get(&device_handle)
         .unwrap()
         .timeline_next
+        .load(Ordering::Relaxed)
         .saturating_sub(1);
     let pending = if old_state.is_sparse {
         let binds = sparse::collect_sparse_binds_for_teardown(
@@ -1206,7 +1208,10 @@ pub(super) fn destroy(
 ) {
     if let Some(buffer) = buffers.remove(&buffer_handle) {
         if let Some(device) = devices.get_mut(&buffer.device_handle) {
-            let barrier = device.timeline_next.saturating_sub(1);
+            let barrier = device
+                .timeline_next
+                .load(Ordering::Relaxed)
+                .saturating_sub(1);
 
             if buffer.is_view {
                 device.deletion_queue.queue(

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -679,7 +679,8 @@ pub(super) fn submit(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?
-            .timeline_next;
+            .timeline_next
+            .fetch_add(1, Ordering::Relaxed);
         let timeline_sem = state
             .contexts
             .get(&ctx)
@@ -707,7 +708,6 @@ pub(super) fn submit(
         {
             let retired = super::context::device_retired(state, device_handle);
             if let Some(ld) = state.devices.get_mut(&device_handle) {
-                ld.timeline_next = signal_value.saturating_add(1);
                 ld.process_deletion_queue_up_to(retired);
             }
         }
@@ -1367,7 +1367,7 @@ pub(super) fn submit(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        ld.timeline_next
+        ld.timeline_next.fetch_add(1, Ordering::Relaxed)
     };
 
     let used_slots =
@@ -1426,9 +1426,6 @@ pub(super) fn submit(
         ));
     }
 
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.timeline_next = signal_value.saturating_add(1);
-    }
     if let Some(sc) = state.contexts.get_mut(&ctx) {
         sc.last_submitted_seq = signal_value;
         sc.timeline_cmd_buffers
@@ -2339,7 +2336,7 @@ fn submit_graph_impl(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        ld.timeline_next
+        ld.timeline_next.fetch_add(1, Ordering::Relaxed)
     };
 
     let used_slots = collect_slot_keys_from_graph_commands(
@@ -2396,10 +2393,6 @@ fn submit_graph_impl(
             "Failed to queue_submit2 command buffer: {:?}",
             e
         ));
-    }
-
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.timeline_next = signal_value.saturating_add(1);
     }
 
     // Post-submit: store the CB for lifecycle management.
@@ -2534,7 +2527,7 @@ pub(super) fn try_resubmit_retained(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        ld.timeline_next
+        ld.timeline_next.fetch_add(1, Ordering::Relaxed)
     };
 
     let timeline_sem = state
@@ -2574,7 +2567,6 @@ pub(super) fn try_resubmit_retained(
     {
         let retired = super::context::device_retired(state, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.timeline_next = signal_value.saturating_add(1);
             ld.process_deletion_queue_up_to(retired);
             ld.drain_ready_slot_reclamations(&state.contexts);
         }

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -602,19 +602,21 @@ pub(super) fn submit(
         let completed_timeline = super::context::device_retired(state, device_handle);
 
         if has_write_buffer {
-            for belt in state.staging_belts.values_mut() {
-                belt.reclaim(
-                    &state.compute_fence_pool,
-                    &state.devices,
-                    completed_timeline,
-                )?;
+            let (fence_pool, devices, contexts) = (
+                &state.compute_fence_pool,
+                &state.devices,
+                &mut state.contexts,
+            );
+            if let Some(sc) = contexts.get_mut(&ctx) {
+                sc.staging_belt
+                    .reclaim(fence_pool, devices, completed_timeline)?;
             }
             reap_signaled_fences(state);
         }
 
         if has_write_texture {
-            if let Some(pool) = state.texture_staging_pools.get_mut(&device_handle) {
-                pool.reclaim(completed_timeline);
+            if let Some(sc) = state.contexts.get_mut(&ctx) {
+                sc.texture_staging_pool.reclaim(completed_timeline);
             }
         }
     }
@@ -622,7 +624,7 @@ pub(super) fn submit(
     // Belt slices for DEVICE_LOCAL WriteBuffer copies (same iteration order as command loop).
     let mut belt_slices: Vec<(vk::Buffer, u64)> = Vec::new();
 
-    // Pre-pass: stage CPU data for WriteBuffer commands (needs mutable buffer
+    // Pre-pass: stage CPU data for WriteBuffer commands (needs mutable belt
     // access before we borrow state immutably for the command loop).
     if has_write_buffer {
         for command in commands {
@@ -632,11 +634,21 @@ pub(super) fn submit(
                 data,
             } = command
             {
-                let buf = state
-                    .buffers
-                    .get(buf_handle)
-                    .context("WriteBuffer: invalid buffer handle")?;
-                if let Some(base) = buf.host_mapped {
+                // Extract Copy fields from the buffer state so the borrow ends
+                // before we take a mutable borrow of state.contexts for the belt.
+                let (host_mapped, is_storage, buf_device, buf_memory) = {
+                    let buf = state
+                        .buffers
+                        .get(buf_handle)
+                        .context("WriteBuffer: invalid buffer handle")?;
+                    (
+                        buf.host_mapped,
+                        buf.is_storage,
+                        buf.device_handle,
+                        buf.memory,
+                    )
+                };
+                if let Some(base) = host_mapped {
                     let p = base as *mut u8;
                     unsafe {
                         std::ptr::copy_nonoverlapping(
@@ -645,29 +657,29 @@ pub(super) fn submit(
                             data.len(),
                         );
                     }
-                } else if !buf.is_storage {
-                    let dev = state
-                        .devices
-                        .get(&buf.device_handle)
-                        .context("WriteBuffer: device invalid")?;
-                    unsafe {
-                        let ptr = dev
-                            .map_memory2(buf.memory, *offset, data.len() as u64)
-                            .context("WriteBuffer: map failed")?;
-                        std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
-                        dev.unmap_memory2(buf.memory)
-                            .context("WriteBuffer: unmap failed")?;
-                    }
-                } else {
-                    let buf_device = buf.device_handle;
+                } else if !is_storage {
                     let dev = state
                         .devices
                         .get(&buf_device)
                         .context("WriteBuffer: device invalid")?;
-                    let belt_entry = state.staging_belts.entry(buf_device).or_insert_with(|| {
-                        staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                    });
-                    let (stg_buf, stg_off) = belt_entry.write(&state.instance, dev, data)?;
+                    unsafe {
+                        let ptr = dev
+                            .map_memory2(buf_memory, *offset, data.len() as u64)
+                            .context("WriteBuffer: map failed")?;
+                        std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
+                        dev.unmap_memory2(buf_memory)
+                            .context("WriteBuffer: unmap failed")?;
+                    }
+                } else {
+                    let dev = state
+                        .devices
+                        .get(&buf_device)
+                        .context("WriteBuffer: device invalid")?;
+                    let sc = state
+                        .contexts
+                        .get_mut(&ctx)
+                        .context("Invalid context handle")?;
+                    let (stg_buf, stg_off) = sc.staging_belt.write(&state.instance, dev, data)?;
                     belt_slices.push((stg_buf, stg_off));
                 }
             }
@@ -721,14 +733,6 @@ pub(super) fn submit(
     let buffers = &state.buffers;
 
     let mut texture_upload_scratch: Vec<super::texture::ComputeTextureScratch> = Vec::new();
-    if has_write_texture {
-        // Ensure a pool exists for this device before the upload loop so we can
-        // hold a mutable reference to just the pool while borrowing other fields.
-        state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(staging::TextureStagingPool::new);
-    }
     for command in commands {
         match command {
             GpuCommand::WriteTexture {
@@ -737,7 +741,11 @@ pub(super) fn submit(
                 width,
                 height,
             } => {
-                let pool = state.texture_staging_pools.get_mut(&device_handle).unwrap();
+                let pool = &mut state
+                    .contexts
+                    .get_mut(&ctx)
+                    .context("Invalid context handle")?
+                    .texture_staging_pool;
                 texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
                     &state.instance,
                     &state.devices,
@@ -759,7 +767,11 @@ pub(super) fn submit(
                 height,
                 data,
             } => {
-                let pool = state.texture_staging_pools.get_mut(&device_handle).unwrap();
+                let pool = &mut state
+                    .contexts
+                    .get_mut(&ctx)
+                    .context("Invalid context handle")?
+                    .texture_staging_pool;
                 texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
                     &state.instance,
                     &state.devices,
@@ -1439,18 +1451,14 @@ pub(super) fn submit(
             .into_iter()
             .map(|s| s.entry)
             .collect();
-        state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(staging::TextureStagingPool::new)
-            .release(signal_value, entries);
+        if let Some(sc) = state.contexts.get_mut(&ctx) {
+            sc.texture_staging_pool.release(signal_value, entries);
+        }
     }
 
-    state
-        .staging_belts
-        .entry(device_handle)
-        .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-        .finish(signal_value);
+    if let Some(sc) = state.contexts.get_mut(&ctx) {
+        sc.staging_belt.finish(signal_value);
+    }
 
     debug_assert_eq!(
         belt_idx,
@@ -1557,30 +1565,27 @@ fn submit_graph_impl(
         let _rz = tracy_zone!("vk.submit_graph.belt_reclaim");
         let completed_timeline = super::context::device_retired(state, device_handle);
 
-        for belt in state.staging_belts.values_mut() {
-            belt.reclaim(
+        {
+            let (fence_pool, devices, contexts) = (
                 &state.compute_fence_pool,
                 &state.devices,
-                completed_timeline,
-            )?;
+                &mut state.contexts,
+            );
+            if let Some(sc) = contexts.get_mut(&ctx) {
+                sc.staging_belt
+                    .reclaim(fence_pool, devices, completed_timeline)?;
+            }
         }
         reap_signaled_fences(state);
 
         if has_write_texture_graph {
-            if let Some(pool) = state.texture_staging_pools.get_mut(&device_handle) {
-                pool.reclaim(completed_timeline);
+            if let Some(sc) = state.contexts.get_mut(&ctx) {
+                sc.texture_staging_pool.reclaim(completed_timeline);
             }
         }
     }
 
-    if has_write_texture_graph {
-        state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(staging::TextureStagingPool::new);
-    }
-
-    // --- Pre-pass: stage CPU data for WriteBuffer in compute segments ---
+    // --- Pre-pass: stage CPU data for WriteBuffer/WriteTexture in compute segments ---
     let mut belt_slices: Vec<(vk::Buffer, u64)> = Vec::new();
     let mut texture_upload_scratch: Vec<super::texture::ComputeTextureScratch> = Vec::new();
 
@@ -1593,11 +1598,21 @@ fn submit_graph_impl(
                         offset,
                         data,
                     } => {
-                        let buf = state
-                            .buffers
-                            .get(buf_handle)
-                            .context("WriteBuffer: invalid buffer handle")?;
-                        if let Some(base) = buf.host_mapped {
+                        // Extract Copy fields so the state.buffers borrow ends
+                        // before we take &mut state.contexts for the belt.
+                        let (host_mapped, is_storage, buf_device, buf_memory) = {
+                            let buf = state
+                                .buffers
+                                .get(buf_handle)
+                                .context("WriteBuffer: invalid buffer handle")?;
+                            (
+                                buf.host_mapped,
+                                buf.is_storage,
+                                buf.device_handle,
+                                buf.memory,
+                            )
+                        };
+                        if let Some(base) = host_mapped {
                             let p = base as *mut u8;
                             unsafe {
                                 std::ptr::copy_nonoverlapping(
@@ -1606,35 +1621,34 @@ fn submit_graph_impl(
                                     data.len(),
                                 );
                             }
-                        } else if !buf.is_storage {
+                        } else if !is_storage {
                             let dev = state
                                 .devices
-                                .get(&buf.device_handle)
+                                .get(&buf_device)
                                 .context("WriteBuffer: device invalid")?;
                             unsafe {
                                 let ptr = dev
-                                    .map_memory2(buf.memory, *offset, data.len() as u64)
+                                    .map_memory2(buf_memory, *offset, data.len() as u64)
                                     .context("WriteBuffer: map failed")?;
                                 std::ptr::copy_nonoverlapping(
                                     data.as_ptr(),
                                     ptr as *mut u8,
                                     data.len(),
                                 );
-                                dev.unmap_memory2(buf.memory)
+                                dev.unmap_memory2(buf_memory)
                                     .context("WriteBuffer: unmap failed")?;
                             }
                         } else {
-                            let buf_device = buf.device_handle;
                             let dev = state
                                 .devices
                                 .get(&buf_device)
                                 .context("WriteBuffer: device invalid")?;
-                            let belt_entry =
-                                state.staging_belts.entry(buf_device).or_insert_with(|| {
-                                    staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE)
-                                });
+                            let sc = state
+                                .contexts
+                                .get_mut(&ctx)
+                                .context("Invalid context handle")?;
                             let (stg_buf, stg_off) =
-                                belt_entry.write(&state.instance, dev, data)?;
+                                sc.staging_belt.write(&state.instance, dev, data)?;
                             belt_slices.push((stg_buf, stg_off));
                         }
                     }
@@ -1644,7 +1658,11 @@ fn submit_graph_impl(
                         width,
                         height,
                     } => {
-                        let pool = state.texture_staging_pools.get_mut(&device_handle).unwrap();
+                        let pool = &mut state
+                            .contexts
+                            .get_mut(&ctx)
+                            .context("Invalid context handle")?
+                            .texture_staging_pool;
                         texture_upload_scratch.push(
                             super::texture::allocate_compute_texture_staging(
                                 &state.instance,
@@ -1668,7 +1686,11 @@ fn submit_graph_impl(
                         height,
                         data,
                     } => {
-                        let pool = state.texture_staging_pools.get_mut(&device_handle).unwrap();
+                        let pool = &mut state
+                            .contexts
+                            .get_mut(&ctx)
+                            .context("Invalid context handle")?
+                            .texture_staging_pool;
                         texture_upload_scratch.push(
                             super::texture::allocate_compute_texture_staging(
                                 &state.instance,
@@ -2417,18 +2439,14 @@ fn submit_graph_impl(
             .into_iter()
             .map(|s| s.entry)
             .collect();
-        state
-            .texture_staging_pools
-            .entry(device_handle)
-            .or_insert_with(staging::TextureStagingPool::new)
-            .release(signal_value, entries);
+        if let Some(sc) = state.contexts.get_mut(&ctx) {
+            sc.texture_staging_pool.release(signal_value, entries);
+        }
     }
 
-    state
-        .staging_belts
-        .entry(device_handle)
-        .or_insert_with(|| staging::StagingBelt::new(staging::DEFAULT_STAGING_CHUNK_SIZE))
-        .finish(signal_value);
+    if let Some(sc) = state.contexts.get_mut(&ctx) {
+        sc.staging_belt.finish(signal_value);
+    }
 
     if let Some(prof) = vk_gpu_profile {
         let (device_clone, timeline_sem) = {

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -428,6 +428,28 @@ unsafe fn vulkan_finish_gpu_profile(
     Ok(())
 }
 
+/// Returns the GPU-completed timeline value for a single context by reading its
+/// timeline semaphore counter directly, without consulting any other context.
+///
+/// Used on the submit hot path to replace `device_retired` (max-over-contexts)
+/// as the reclaim gate. Because all contexts submit to the same `vk::Queue`,
+/// when this context's semaphore reaches V every submit with a global timeline
+/// value ≤ V — including those from other contexts — has already completed on
+/// that queue. Draining with V is therefore safe and never creates a
+/// cross-context dependency.
+pub(super) fn ctx_completed_value(
+    state: &super::types::VulkanState,
+    ctx: super::ContextHandle,
+    device_handle: super::DeviceHandle,
+) -> u64 {
+    let sem = state.contexts.get(&ctx).map(|sc| sc.timeline_semaphore);
+    let dev = state.devices.get(&device_handle).map(|ld| &ld.device);
+    match (dev, sem) {
+        (Some(dev), Some(sem)) => unsafe { dev.get_semaphore_counter_value(sem).unwrap_or(0) },
+        _ => 0,
+    }
+}
+
 /// Reap fences that have already signaled from the compute fence pool.
 ///
 /// Without this, every `submit_graph` that doesn't have a paired `wait_fence`
@@ -599,7 +621,7 @@ pub(super) fn submit(
 
     if has_write_buffer || has_write_texture {
         let _rz = tracy_zone!("vk.submit.belt_reclaim");
-        let completed_timeline = super::context::device_retired(state, device_handle);
+        let completed_timeline = ctx_completed_value(state, ctx, device_handle);
 
         if has_write_buffer {
             let (fence_pool, devices, contexts) = (
@@ -718,9 +740,9 @@ pub(super) fn submit(
         };
         r.context("Failed queue_submit2 for empty compute submit")?;
         {
-            let retired = super::context::device_retired(state, device_handle);
+            let completed = ctx_completed_value(state, ctx, device_handle);
             if let Some(ld) = state.devices.get_mut(&device_handle) {
-                ld.process_deletion_queue_up_to(retired);
+                ld.process_deletion_queue_up_to(completed);
             }
         }
         if let Some(sc) = state.contexts.get_mut(&ctx) {
@@ -1493,9 +1515,9 @@ pub(super) fn submit(
     }
 
     {
-        let retired = super::context::device_retired(state, device_handle);
+        let completed = ctx_completed_value(state, ctx, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(retired);
+            ld.process_deletion_queue_up_to(completed);
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
@@ -1563,7 +1585,7 @@ fn submit_graph_impl(
 
     if has_upload {
         let _rz = tracy_zone!("vk.submit_graph.belt_reclaim");
-        let completed_timeline = super::context::device_retired(state, device_handle);
+        let completed_timeline = ctx_completed_value(state, ctx, device_handle);
 
         {
             let (fence_pool, devices, contexts) = (
@@ -2482,9 +2504,9 @@ fn submit_graph_impl(
     }
 
     {
-        let retired = super::context::device_retired(state, device_handle);
+        let completed = ctx_completed_value(state, ctx, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(retired);
+            ld.process_deletion_queue_up_to(completed);
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
@@ -2583,9 +2605,9 @@ pub(super) fn try_resubmit_retained(
     }
 
     {
-        let retired = super::context::device_retired(state, device_handle);
+        let completed = ctx_completed_value(state, ctx, device_handle);
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(retired);
+            ld.process_deletion_queue_up_to(completed);
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -732,18 +732,22 @@ pub(super) fn submit(
             .get(&device_handle)
             .context("Invalid device handle")?;
         let queue = ld.queue;
+        let queue_lock = std::sync::Arc::clone(&ld.queue_lock);
         let signal_info = vk::SemaphoreSubmitInfo::default()
             .semaphore(timeline_sem)
             .value(signal_value)
             .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS);
         let submit_info2 =
             vk::SubmitInfo2::default().signal_semaphore_infos(std::slice::from_ref(&signal_info));
-        let r = unsafe {
-            ld.device.queue_submit2(
-                queue,
-                std::slice::from_ref(&submit_info2),
-                vk::Fence::null(),
-            )
+        let r = {
+            let _queue_guard = queue_lock.lock().unwrap();
+            unsafe {
+                ld.device.queue_submit2(
+                    queue,
+                    std::slice::from_ref(&submit_info2),
+                    vk::Fence::null(),
+                )
+            }
         };
         r.context("Failed queue_submit2 for empty compute submit")?;
         {
@@ -1434,6 +1438,7 @@ pub(super) fn submit(
         .devices
         .get(&device_handle)
         .context("Invalid device handle")?;
+    let queue_lock = std::sync::Arc::clone(&submit_device_core.queue_lock);
     let cmd_info = vk::CommandBufferSubmitInfo::default().command_buffer(cmd);
     let signal_info = vk::SemaphoreSubmitInfo::default()
         .semaphore(timeline_sem)
@@ -1445,6 +1450,7 @@ pub(super) fn submit(
 
     let queue_submit_result = {
         let _tz = tracy_zone!("vk.queue_submit2");
+        let _queue_guard = queue_lock.lock().unwrap();
         unsafe {
             submit_device_core.device.queue_submit2(
                 submit_device_core.queue,
@@ -2444,6 +2450,7 @@ fn submit_graph_impl(
         .devices
         .get(&device_handle)
         .context("Invalid device handle")?;
+    let queue_lock = std::sync::Arc::clone(&submit_device.queue_lock);
     let cmd_info = vk::CommandBufferSubmitInfo::default().command_buffer(cmd);
     let signal_info = vk::SemaphoreSubmitInfo::default()
         .semaphore(timeline_sem)
@@ -2455,6 +2462,7 @@ fn submit_graph_impl(
 
     let queue_submit_result = {
         let _tz = tracy_zone!("vk.queue_submit2");
+        let _queue_guard = queue_lock.lock().unwrap();
         unsafe {
             submit_device.device.queue_submit2(
                 submit_device.queue,
@@ -2641,6 +2649,7 @@ pub(super) fn try_resubmit_retained(
         .devices
         .get(&device_handle)
         .context("Invalid device handle")?;
+    let queue_lock = std::sync::Arc::clone(&submit_device.queue_lock);
     let cmd_info = vk::CommandBufferSubmitInfo::default().command_buffer(cmd);
     let signal_info = vk::SemaphoreSubmitInfo::default()
         .semaphore(timeline_sem)
@@ -2652,6 +2661,7 @@ pub(super) fn try_resubmit_retained(
 
     {
         let _tz = tracy_zone!("vk.resubmit_retained");
+        let _queue_guard = queue_lock.lock().unwrap();
         unsafe {
             submit_device.device.queue_submit2(
                 submit_device.queue,

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -741,8 +741,15 @@ pub(super) fn submit(
         r.context("Failed queue_submit2 for empty compute submit")?;
         {
             let completed = ctx_completed_value(state, ctx, device_handle);
+            let ctx_batch: Vec<_> = state
+                .contexts
+                .get_mut(&ctx)
+                .map(|sc| sc.deletion_queue.drain_up_to(completed))
+                .unwrap_or_default();
             if let Some(ld) = state.devices.get_mut(&device_handle) {
-                ld.process_deletion_queue_up_to(completed);
+                for r in ctx_batch {
+                    super::types::destroy_pending_deletion(ld, r);
+                }
             }
         }
         if let Some(sc) = state.contexts.get_mut(&ctx) {
@@ -1516,8 +1523,15 @@ pub(super) fn submit(
 
     {
         let completed = ctx_completed_value(state, ctx, device_handle);
+        let ctx_batch: Vec<_> = state
+            .contexts
+            .get_mut(&ctx)
+            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(completed);
+            for r in ctx_batch {
+                super::types::destroy_pending_deletion(ld, r);
+            }
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
@@ -2505,8 +2519,15 @@ fn submit_graph_impl(
 
     {
         let completed = ctx_completed_value(state, ctx, device_handle);
+        let ctx_batch: Vec<_> = state
+            .contexts
+            .get_mut(&ctx)
+            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(completed);
+            for r in ctx_batch {
+                super::types::destroy_pending_deletion(ld, r);
+            }
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
@@ -2606,8 +2627,15 @@ pub(super) fn try_resubmit_retained(
 
     {
         let completed = ctx_completed_value(state, ctx, device_handle);
+        let ctx_batch: Vec<_> = state
+            .contexts
+            .get_mut(&ctx)
+            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(completed);
+            for r in ctx_batch {
+                super::types::destroy_pending_deletion(ld, r);
+            }
             ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -368,7 +368,7 @@ fn vulkan_decode_duration_ns(start: u64, end: u64, valid_bits: u32, period_ns: f
 }
 
 unsafe fn vulkan_finish_gpu_profile(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     device: &ash::Device,
     timeline_sem: vk::Semaphore,
@@ -463,24 +463,26 @@ pub(super) fn ctx_completed_value(
 /// fall over, the device is lost (`ERROR_DEVICE_LOST` on the next
 /// `queue_submit`), and the unbounded HashMap teardown corrupts the heap on
 /// shutdown.
-fn reap_signaled_fences(state: &mut super::types::VulkanState) {
-    let signaled: Vec<u64> = state
-        .compute_fence_pool
-        .iter()
-        .filter_map(|(token, (device_handle, fence, _))| {
-            let logical_device = state.devices.get(device_handle)?;
-            let signaled =
-                unsafe { logical_device.device.get_fence_status(*fence) }.unwrap_or(false);
-            if signaled {
-                Some(*token)
-            } else {
-                None
-            }
-        })
-        .collect();
+fn reap_signaled_fences(state: &super::types::VulkanState) {
+    let signaled: Vec<u64> = {
+        let pool = state.compute_fence_pool.lock().unwrap();
+        pool.iter()
+            .filter_map(|(token, (device_handle, fence, _))| {
+                let logical_device = state.devices.get(device_handle)?;
+                let signaled =
+                    unsafe { logical_device.device.get_fence_status(*fence) }.unwrap_or(false);
+                if signaled {
+                    Some(*token)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
 
+    let mut pool = state.compute_fence_pool.lock().unwrap();
     for token in signaled {
-        if let Some((device_handle, fence, cmd_buf)) = state.compute_fence_pool.remove(&token) {
+        if let Some((device_handle, fence, cmd_buf)) = pool.remove(&token) {
             if let Some(logical_device) = state.devices.get(&device_handle) {
                 unsafe {
                     if let Some(cb) = cmd_buf {
@@ -591,7 +593,7 @@ pub(super) fn destroy(
 /// Submit compute commands without blocking. Returns a fence token for polling/waiting.
 /// Submit a batch of GPU commands as a single compute submission.
 pub(super) fn submit(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     commands: &[GpuCommand],
 ) -> Result<TimelineValue> {
@@ -1266,7 +1268,7 @@ pub(super) fn submit(
                     texture_upload_idx += 1;
                     super::texture::record_compute_texture_upload(
                         &state.devices,
-                        &mut state.textures,
+                        &state.textures,
                         cmd,
                         scratch,
                     )?;
@@ -1577,7 +1579,7 @@ pub(super) fn submit(
 /// everything into one `VkCommandBuffer` and performing a single
 /// `queue_submit2` with a timeline semaphore signal at the end.
 pub(super) fn submit_graph(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     commands: &[GraphCommand],
 ) -> Result<TimelineValue> {
@@ -1596,7 +1598,7 @@ pub(super) fn submit_graph(
 /// - the CB is recorded with `ONE_TIME_SUBMIT`
 /// - after submit it is stored in `timeline_cmd_buffers` and freed once the GPU retires it
 fn submit_graph_impl(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     commands: &[GraphCommand],
     retain_key: Option<u64>,
@@ -2211,7 +2213,7 @@ fn submit_graph_impl(
                     texture_upload_idx += 1;
                     super::texture::record_compute_texture_upload(
                         &state.devices,
-                        &mut state.textures,
+                        &state.textures,
                         cmd,
                         scratch,
                     )?;
@@ -2557,8 +2559,8 @@ fn submit_graph_impl(
 
     // Mark rendered targets
     for t in rendered_targets {
-        if let Some(rt) = state.render_targets.get_mut(&t) {
-            rt.has_rendered = true;
+        if let Some(rt) = state.render_targets.get(&t) {
+            rt.has_rendered.store(true, Ordering::Relaxed);
         }
     }
 
@@ -2598,7 +2600,7 @@ fn submit_graph_impl(
 /// If commands contain any WriteBuffer/WriteTexture nodes the call falls back to a normal
 /// (non-retained) submit via [`submit_graph`].
 pub(super) fn submit_graph_and_retain(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     commands: &[GraphCommand],
     key: u64,
@@ -2616,7 +2618,7 @@ pub(super) fn submit_graph_and_retain(
 /// Safety: The caller must have confirmed that the GPU has completed the previous
 /// submission of this CB (e.g. by `wait_until`) so it is in executable state.
 pub(super) fn try_resubmit_retained(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     key: u64,
 ) -> Result<Option<TimelineValue>> {
@@ -2712,7 +2714,7 @@ pub(super) fn try_resubmit_retained(
 /// Evict the retained dispatch CB for `key` (or any retained CB if `key` doesn't match),
 /// returning the `VkCommandBuffer` to `free_cmd_buffers` for pool reuse.
 pub(super) fn evict_retained(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     _key: u64,
 ) {
@@ -2725,7 +2727,7 @@ pub(super) fn evict_retained(
 }
 
 pub(super) fn reap_timeline_cmd_buffers_up_to(
-    state: &mut super::types::VulkanState,
+    state: &super::types::VulkanState,
     ctx: super::ContextHandle,
     max_completed_value: u64,
 ) {

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -442,7 +442,10 @@ pub(super) fn ctx_completed_value(
     ctx: super::ContextHandle,
     device_handle: super::DeviceHandle,
 ) -> u64 {
-    let sem = state.contexts.get(&ctx).map(|sc| sc.timeline_semaphore);
+    let sem = state
+        .contexts
+        .get(&ctx)
+        .map(|sc| sc.lock().unwrap().timeline_semaphore);
     let dev = state.devices.get(&device_handle).map(|ld| &ld.device);
     match (dev, sem) {
         (Some(dev), Some(sem)) => unsafe { dev.get_semaphore_counter_value(sem).unwrap_or(0) },
@@ -497,7 +500,7 @@ fn reap_signaled_fences(state: &mut super::types::VulkanState) {
 
 /// Create a compute pipeline.
 pub(super) fn create(
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     compute_pipelines: &mut HashMap<ComputePipelineHandle, ComputePipelineState>,
     next_compute_pipeline_handle: &mut ComputePipelineHandle,
     device_handle: DeviceHandle,
@@ -563,7 +566,7 @@ pub(super) fn create(
 
 /// Destroy a compute pipeline.
 pub(super) fn destroy(
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     compute_pipelines: &mut HashMap<ComputePipelineHandle, ComputePipelineState>,
     pipeline_handle: ComputePipelineHandle,
 ) {
@@ -596,6 +599,8 @@ pub(super) fn submit(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let _tz = tracy_zone!("vk.submit");
     // Detect WriteBuffer up-front so we can skip all the staging-belt /
@@ -624,21 +629,23 @@ pub(super) fn submit(
         let completed_timeline = ctx_completed_value(state, ctx, device_handle);
 
         if has_write_buffer {
-            let (fence_pool, devices, contexts) = (
-                &state.compute_fence_pool,
-                &state.devices,
-                &mut state.contexts,
-            );
-            if let Some(sc) = contexts.get_mut(&ctx) {
-                sc.staging_belt
-                    .reclaim(fence_pool, devices, completed_timeline)?;
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc.lock().unwrap().staging_belt.reclaim(
+                    &state.compute_fence_pool,
+                    &state.devices,
+                    completed_timeline,
+                )?;
             }
             reap_signaled_fences(state);
         }
 
         if has_write_texture {
-            if let Some(sc) = state.contexts.get_mut(&ctx) {
-                sc.texture_staging_pool.reclaim(completed_timeline);
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc
+                    .lock()
+                    .unwrap()
+                    .texture_staging_pool
+                    .reclaim(completed_timeline);
             }
         }
     }
@@ -697,10 +704,8 @@ pub(super) fn submit(
                         .devices
                         .get(&buf_device)
                         .context("WriteBuffer: device invalid")?;
-                    let sc = state
-                        .contexts
-                        .get_mut(&ctx)
-                        .context("Invalid context handle")?;
+                    let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+                    let mut sc = sc_arc.lock().unwrap();
                     let (stg_buf, stg_off) = sc.staging_belt.write(&state.instance, dev, data)?;
                     belt_slices.push((stg_buf, stg_off));
                 }
@@ -719,6 +724,8 @@ pub(super) fn submit(
             .contexts
             .get(&ctx)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .timeline_semaphore;
         let ld = state
             .devices
@@ -743,10 +750,10 @@ pub(super) fn submit(
             let completed = ctx_completed_value(state, ctx, device_handle);
             let ctx_batch: Vec<_> = state
                 .contexts
-                .get_mut(&ctx)
-                .map(|sc| sc.deletion_queue.drain_up_to(completed))
+                .get(&ctx)
+                .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(completed))
                 .unwrap_or_default();
-            if let Some(ld) = state.devices.get_mut(&device_handle) {
+            if let Some(ld) = state.devices.get(&device_handle) {
                 let ledger_arc = std::sync::Arc::clone(&ld.ledger);
                 let mut ledger = ledger_arc.lock().unwrap();
                 for r in ctx_batch {
@@ -754,8 +761,8 @@ pub(super) fn submit(
                 }
             }
         }
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.last_submitted_seq = signal_value;
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc.lock().unwrap().last_submitted_seq = signal_value;
         }
         return Ok(signal_value);
     }
@@ -772,11 +779,9 @@ pub(super) fn submit(
                 width,
                 height,
             } => {
-                let pool = &mut state
-                    .contexts
-                    .get_mut(&ctx)
-                    .context("Invalid context handle")?
-                    .texture_staging_pool;
+                let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+                let mut sc_guard = sc_arc.lock().unwrap();
+                let pool = &mut sc_guard.texture_staging_pool;
                 texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
                     &state.instance,
                     &state.devices,
@@ -798,11 +803,9 @@ pub(super) fn submit(
                 height,
                 data,
             } => {
-                let pool = &mut state
-                    .contexts
-                    .get_mut(&ctx)
-                    .context("Invalid context handle")?
-                    .texture_staging_pool;
+                let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+                let mut sc_guard = sc_arc.lock().unwrap();
+                let pool = &mut sc_guard.texture_staging_pool;
                 texture_upload_scratch.push(super::texture::allocate_compute_texture_staging(
                     &state.instance,
                     &state.devices,
@@ -836,11 +839,9 @@ pub(super) fn submit(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        let sc = state
-            .contexts
-            .get_mut(&ctx)
-            .context("Invalid context handle")?;
-        let cb = acquire_cmd_buffer(ld, sc)?;
+        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let mut sc = sc_arc.lock().unwrap();
+        let cb = acquire_cmd_buffer(ld, &mut sc)?;
         let begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         if let Err(e) = unsafe { ld.device.begin_command_buffer(cb, &begin_info) } {
@@ -1426,6 +1427,8 @@ pub(super) fn submit(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .timeline_semaphore;
     let submit_device_core = state
         .devices
@@ -1455,6 +1458,8 @@ pub(super) fn submit(
             .contexts
             .get(&ctx)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .command_pool;
         unsafe {
             submit_device_core
@@ -1472,7 +1477,8 @@ pub(super) fn submit(
         ));
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         sc.last_submitted_seq = signal_value;
         sc.timeline_cmd_buffers
             .entry(signal_value)
@@ -1485,13 +1491,17 @@ pub(super) fn submit(
             .into_iter()
             .map(|s| s.entry)
             .collect();
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.texture_staging_pool.release(signal_value, entries);
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc
+                .lock()
+                .unwrap()
+                .texture_staging_pool
+                .release(signal_value, entries);
         }
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
-        sc.staging_belt.finish(signal_value);
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        sc_arc.lock().unwrap().staging_belt.finish(signal_value);
     }
 
     debug_assert_eq!(
@@ -1510,6 +1520,8 @@ pub(super) fn submit(
                 .contexts
                 .get(&ctx)
                 .context("Invalid context handle")?
+                .lock()
+                .unwrap()
                 .timeline_semaphore;
             (ld.device.clone(), sem)
         };
@@ -1530,10 +1542,10 @@ pub(super) fn submit(
         let completed = ctx_completed_value(state, ctx, device_handle);
         let ctx_batch: Vec<_> = state
             .contexts
-            .get_mut(&ctx)
-            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
-        if let Some(ld) = state.devices.get_mut(&device_handle) {
+        if let Some(ld) = state.devices.get(&device_handle) {
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             {
                 let mut ledger = ledger_arc.lock().unwrap();
@@ -1587,6 +1599,8 @@ fn submit_graph_impl(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .device;
     let _tz = tracy_zone!("vk.submit_graph");
     // --- Same housekeeping as `submit` ---
@@ -1616,21 +1630,23 @@ fn submit_graph_impl(
         let completed_timeline = ctx_completed_value(state, ctx, device_handle);
 
         {
-            let (fence_pool, devices, contexts) = (
-                &state.compute_fence_pool,
-                &state.devices,
-                &mut state.contexts,
-            );
-            if let Some(sc) = contexts.get_mut(&ctx) {
-                sc.staging_belt
-                    .reclaim(fence_pool, devices, completed_timeline)?;
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc.lock().unwrap().staging_belt.reclaim(
+                    &state.compute_fence_pool,
+                    &state.devices,
+                    completed_timeline,
+                )?;
             }
         }
         reap_signaled_fences(state);
 
         if has_write_texture_graph {
-            if let Some(sc) = state.contexts.get_mut(&ctx) {
-                sc.texture_staging_pool.reclaim(completed_timeline);
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc
+                    .lock()
+                    .unwrap()
+                    .texture_staging_pool
+                    .reclaim(completed_timeline);
             }
         }
     }
@@ -1693,10 +1709,9 @@ fn submit_graph_impl(
                                 .devices
                                 .get(&buf_device)
                                 .context("WriteBuffer: device invalid")?;
-                            let sc = state
-                                .contexts
-                                .get_mut(&ctx)
-                                .context("Invalid context handle")?;
+                            let sc_arc =
+                                state.contexts.get(&ctx).context("Invalid context handle")?;
+                            let mut sc = sc_arc.lock().unwrap();
                             let (stg_buf, stg_off) =
                                 sc.staging_belt.write(&state.instance, dev, data)?;
                             belt_slices.push((stg_buf, stg_off));
@@ -1708,11 +1723,9 @@ fn submit_graph_impl(
                         width,
                         height,
                     } => {
-                        let pool = &mut state
-                            .contexts
-                            .get_mut(&ctx)
-                            .context("Invalid context handle")?
-                            .texture_staging_pool;
+                        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+                        let mut sc_guard = sc_arc.lock().unwrap();
+                        let pool = &mut sc_guard.texture_staging_pool;
                         texture_upload_scratch.push(
                             super::texture::allocate_compute_texture_staging(
                                 &state.instance,
@@ -1736,11 +1749,9 @@ fn submit_graph_impl(
                         height,
                         data,
                     } => {
-                        let pool = &mut state
-                            .contexts
-                            .get_mut(&ctx)
-                            .context("Invalid context handle")?
-                            .texture_staging_pool;
+                        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+                        let mut sc_guard = sc_arc.lock().unwrap();
+                        let pool = &mut sc_guard.texture_staging_pool;
                         texture_upload_scratch.push(
                             super::texture::allocate_compute_texture_staging(
                                 &state.instance,
@@ -1768,11 +1779,9 @@ fn submit_graph_impl(
             .devices
             .get(&device_handle)
             .context("Invalid device handle")?;
-        let sc = state
-            .contexts
-            .get_mut(&ctx)
-            .context("Invalid context handle")?;
-        let cb = acquire_cmd_buffer(ld, sc)?;
+        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let mut sc = sc_arc.lock().unwrap();
+        let cb = acquire_cmd_buffer(ld, &mut sc)?;
         // Use ONE_TIME_SUBMIT for normal submits (driver hint for optimization).
         // When retaining, omit the flag so the CB stays executable after GPU completion
         // and can be resubmitted on the next frame.
@@ -2428,6 +2437,8 @@ fn submit_graph_impl(
         .contexts
         .get(&ctx)
         .context("Invalid context handle")?
+        .lock()
+        .unwrap()
         .timeline_semaphore;
     let submit_device = state
         .devices
@@ -2457,6 +2468,8 @@ fn submit_graph_impl(
             .contexts
             .get(&ctx)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .command_pool;
         unsafe {
             submit_device.device.free_command_buffers(ctx_pool, &[cmd]);
@@ -2471,7 +2484,8 @@ fn submit_graph_impl(
     }
 
     // Post-submit: store the CB for lifecycle management.
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         sc.last_submitted_seq = signal_value;
         if let Some(key) = retain_key {
             sc.retained_compute_cb = Some(super::types::RetainedVkCb {
@@ -2492,13 +2506,17 @@ fn submit_graph_impl(
             .into_iter()
             .map(|s| s.entry)
             .collect();
-        if let Some(sc) = state.contexts.get_mut(&ctx) {
-            sc.texture_staging_pool.release(signal_value, entries);
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc
+                .lock()
+                .unwrap()
+                .texture_staging_pool
+                .release(signal_value, entries);
         }
     }
 
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
-        sc.staging_belt.finish(signal_value);
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        sc_arc.lock().unwrap().staging_belt.finish(signal_value);
     }
 
     if let Some(prof) = vk_gpu_profile {
@@ -2511,6 +2529,8 @@ fn submit_graph_impl(
                 .contexts
                 .get(&ctx)
                 .context("Invalid context handle")?
+                .lock()
+                .unwrap()
                 .timeline_semaphore;
             (ld.device.clone(), sem)
         };
@@ -2538,10 +2558,10 @@ fn submit_graph_impl(
         let completed = ctx_completed_value(state, ctx, device_handle);
         let ctx_batch: Vec<_> = state
             .contexts
-            .get_mut(&ctx)
-            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
-        if let Some(ld) = state.devices.get_mut(&device_handle) {
+        if let Some(ld) = state.devices.get(&device_handle) {
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             {
                 let mut ledger = ledger_arc.lock().unwrap();
@@ -2592,13 +2612,14 @@ pub(super) fn try_resubmit_retained(
     ctx: super::ContextHandle,
     key: u64,
 ) -> Result<Option<TimelineValue>> {
-    let device_handle = state
-        .contexts
-        .get(&ctx)
-        .context("Invalid context handle")?
-        .device;
+    let (device_handle, timeline_sem) = {
+        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let sc = sc_arc.lock().unwrap();
+        (sc.device, sc.timeline_semaphore)
+    };
     let retained = {
-        let sc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let sc_arc = state.contexts.get(&ctx).context("Invalid context handle")?;
+        let sc = sc_arc.lock().unwrap();
         match sc.retained_compute_cb.as_ref() {
             Some(r) if r.fingerprint == key => Some((r.command_buffer, r.used_slots.clone())),
             _ => None,
@@ -2616,12 +2637,6 @@ pub(super) fn try_resubmit_retained(
             .context("Invalid device handle")?;
         ld.timeline_next.fetch_add(1, Ordering::Relaxed)
     };
-
-    let timeline_sem = state
-        .contexts
-        .get(&ctx)
-        .context("Invalid context handle")?
-        .timeline_semaphore;
     let submit_device = state
         .devices
         .get(&device_handle)
@@ -2658,10 +2673,10 @@ pub(super) fn try_resubmit_retained(
         let completed = ctx_completed_value(state, ctx, device_handle);
         let ctx_batch: Vec<_> = state
             .contexts
-            .get_mut(&ctx)
-            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
-        if let Some(ld) = state.devices.get_mut(&device_handle) {
+        if let Some(ld) = state.devices.get(&device_handle) {
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             {
                 let mut ledger = ledger_arc.lock().unwrap();
@@ -2677,8 +2692,8 @@ pub(super) fn try_resubmit_retained(
             }
         }
     }
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
-        sc.last_submitted_seq = signal_value;
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        sc_arc.lock().unwrap().last_submitted_seq = signal_value;
     }
 
     Ok(Some(signal_value))
@@ -2691,7 +2706,8 @@ pub(super) fn evict_retained(
     ctx: super::ContextHandle,
     _key: u64,
 ) {
-    if let Some(sc) = state.contexts.get_mut(&ctx) {
+    if let Some(sc_arc) = state.contexts.get(&ctx) {
+        let mut sc = sc_arc.lock().unwrap();
         if let Some(old) = sc.retained_compute_cb.take() {
             sc.free_cmd_buffers.push(old.command_buffer);
         }
@@ -2704,10 +2720,11 @@ pub(super) fn reap_timeline_cmd_buffers_up_to(
     max_completed_value: u64,
 ) {
     let (device, pool, keys): (DeviceHandle, vk::CommandPool, Vec<u64>) = {
-        let sc = match state.contexts.get(&ctx) {
+        let sc_arc = match state.contexts.get(&ctx) {
             Some(s) => s,
             None => return,
         };
+        let sc = sc_arc.lock().unwrap();
         if sc.timeline_cmd_buffers.is_empty() {
             return;
         }
@@ -2723,7 +2740,8 @@ pub(super) fn reap_timeline_cmd_buffers_up_to(
         return;
     }
     let cbs_to_free: Vec<vk::CommandBuffer> = {
-        let sc = state.contexts.get_mut(&ctx).expect("context");
+        let sc_arc = state.contexts.get(&ctx).expect("context");
+        let mut sc = sc_arc.lock().unwrap();
         keys.iter()
             .filter_map(|k| sc.timeline_cmd_buffers.remove(k))
             .flatten()

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -747,8 +747,10 @@ pub(super) fn submit(
                 .map(|sc| sc.deletion_queue.drain_up_to(completed))
                 .unwrap_or_default();
             if let Some(ld) = state.devices.get_mut(&device_handle) {
+                let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+                let mut ledger = ledger_arc.lock().unwrap();
                 for r in ctx_batch {
-                    super::types::destroy_pending_deletion(ld, r);
+                    super::types::destroy_pending_deletion(ld, &mut ledger, r);
                 }
             }
         }
@@ -1413,8 +1415,11 @@ pub(super) fn submit(
 
     let used_slots =
         collect_slot_keys_from_gpu_commands(commands, &state.compute_pipelines, &state.buffers);
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.record_slot_usage(ctx, signal_value, used_slots);
+    if let Some(ld) = state.devices.get(&device_handle) {
+        ld.ledger
+            .lock()
+            .unwrap()
+            .record_slot_usage(ctx, signal_value, used_slots);
     }
 
     let timeline_sem = state
@@ -1529,10 +1534,19 @@ pub(super) fn submit(
             .map(|sc| sc.deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            for r in ctx_batch {
-                super::types::destroy_pending_deletion(ld, r);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            {
+                let mut ledger = ledger_arc.lock().unwrap();
+                for r in ctx_batch {
+                    super::types::destroy_pending_deletion(ld, &mut ledger, r);
+                }
+                let completed_values = super::types::snapshot_context_completed_values(
+                    &ld.device,
+                    &state.contexts,
+                    device_handle,
+                );
+                ledger.drain_ready_slot_reclamations(&completed_values);
             }
-            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
 
@@ -2403,8 +2417,11 @@ fn submit_graph_impl(
         &state.pipelines,
         &state.buffers,
     );
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.record_slot_usage(ctx, signal_value, used_slots.iter().copied());
+    if let Some(ld) = state.devices.get(&device_handle) {
+        ld.ledger
+            .lock()
+            .unwrap()
+            .record_slot_usage(ctx, signal_value, used_slots.iter().copied());
     }
 
     let timeline_sem = state
@@ -2525,10 +2542,19 @@ fn submit_graph_impl(
             .map(|sc| sc.deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            for r in ctx_batch {
-                super::types::destroy_pending_deletion(ld, r);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            {
+                let mut ledger = ledger_arc.lock().unwrap();
+                for r in ctx_batch {
+                    super::types::destroy_pending_deletion(ld, &mut ledger, r);
+                }
+                let completed_values = super::types::snapshot_context_completed_values(
+                    &ld.device,
+                    &state.contexts,
+                    device_handle,
+                );
+                ledger.drain_ready_slot_reclamations(&completed_values);
             }
-            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
 
@@ -2621,8 +2647,11 @@ pub(super) fn try_resubmit_retained(
         .context("Failed to queue_submit2 retained dispatch CB")?;
     }
 
-    if let Some(ld) = state.devices.get_mut(&device_handle) {
-        ld.record_slot_usage(ctx, signal_value, used_slots);
+    if let Some(ld) = state.devices.get(&device_handle) {
+        ld.ledger
+            .lock()
+            .unwrap()
+            .record_slot_usage(ctx, signal_value, used_slots);
     }
 
     {
@@ -2633,10 +2662,19 @@ pub(super) fn try_resubmit_retained(
             .map(|sc| sc.deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
         if let Some(ld) = state.devices.get_mut(&device_handle) {
-            for r in ctx_batch {
-                super::types::destroy_pending_deletion(ld, r);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            {
+                let mut ledger = ledger_arc.lock().unwrap();
+                for r in ctx_batch {
+                    super::types::destroy_pending_deletion(ld, &mut ledger, r);
+                }
+                let completed_values = super::types::snapshot_context_completed_values(
+                    &ld.device,
+                    &state.contexts,
+                    device_handle,
+                );
+                ledger.drain_ready_slot_reclamations(&completed_values);
             }
-            ld.drain_ready_slot_reclamations(&state.contexts);
         }
     }
     if let Some(sc) = state.contexts.get_mut(&ctx) {

--- a/src/backend/vulkan/context.rs
+++ b/src/backend/vulkan/context.rs
@@ -86,6 +86,7 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
                 super::staging::DEFAULT_STAGING_CHUNK_SIZE,
             ),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
+            deletion_queue: super::types::DeletionQueue::new(),
         },
     );
     Ok(id)
@@ -113,11 +114,26 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
 
     crate::backend::signal_fence::join_fence_poller(&sc.fence_shutdown, sc.fence_thread.take());
 
+    let ctx_batch = sc.deletion_queue.flush_all_drain();
+
+    {
+        // Use `get_mut` while we still need `&mut LogicalDevice` for
+        // `destroy_pending_deletion` (sparse page pool etc.).
+        let Some(ld) = state.devices.get_mut(&device) else {
+            return;
+        };
+        unsafe {
+            let _ = ld.device.device_wait_idle();
+        }
+        for r in ctx_batch {
+            super::types::destroy_pending_deletion(ld, r);
+        }
+    }
+
     let Some(ld) = state.devices.get(&device) else {
         return;
     };
     unsafe {
-        let _ = ld.device.device_wait_idle();
         sc.staging_belt.destroy_all(ld);
         sc.texture_staging_pool.destroy_all(ld);
         for (_, cbs) in sc.timeline_cmd_buffers.drain() {

--- a/src/backend/vulkan/context.rs
+++ b/src/backend/vulkan/context.rs
@@ -82,6 +82,10 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
             free_cmd_buffers: Vec::new(),
             retained_compute_cb: None,
             timeline_cmd_buffers: std::collections::HashMap::new(),
+            staging_belt: super::staging::StagingBelt::new(
+                super::staging::DEFAULT_STAGING_CHUNK_SIZE,
+            ),
+            texture_staging_pool: super::staging::TextureStagingPool::new(),
         },
     );
     Ok(id)
@@ -114,6 +118,8 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
     };
     unsafe {
         let _ = ld.device.device_wait_idle();
+        sc.staging_belt.destroy_all(ld);
+        sc.texture_staging_pool.destroy_all(ld);
         for (_, cbs) in sc.timeline_cmd_buffers.drain() {
             for cb in cbs {
                 ld.device.free_command_buffers(sc.command_pool, &[cb]);

--- a/src/backend/vulkan/context.rs
+++ b/src/backend/vulkan/context.rs
@@ -125,8 +125,10 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
         unsafe {
             let _ = ld.device.device_wait_idle();
         }
+        let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for r in ctx_batch {
-            super::types::destroy_pending_deletion(ld, r);
+            super::types::destroy_pending_deletion(ld, &mut ledger, r);
         }
     }
 

--- a/src/backend/vulkan/context.rs
+++ b/src/backend/vulkan/context.rs
@@ -4,13 +4,15 @@ use super::types::{SubmissionContext, VulkanState};
 use super::{ContextHandle, DeviceHandle};
 use anyhow::{Context as _, Result};
 use ash::vk;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 
 /// Latest device-global seq retired on `device` (max over live context semaphores, floored).
 pub(super) fn device_retired(state: &VulkanState, device: DeviceHandle) -> u64 {
     let floor = state
         .devices
         .get(&device)
-        .map(|d| d.retired_floor)
+        .map(|d| d.retired_floor.load(Ordering::Relaxed))
         .unwrap_or(0);
     let Some(ld) = state.devices.get(&device) else {
         return floor;
@@ -18,11 +20,16 @@ pub(super) fn device_retired(state: &VulkanState, device: DeviceHandle) -> u64 {
     let max_ctx = state
         .contexts
         .values()
-        .filter(|c| c.device == device)
-        .map(|c| unsafe {
-            ld.device
-                .get_semaphore_counter_value(c.timeline_semaphore)
-                .unwrap_or(0)
+        .filter_map(|sc_arc| {
+            let sc = sc_arc.lock().unwrap();
+            if sc.device != device {
+                return None;
+            }
+            Some(unsafe {
+                ld.device
+                    .get_semaphore_counter_value(sc.timeline_semaphore)
+                    .unwrap_or(0)
+            })
         })
         .max()
         .unwrap_or(0);
@@ -71,7 +78,7 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
     state.next_context_id = state.next_context_id.saturating_add(1);
     state.contexts.insert(
         id,
-        SubmissionContext {
+        Arc::new(Mutex::new(SubmissionContext {
             device,
             timeline_semaphore,
             last_submitted_seq: 0,
@@ -87,15 +94,16 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
             ),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
             deletion_queue: super::types::DeletionQueue::new(),
-        },
+        })),
     );
     Ok(id)
 }
 
 pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
-    let Some(mut sc) = state.contexts.remove(&ctx) else {
+    let Some(sc_arc) = state.contexts.remove(&ctx) else {
         return;
     };
+    let mut sc = sc_arc.lock().unwrap();
     let device = sc.device;
     let completed = unsafe {
         state
@@ -108,27 +116,28 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
             })
             .unwrap_or(0)
     };
-    if let Some(ld) = state.devices.get_mut(&device) {
-        ld.retired_floor = ld.retired_floor.max(completed);
+    if let Some(ld) = state.devices.get(&device) {
+        ld.retired_floor.fetch_max(completed, Ordering::Relaxed);
     }
 
-    crate::backend::signal_fence::join_fence_poller(&sc.fence_shutdown, sc.fence_thread.take());
+    let fence_thread = sc.fence_thread.take();
+    crate::backend::signal_fence::join_fence_poller(&sc.fence_shutdown, fence_thread);
 
     let ctx_batch = sc.deletion_queue.flush_all_drain();
 
     {
-        // Use `get_mut` while we still need `&mut LogicalDevice` for
-        // `destroy_pending_deletion` (sparse page pool etc.).
-        let Some(ld) = state.devices.get_mut(&device) else {
+        let Some(ld) = state.devices.get(&device) else {
             return;
         };
         unsafe {
             let _ = ld.device.device_wait_idle();
         }
-        let ledger_arc = std::sync::Arc::clone(&ld.ledger);
-        let mut ledger = ledger_arc.lock().unwrap();
-        for r in ctx_batch {
-            super::types::destroy_pending_deletion(ld, &mut ledger, r);
+        if !ctx_batch.is_empty() {
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            let mut ledger = ledger_arc.lock().unwrap();
+            for r in ctx_batch {
+                super::types::destroy_pending_deletion(ld, &mut ledger, r);
+            }
         }
     }
 
@@ -138,13 +147,14 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
     unsafe {
         sc.staging_belt.destroy_all(ld);
         sc.texture_staging_pool.destroy_all(ld);
+        let command_pool = sc.command_pool;
         for (_, cbs) in sc.timeline_cmd_buffers.drain() {
             for cb in cbs {
-                ld.device.free_command_buffers(sc.command_pool, &[cb]);
+                ld.device.free_command_buffers(command_pool, &[cb]);
             }
         }
         for cb in sc.free_cmd_buffers.drain(..) {
-            ld.device.free_command_buffers(sc.command_pool, &[cb]);
+            ld.device.free_command_buffers(command_pool, &[cb]);
         }
         if let Some(retained) = sc.retained_compute_cb.take() {
             ld.device
@@ -171,11 +181,14 @@ pub(super) fn wait_until_device_seq_at_least(state: &VulkanState, device: Device
 
     // Find a context on this device whose last_submitted_seq covers `seq`.
     // In the unified-context model there is typically exactly one such context.
-    let sem = state
-        .contexts
-        .values()
-        .find(|c| c.device == device && c.last_submitted_seq >= seq)
-        .map(|c| c.timeline_semaphore);
+    let sem = state.contexts.values().find_map(|sc_arc| {
+        let sc = sc_arc.lock().unwrap();
+        if sc.device == device && sc.last_submitted_seq >= seq {
+            Some(sc.timeline_semaphore)
+        } else {
+            None
+        }
+    });
 
     if let Some(sem) = sem {
         let wait = vk::SemaphoreWaitInfo::default()
@@ -196,12 +209,14 @@ pub(super) fn wait_until_device_seq_at_least(state: &VulkanState, device: Device
                 );
                 return;
             }
-            if let Some(sem) = state
-                .contexts
-                .values()
-                .find(|c| c.device == device && c.last_submitted_seq >= seq)
-                .map(|c| c.timeline_semaphore)
-            {
+            if let Some(sem) = state.contexts.values().find_map(|sc_arc| {
+                let sc = sc_arc.lock().unwrap();
+                if sc.device == device && sc.last_submitted_seq >= seq {
+                    Some(sc.timeline_semaphore)
+                } else {
+                    None
+                }
+            }) {
                 let wait = vk::SemaphoreWaitInfo::default()
                     .semaphores(std::slice::from_ref(&sem))
                     .values(std::slice::from_ref(&seq));
@@ -223,5 +238,7 @@ pub(super) fn context_device(state: &VulkanState, ctx: ContextHandle) -> DeviceH
         .contexts
         .get(&ctx)
         .expect("invalid context handle")
+        .lock()
+        .unwrap()
         .device
 }

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -489,6 +489,7 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             deletion_queue: Mutex::new(types::DeletionQueue::new()),
             timeline_next: Arc::new(AtomicU64::new(1)),
             retired_floor: AtomicU64::new(0),
+            queue_lock: Arc::new(Mutex::new(())),
             pipeline_cache,
             vk_timestamp_compute_and_graphics: physical_device.vk_timestamp_compute_and_graphics,
             vk_timestamp_period_ns: physical_device.vk_timestamp_period_ns,

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -468,7 +468,7 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
 
     state.devices.insert(
         handle,
-        types::LogicalDevice {
+        Arc::new(types::LogicalDevice {
             device,
             physical_device: physical_device_handle,
             adapter_id,
@@ -479,20 +479,20 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             supports_sparse_buffer: supports_sparse,
             sparse_buffer_block_size,
             sparse_memory_type_index,
-            sparse_page_pool,
+            sparse_page_pool: Mutex::new(sparse_page_pool),
             map_memory2: map_memory2_loader,
             bindless_descriptor_pool,
             bindless_descriptor_set_layout,
             bindless_descriptor_set,
             bindless_pipeline_layout,
             ledger: Arc::new(Mutex::new(types::DeviceLedger::new())),
-            deletion_queue: types::DeletionQueue::new(),
+            deletion_queue: Mutex::new(types::DeletionQueue::new()),
             timeline_next: Arc::new(AtomicU64::new(1)),
-            retired_floor: 0,
+            retired_floor: AtomicU64::new(0),
             pipeline_cache,
             vk_timestamp_compute_and_graphics: physical_device.vk_timestamp_compute_and_graphics,
             vk_timestamp_period_ns: physical_device.vk_timestamp_period_ns,
-        },
+        }),
     );
 
     tracing::info!(
@@ -518,7 +518,7 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
         samplers = state.samplers.len(),
         "destroying Vulkan device"
     );
-    if let Some(mut logical_device) = state.devices.remove(&device_handle) {
+    if let Some(logical_device) = state.devices.remove(&device_handle) {
         unsafe {
             let wait_result = logical_device.device.device_wait_idle();
 
@@ -527,7 +527,7 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
             // always valid and implicitly reclaims all child objects, so skip
             // individual cleanup and jump straight to it.
             if matches!(wait_result, Err(vk::Result::ERROR_DEVICE_LOST)) {
-                let pending = logical_device.deletion_queue.len();
+                let pending = logical_device.deletion_queue.lock().unwrap().len();
                 tracing::warn!(
                     %device_handle,
                     pending_deferred = pending,
@@ -561,20 +561,15 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 // Per-context staging belt and texture pool: device is being lost so just
                 // drop entries without Vulkan destroy calls (handles are invalid after
                 // device loss). Drop the entire context entries for this device.
-                state.contexts.retain(|_, sc| sc.device != device_handle);
+                state
+                    .contexts
+                    .retain(|_, sc| sc.lock().unwrap().device != device_handle);
                 logical_device.device.destroy_device(None);
                 return;
             }
 
-            // Flush any pending deferred deletions
-            let pending = logical_device.deletion_queue.flush_all_drain();
-            if !pending.is_empty() {
-                let ledger_arc = std::sync::Arc::clone(&logical_device.ledger);
-                let mut ledger = ledger_arc.lock().unwrap();
-                for r in pending {
-                    types::destroy_pending_deletion(&mut logical_device, &mut ledger, r);
-                }
-            }
+            // Flush any pending deferred deletions via the new &self helper.
+            logical_device.flush_deletion_queue();
 
             // Destroy per-context staging belt and texture pool for this device.
             // Command pools/semaphores in the context are intentionally NOT destroyed
@@ -582,11 +577,12 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
             let ctx_keys: Vec<_> = state
                 .contexts
                 .iter()
-                .filter(|(_, sc)| sc.device == device_handle)
+                .filter(|(_, sc)| sc.lock().unwrap().device == device_handle)
                 .map(|(k, _)| *k)
                 .collect();
             for key in ctx_keys {
-                if let Some(mut sc) = state.contexts.remove(&key) {
+                if let Some(sc_arc) = state.contexts.remove(&key) {
+                    let mut sc = sc_arc.lock().unwrap();
                     sc.staging_belt.destroy_all(&logical_device);
                     sc.texture_staging_pool.destroy_all(&logical_device);
                 }
@@ -756,8 +752,8 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 super::surface::destroy_with_logical_device(
                     &state.entry,
                     &state.instance,
-                    &mut logical_device,
-                    &mut state.devices,
+                    &logical_device,
+                    &state.devices,
                     &mut state.surfaces,
                     &mut state.textures,
                     handle,
@@ -840,7 +836,7 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
             // Free all VkDeviceMemory chunks held by the sparse page pool.
             // All sparse buffers have already been unbound and destroyed above,
             // so the memories are no longer bound to any VkBuffer sparse region.
-            if let Some(pool) = logical_device.sparse_page_pool.take() {
+            if let Some(pool) = logical_device.sparse_page_pool.lock().unwrap().take() {
                 pool.destroy(&logical_device.device);
             }
 

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -8,6 +8,8 @@ use ash::vk;
 use ash::{ext, khr};
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 /// Enumerate available physical devices/adapters.
 pub(super) fn enumerate(physical_devices: &[PhysicalDeviceInfo]) -> Vec<AdapterInfo> {
@@ -488,7 +490,7 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             deletion_queue: types::DeletionQueue::new(),
             slot_last_seen: HashMap::new(),
             pending_slot_reclamations: Vec::new(),
-            timeline_next: 1,
+            timeline_next: Arc::new(AtomicU64::new(1)),
             retired_floor: 0,
             pipeline_cache,
             vk_timestamp_compute_and_graphics: physical_device.vk_timestamp_compute_and_graphics,

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -6,10 +6,9 @@ use crate::backend::{AdapterInfo, BackendType, DeviceType};
 use anyhow::{Context, Result};
 use ash::vk;
 use ash::{ext, khr};
-use std::collections::HashMap;
 use std::ffi::CStr;
 use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Enumerate available physical devices/adapters.
 pub(super) fn enumerate(physical_devices: &[PhysicalDeviceInfo]) -> Vec<AdapterInfo> {
@@ -486,10 +485,8 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             bindless_descriptor_set_layout,
             bindless_descriptor_set,
             bindless_pipeline_layout,
-            resource_registry: types::ResourceRegistry::new(),
+            ledger: Arc::new(Mutex::new(types::DeviceLedger::new())),
             deletion_queue: types::DeletionQueue::new(),
-            slot_last_seen: HashMap::new(),
-            pending_slot_reclamations: Vec::new(),
             timeline_next: Arc::new(AtomicU64::new(1)),
             retired_floor: 0,
             pipeline_cache,
@@ -571,8 +568,12 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
 
             // Flush any pending deferred deletions
             let pending = logical_device.deletion_queue.flush_all_drain();
-            for r in pending {
-                types::destroy_pending_deletion(&mut logical_device, r);
+            if !pending.is_empty() {
+                let ledger_arc = std::sync::Arc::clone(&logical_device.ledger);
+                let mut ledger = ledger_arc.lock().unwrap();
+                for r in pending {
+                    types::destroy_pending_deletion(&mut logical_device, &mut ledger, r);
+                }
             }
 
             // Destroy per-context staging belt and texture pool for this device.

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -561,9 +561,10 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 state
                     .compute_fence_pool
                     .retain(|_, (dh, _, _)| *dh != device_handle);
-                // Texture staging pool: device is being lost so just drop entries
-                // without Vulkan destroy calls (handles are invalid after device loss).
-                state.texture_staging_pools.remove(&device_handle);
+                // Per-context staging belt and texture pool: device is being lost so just
+                // drop entries without Vulkan destroy calls (handles are invalid after
+                // device loss). Drop the entire context entries for this device.
+                state.contexts.retain(|_, sc| sc.device != device_handle);
                 logical_device.device.destroy_device(None);
                 return;
             }
@@ -574,8 +575,20 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 types::destroy_pending_deletion(&mut logical_device, r);
             }
 
-            if let Some(mut belt) = state.staging_belts.remove(&device_handle) {
-                belt.destroy_all(&logical_device);
+            // Destroy per-context staging belt and texture pool for this device.
+            // Command pools/semaphores in the context are intentionally NOT destroyed
+            // here — they are child objects of the device and reclaimed by vkDestroyDevice.
+            let ctx_keys: Vec<_> = state
+                .contexts
+                .iter()
+                .filter(|(_, sc)| sc.device == device_handle)
+                .map(|(k, _)| *k)
+                .collect();
+            for key in ctx_keys {
+                if let Some(mut sc) = state.contexts.remove(&key) {
+                    sc.staging_belt.destroy_all(&logical_device);
+                    sc.texture_staging_pool.destroy_all(&logical_device);
+                }
             }
 
             // Destroy buffers owned by this device
@@ -803,11 +816,6 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                 }
                 // Texture staging for fence pool tokens is now handled via the
                 // TextureStagingPool; it will be destroyed below.
-            }
-
-            // Destroy all pooled texture staging resources for this device.
-            if let Some(mut pool) = state.texture_staging_pools.remove(&device_handle) {
-                pool.destroy_all(&logical_device);
             }
 
             if let Some(pipeline_layout) = logical_device.bindless_pipeline_layout {

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -558,6 +558,8 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                     .retain(|_, s| s.device_handle != device_handle);
                 state
                     .compute_fence_pool
+                    .lock()
+                    .unwrap()
                     .retain(|_, (dh, _, _)| *dh != device_handle);
                 // Per-context staging belt and texture pool: device is being lost so just
                 // drop entries without Vulkan destroy calls (handles are invalid after
@@ -799,12 +801,15 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
             // fences in the pool; they must be destroyed before vkDestroyDevice.
             let fence_tokens: Vec<u64> = state
                 .compute_fence_pool
+                .lock()
+                .unwrap()
                 .iter()
                 .filter(|(_, (dh, _, _))| *dh == device_handle)
                 .map(|(tok, _)| *tok)
                 .collect();
+            let mut fence_pool = state.compute_fence_pool.lock().unwrap();
             for tok in fence_tokens {
-                if let Some((_, fence, cmd_buf)) = state.compute_fence_pool.remove(&tok) {
+                if let Some((_, fence, cmd_buf)) = fence_pool.remove(&tok) {
                     if let Some(cb) = cmd_buf {
                         logical_device
                             .device

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -328,7 +328,7 @@ impl GpuBackend for VulkanBackend {
             .state
             .contexts
             .iter()
-            .filter(|(_, sc)| sc.device == device_handle)
+            .filter(|(_, sc)| sc.lock().unwrap().device == device_handle)
             .map(|(k, _)| *k)
             .collect();
         for ctx in ctxs {
@@ -379,7 +379,7 @@ impl GpuBackend for VulkanBackend {
         flags: crate::types::BufferFlags,
     ) -> Result<BufferHandle> {
         buffer::create(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             &mut self.state.next_buffer_handle,
             &self.state.instance,
@@ -393,11 +393,7 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn destroy_buffer(&mut self, buffer_handle: BufferHandle) {
-        buffer::destroy(
-            &mut self.state.devices,
-            &mut self.state.buffers,
-            buffer_handle,
-        );
+        buffer::destroy(&self.state.devices, &mut self.state.buffers, buffer_handle);
     }
 
     fn write_buffer(
@@ -443,7 +439,7 @@ impl GpuBackend for VulkanBackend {
         if use_sparse {
             let handle = buffer::create_sparse_with_capacity(
                 &self.state.instance,
-                &mut self.state.devices,
+                &self.state.devices,
                 &mut self.state.buffers,
                 &mut self.state.next_buffer_handle,
                 device_handle,
@@ -456,7 +452,7 @@ impl GpuBackend for VulkanBackend {
             return Ok((handle, cap_out));
         }
         let handle = buffer::create(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             &mut self.state.next_buffer_handle,
             &self.state.instance,
@@ -477,7 +473,7 @@ impl GpuBackend for VulkanBackend {
         new_logical_size: u64,
     ) -> Result<()> {
         buffer::set_logical_size(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             device_handle,
             buffer_handle,
@@ -487,7 +483,7 @@ impl GpuBackend for VulkanBackend {
 
     fn hint_buffer_unused_above(&mut self, buffer_handle: BufferHandle, offset: u64) {
         buffer::hint_unused_above(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             buffer_handle,
             offset,
@@ -524,7 +520,7 @@ impl GpuBackend for VulkanBackend {
         element_stride: Option<u32>,
     ) -> Result<BufferHandle> {
         buffer::create_view(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             &mut self.state.next_buffer_handle,
             parent,
@@ -543,7 +539,7 @@ impl GpuBackend for VulkanBackend {
     ) -> Result<()> {
         buffer::resize(
             &self.state.instance,
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.buffers,
             device_handle,
             buffer_handle,
@@ -576,7 +572,7 @@ impl GpuBackend for VulkanBackend {
         size: u64,
     ) -> Result<()> {
         buffer::clear(
-            &mut self.state.devices,
+            &self.state.devices,
             &self.state.buffers,
             device_handle,
             buffer_handle,
@@ -746,7 +742,7 @@ impl GpuBackend for VulkanBackend {
         surface::create(
             &self.state.entry,
             &self.state.instance,
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.surfaces,
             &mut self.state.textures,
             &mut self.state.next_surface_handle,
@@ -762,7 +758,7 @@ impl GpuBackend for VulkanBackend {
         surface::destroy(
             &self.state.entry,
             &self.state.instance,
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.surfaces,
             &mut self.state.textures,
             surface_handle,
@@ -793,9 +789,11 @@ impl GpuBackend for VulkanBackend {
             .contexts
             .get(&frame.context)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .timeline_semaphore;
         surface::render(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.surfaces,
             frame.surface,
             frame.image,
@@ -819,8 +817,8 @@ impl GpuBackend for VulkanBackend {
             .and_then(|s| s.frame_sync.get(s.current_frame))
             .and_then(|fs| fs.frame_timeline_value)
         {
-            if let Some(sc) = self.state.contexts.get_mut(&frame.context) {
-                sc.last_submitted_seq = tv;
+            if let Some(sc_arc) = self.state.contexts.get(&frame.context) {
+                sc_arc.lock().unwrap().last_submitted_seq = tv;
             }
         }
         Ok(())
@@ -835,7 +833,7 @@ impl GpuBackend for VulkanBackend {
         surface::resize(
             &self.state.entry,
             &self.state.instance,
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.surfaces,
             &mut self.state.textures,
             &mut self.state.next_texture_handle,
@@ -939,7 +937,7 @@ impl GpuBackend for VulkanBackend {
     ) -> Result<TextureHandle> {
         texture::create(
             &self.state.instance,
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.textures,
             &mut self.state.next_texture_handle,
             device_handle,
@@ -993,7 +991,7 @@ impl GpuBackend for VulkanBackend {
 
     fn destroy_texture(&mut self, texture_handle: TextureHandle) {
         texture::destroy(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.textures,
             texture_handle,
         );
@@ -1027,7 +1025,7 @@ impl GpuBackend for VulkanBackend {
         desc: &crate::types::SamplerDesc,
     ) -> Result<SamplerHandle> {
         sampler::create(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.samplers,
             &mut self.state.next_sampler_handle,
             device_handle,
@@ -1037,7 +1035,7 @@ impl GpuBackend for VulkanBackend {
 
     fn destroy_sampler(&mut self, sampler_handle: SamplerHandle) {
         sampler::destroy(
-            &mut self.state.devices,
+            &self.state.devices,
             &mut self.state.samplers,
             sampler_handle,
         );
@@ -1097,9 +1095,10 @@ impl GpuBackend for VulkanBackend {
 
     fn gpu_progress(&self, ctx: ContextHandle) -> crate::timeline::TimelineValue {
         let _tz = crate::tracy_zone!("vk.gpu_progress");
-        let Some(sc) = self.state.contexts.get(&ctx) else {
+        let Some(sc_arc) = self.state.contexts.get(&ctx) else {
             return 0;
         };
+        let sc = sc_arc.lock().unwrap();
         let Some(ld) = self.state.devices.get(&sc.device) else {
             return 0;
         };
@@ -1126,7 +1125,7 @@ impl GpuBackend for VulkanBackend {
             .state
             .contexts
             .get(&ctx)
-            .map(|sc| std::sync::Arc::clone(&sc.signal_queue));
+            .map(|sc| std::sync::Arc::clone(&sc.lock().unwrap().signal_queue));
         let Some(signal_queue) = signal_queue else {
             return Vec::new();
         };
@@ -1149,9 +1148,10 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn peek_oldest_in_flight(&self, ctx: ContextHandle) -> Option<crate::timeline::TimelineValue> {
-        let sc = self.state.contexts.get(&ctx)?;
+        let sc_arc = self.state.contexts.get(&ctx)?;
+        let last_submitted_seq = sc_arc.lock().unwrap().last_submitted_seq;
         let progress = self.gpu_progress(ctx);
-        if progress < sc.last_submitted_seq {
+        if progress < last_submitted_seq {
             Some(progress.saturating_add(1))
         } else {
             None
@@ -1180,6 +1180,8 @@ impl GpuBackend for VulkanBackend {
                 .contexts
                 .get(&ctx)
                 .context("Invalid context handle")?
+                .lock()
+                .unwrap()
                 .timeline_semaphore;
             let dev = &self.state.devices.get(&device_handle).unwrap().device;
             let wait = vk::SemaphoreWaitInfo::default()
@@ -1200,11 +1202,11 @@ impl GpuBackend for VulkanBackend {
             let _reap = crate::tracy_zone!("vk.wait_until.reap_timeline_cmd_buffers");
             compute::reap_timeline_cmd_buffers_up_to(&mut self.state, ctx, value);
         }
-        if let Some(ld) = self.state.devices.get_mut(&device_handle) {
+        if let Some(ld) = self.state.devices.get(&device_handle) {
             let drain_to = value.min(retired);
             let drained = {
                 let _drain = crate::tracy_zone!("vk.wait_until.deletion_queue.drain");
-                ld.deletion_queue.drain_up_to(drain_to)
+                ld.deletion_queue.lock().unwrap().drain_up_to(drain_to)
             };
             {
                 let _destroy = crate::tracy_zone!("vk.wait_until.deletion_queue.destroy");
@@ -1236,6 +1238,8 @@ impl GpuBackend for VulkanBackend {
             .contexts
             .get(&ctx)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .timeline_semaphore;
         let dev = &self.state.devices.get(&device_handle).unwrap().device;
         let wait = vk::SemaphoreWaitInfo::default()
@@ -1246,8 +1250,12 @@ impl GpuBackend for VulkanBackend {
             Ok(()) => {
                 let retired = context::device_retired(&self.state, device_handle);
                 compute::reap_timeline_cmd_buffers_up_to(&mut self.state, ctx, value);
-                if let Some(ld) = self.state.devices.get_mut(&device_handle) {
-                    let drained = ld.deletion_queue.drain_up_to(value.min(retired));
+                if let Some(ld) = self.state.devices.get(&device_handle) {
+                    let drained = ld
+                        .deletion_queue
+                        .lock()
+                        .unwrap()
+                        .drain_up_to(value.min(retired));
                     let ledger_arc = std::sync::Arc::clone(&ld.ledger);
                     let mut ledger = ledger_arc.lock().unwrap();
                     for r in drained {
@@ -1337,7 +1345,8 @@ impl GpuBackend for VulkanBackend {
         let Some(logical_device) = self.state.devices.get(&device_handle) else {
             return;
         };
-        for sc in self.state.contexts.values_mut() {
+        for sc_arc in self.state.contexts.values() {
+            let mut sc = sc_arc.lock().unwrap();
             if sc.device == device_handle {
                 unsafe { sc.staging_belt.trim(logical_device) };
             }
@@ -1377,10 +1386,10 @@ impl GpuBackend for VulkanBackend {
         let ctx_batch: Vec<_> = self
             .state
             .contexts
-            .get_mut(&ctx)
-            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
-        if let Some(ld) = self.state.devices.get_mut(&device_handle) {
+        if let Some(ld) = self.state.devices.get(&device_handle) {
             let ledger_arc = std::sync::Arc::clone(&ld.ledger);
             {
                 let mut ledger = ledger_arc.lock().unwrap();
@@ -1404,7 +1413,7 @@ impl GpuBackend for VulkanBackend {
         self.state
             .devices
             .get(&device_handle)
-            .map(|d| d.deletion_queue.len())
+            .map(|d| d.deletion_queue.lock().unwrap().len())
             .unwrap_or(0)
     }
 }

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1208,10 +1208,17 @@ impl GpuBackend for VulkanBackend {
             };
             {
                 let _destroy = crate::tracy_zone!("vk.wait_until.deletion_queue.destroy");
+                let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+                let mut ledger = ledger_arc.lock().unwrap();
                 for r in drained {
-                    types::destroy_pending_deletion(ld, r);
+                    types::destroy_pending_deletion(ld, &mut ledger, r);
                 }
-                ld.drain_ready_slot_reclamations(&self.state.contexts);
+                let completed_values = types::snapshot_context_completed_values(
+                    &ld.device,
+                    &self.state.contexts,
+                    device_handle,
+                );
+                ledger.drain_ready_slot_reclamations(&completed_values);
             }
         }
         Ok(())
@@ -1241,10 +1248,17 @@ impl GpuBackend for VulkanBackend {
                 compute::reap_timeline_cmd_buffers_up_to(&mut self.state, ctx, value);
                 if let Some(ld) = self.state.devices.get_mut(&device_handle) {
                     let drained = ld.deletion_queue.drain_up_to(value.min(retired));
+                    let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+                    let mut ledger = ledger_arc.lock().unwrap();
                     for r in drained {
-                        types::destroy_pending_deletion(ld, r);
+                        types::destroy_pending_deletion(ld, &mut ledger, r);
                     }
-                    ld.drain_ready_slot_reclamations(&self.state.contexts);
+                    let completed_values = types::snapshot_context_completed_values(
+                        &ld.device,
+                        &self.state.contexts,
+                        device_handle,
+                    );
+                    ledger.drain_ready_slot_reclamations(&completed_values);
                 }
                 Ok(true)
             }
@@ -1338,7 +1352,13 @@ impl GpuBackend for VulkanBackend {
         self.state
             .devices
             .get(&device_handle)
-            .map(|ld| ld.resource_registry.available_slots(category))
+            .map(|ld| {
+                ld.ledger
+                    .lock()
+                    .unwrap()
+                    .resource_registry
+                    .available_slots(category)
+            })
             .unwrap_or(0)
     }
 
@@ -1361,12 +1381,21 @@ impl GpuBackend for VulkanBackend {
             .map(|sc| sc.deletion_queue.drain_up_to(completed))
             .unwrap_or_default();
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
-            for r in ctx_batch {
-                types::destroy_pending_deletion(ld, r);
+            let ledger_arc = std::sync::Arc::clone(&ld.ledger);
+            {
+                let mut ledger = ledger_arc.lock().unwrap();
+                for r in ctx_batch {
+                    types::destroy_pending_deletion(ld, &mut ledger, r);
+                }
+                let completed_values = types::snapshot_context_completed_values(
+                    &ld.device,
+                    &self.state.contexts,
+                    device_handle,
+                );
+                ledger.drain_ready_slot_reclamations(&completed_values);
             }
             // Device-level queue: user-destroyed resources without context attribution.
             ld.process_deletion_queue_up_to(completed);
-            ld.drain_ready_slot_reclamations(&self.state.contexts);
         }
     }
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1352,9 +1352,9 @@ impl GpuBackend for VulkanBackend {
 
     fn flush_deferred_deletions(&mut self, ctx: ContextHandle) {
         let device_handle = self.context_device(ctx);
-        let retired = context::device_retired(&self.state, device_handle);
+        let completed = compute::ctx_completed_value(&self.state, ctx, device_handle);
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
-            ld.process_deletion_queue_up_to(retired);
+            ld.process_deletion_queue_up_to(completed);
             ld.drain_ready_slot_reclamations(&self.state.contexts);
         }
     }

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1353,7 +1353,18 @@ impl GpuBackend for VulkanBackend {
     fn flush_deferred_deletions(&mut self, ctx: ContextHandle) {
         let device_handle = self.context_device(ctx);
         let completed = compute::ctx_completed_value(&self.state, ctx, device_handle);
+        // Per-context queue: resources whose lifetime is bounded by this context.
+        let ctx_batch: Vec<_> = self
+            .state
+            .contexts
+            .get_mut(&ctx)
+            .map(|sc| sc.deletion_queue.drain_up_to(completed))
+            .unwrap_or_default();
         if let Some(ld) = self.state.devices.get_mut(&device_handle) {
+            for r in ctx_batch {
+                types::destroy_pending_deletion(ld, r);
+            }
+            // Device-level queue: user-destroyed resources without context attribution.
             ld.process_deletion_queue_up_to(completed);
             ld.drain_ready_slot_reclamations(&self.state.contexts);
         }

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -282,8 +282,6 @@ impl VulkanBackend {
             next_sampler_handle: 1,
             slang_compiler,
             compute_fence_pool: HashMap::new(),
-            texture_staging_pools: HashMap::new(),
-            staging_belts: HashMap::new(),
             device_lost: std::sync::atomic::AtomicBool::new(false),
         };
 
@@ -1322,11 +1320,13 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn reset_buffer_heaps(&mut self, device_handle: DeviceHandle) {
-        if let (Some(logical_device), Some(belt)) = (
-            self.state.devices.get(&device_handle),
-            self.state.staging_belts.get_mut(&device_handle),
-        ) {
-            unsafe { belt.trim(logical_device) };
+        let Some(logical_device) = self.state.devices.get(&device_handle) else {
+            return;
+        };
+        for sc in self.state.contexts.values_mut() {
+            if sc.device == device_handle {
+                unsafe { sc.staging_belt.trim(logical_device) };
+            }
         }
     }
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -99,7 +99,7 @@ impl Drop for VulkanBackend {
         tracing::info!(
             devices = self.state.devices.len(),
             surfaces = self.state.surfaces.len(),
-            compute_fences = self.state.compute_fence_pool.len(),
+            compute_fences = self.state.compute_fence_pool.lock().unwrap().len(),
             "VulkanBackend drop"
         );
 
@@ -281,7 +281,7 @@ impl VulkanBackend {
             samplers: HashMap::new(),
             next_sampler_handle: 1,
             slang_compiler,
-            compute_fence_pool: HashMap::new(),
+            compute_fence_pool: Mutex::new(HashMap::new()),
             device_lost: std::sync::atomic::AtomicBool::new(false),
         };
 
@@ -1200,7 +1200,7 @@ impl GpuBackend for VulkanBackend {
         let retired = context::device_retired(&self.state, device_handle);
         {
             let _reap = crate::tracy_zone!("vk.wait_until.reap_timeline_cmd_buffers");
-            compute::reap_timeline_cmd_buffers_up_to(&mut self.state, ctx, value);
+            compute::reap_timeline_cmd_buffers_up_to(&self.state, ctx, value);
         }
         if let Some(ld) = self.state.devices.get(&device_handle) {
             let drain_to = value.min(retired);
@@ -1249,7 +1249,7 @@ impl GpuBackend for VulkanBackend {
         match unsafe { dev.wait_semaphores(&wait, timeout_ns) } {
             Ok(()) => {
                 let retired = context::device_retired(&self.state, device_handle);
-                compute::reap_timeline_cmd_buffers_up_to(&mut self.state, ctx, value);
+                compute::reap_timeline_cmd_buffers_up_to(&self.state, ctx, value);
                 if let Some(ld) = self.state.devices.get(&device_handle) {
                     let drained = ld
                         .deletion_queue
@@ -1287,7 +1287,7 @@ impl GpuBackend for VulkanBackend {
         ctx: ContextHandle,
         commands: &[GpuCommand],
     ) -> Result<crate::timeline::TimelineValue> {
-        compute::submit(&mut self.state, ctx, commands)
+        compute::submit(&self.state, ctx, commands)
     }
 
     fn submit_graph(
@@ -1295,7 +1295,7 @@ impl GpuBackend for VulkanBackend {
         ctx: ContextHandle,
         commands: &[GraphCommand],
     ) -> Result<crate::timeline::TimelineValue> {
-        compute::submit_graph(&mut self.state, ctx, commands)
+        compute::submit_graph(&self.state, ctx, commands)
     }
 
     fn submit_graph_and_retain(
@@ -1304,7 +1304,7 @@ impl GpuBackend for VulkanBackend {
         commands: &[GraphCommand],
         key: u64,
     ) -> Result<crate::timeline::TimelineValue> {
-        compute::submit_graph_and_retain(&mut self.state, ctx, commands, key)
+        compute::submit_graph_and_retain(&self.state, ctx, commands, key)
     }
 
     fn try_resubmit_retained(
@@ -1312,11 +1312,11 @@ impl GpuBackend for VulkanBackend {
         ctx: ContextHandle,
         key: u64,
     ) -> Result<Option<crate::timeline::TimelineValue>> {
-        compute::try_resubmit_retained(&mut self.state, ctx, key)
+        compute::try_resubmit_retained(&self.state, ctx, key)
     }
 
     fn evict_retained(&mut self, ctx: ContextHandle, key: u64) {
-        compute::evict_retained(&mut self.state, ctx, key);
+        compute::evict_retained(&self.state, ctx, key);
     }
 
     fn record_gpu_work(&mut self, frame: &FrameToken, commands: &[GpuCommand]) -> Result<()> {

--- a/src/backend/vulkan/pipeline.rs
+++ b/src/backend/vulkan/pipeline.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 /// Shader modules plus raster state for Vulkan graphics pipeline creation.
 pub(super) struct VulkanGraphicsPipelineCreateBundle<'a> {
-    pub devices: &'a HashMap<DeviceHandle, types::LogicalDevice>,
+    pub devices: &'a HashMap<DeviceHandle, types::SharedLogicalDevice>,
     pub pipelines: &'a mut HashMap<PipelineHandle, PipelineState>,
     pub next_pipeline_handle: &'a mut PipelineHandle,
     pub device_handle: DeviceHandle,
@@ -392,7 +392,7 @@ pub(super) fn create_with_depth(
 
 /// Destroy a graphics pipeline and clean up GPU resources.
 pub(super) fn destroy(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     pipelines: &mut HashMap<PipelineHandle, PipelineState>,
     pipeline_handle: PipelineHandle,
 ) {

--- a/src/backend/vulkan/render_target.rs
+++ b/src/backend/vulkan/render_target.rs
@@ -32,7 +32,7 @@ fn find_memory_type(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create(
     instance: &Instance,
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &mut HashMap<RenderTargetHandle, RenderTargetState>,
     next_render_target_handle: &mut RenderTargetHandle,
     device_handle: DeviceHandle,
@@ -158,7 +158,7 @@ pub(super) fn create(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create_with_depth(
     instance: &Instance,
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &mut HashMap<RenderTargetHandle, RenderTargetState>,
     next_render_target_handle: &mut RenderTargetHandle,
     device_handle: DeviceHandle,
@@ -349,7 +349,7 @@ pub(super) fn create_with_depth(
 
 /// Destroy a render target and free GPU resources.
 pub(super) fn destroy(
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &mut HashMap<RenderTargetHandle, RenderTargetState>,
     target: RenderTargetHandle,
 ) {
@@ -391,7 +391,7 @@ pub(super) fn destroy(
 /// (COLOR_ATTACHMENT_OPTIMAL -> TRANSFER_SRC_OPTIMAL) into `cmd`.
 /// Does NOT begin/end the command buffer and does NOT submit.
 pub(super) fn record_render_pass_to_buffer<F>(
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &HashMap<RenderTargetHandle, RenderTargetState>,
     device_handle: DeviceHandle,
     target: RenderTargetHandle,
@@ -587,7 +587,7 @@ where
 }
 
 pub(super) fn render_to<F>(
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &mut HashMap<RenderTargetHandle, RenderTargetState>,
     device_handle: DeviceHandle,
     target: RenderTargetHandle,
@@ -657,7 +657,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_to_cpu(
     instance: &Instance,
-    devices: &HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
     render_targets: &mut HashMap<RenderTargetHandle, RenderTargetState>,
     target: RenderTargetHandle,
     output: &mut [u8],

--- a/src/backend/vulkan/render_target.rs
+++ b/src/backend/vulkan/render_target.rs
@@ -141,7 +141,7 @@ pub(super) fn create(
             staging_buffer: None,
             staging_memory: None,
             command_buffer: command_buffers[0],
-            has_rendered: false,
+            has_rendered: std::sync::atomic::AtomicBool::new(false),
         },
     );
 
@@ -333,7 +333,7 @@ pub(super) fn create_with_depth(
             staging_buffer: None,
             staging_memory: None,
             command_buffer: command_buffers[0],
-            has_rendered: false,
+            has_rendered: std::sync::atomic::AtomicBool::new(false),
         },
     );
 
@@ -646,8 +646,9 @@ where
     unsafe { logical_device.device.queue_wait_idle(logical_device.queue) }
         .context("Failed to wait for queue")?;
 
-    if let Some(rt) = render_targets.get_mut(&target) {
-        rt.has_rendered = true;
+    if let Some(rt) = render_targets.get(&target) {
+        rt.has_rendered
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     Ok(())
@@ -668,7 +669,10 @@ pub(super) fn read_to_cpu(
             .get(&target)
             .context("Invalid render target handle")?;
 
-        if !render_target.has_rendered {
+        if !render_target
+            .has_rendered
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
             anyhow::bail!("Cannot read from render target that hasn't been rendered to");
         }
 

--- a/src/backend/vulkan/sampler.rs
+++ b/src/backend/vulkan/sampler.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 /// Create a sampler with the given description.
 pub(super) fn create(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     samplers: &mut HashMap<SamplerHandle, SamplerState>,
     next_sampler_handle: &mut SamplerHandle,
     device_handle: DeviceHandle,
@@ -50,7 +50,7 @@ pub(super) fn create(
     *next_sampler_handle += 1;
 
     let bindless_index = {
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let index = logical_device
             .ledger
             .lock()
@@ -96,12 +96,12 @@ pub(super) fn create(
 
 /// Destroy a sampler, unregistering it from bindless and cleaning up GPU resources.
 pub(super) fn destroy(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     samplers: &mut HashMap<SamplerHandle, SamplerState>,
     sampler_handle: SamplerHandle,
 ) {
     if let Some(sampler) = samplers.remove(&sampler_handle) {
-        if let Some(logical_device) = devices.get_mut(&sampler.device_handle) {
+        if let Some(logical_device) = devices.get(&sampler.device_handle) {
             // Defer reclamation: sampler slot must not be reused until all
             // in-flight submissions that referenced it have retired.
             logical_device

--- a/src/backend/vulkan/sampler.rs
+++ b/src/backend/vulkan/sampler.rs
@@ -51,7 +51,12 @@ pub(super) fn create(
 
     let bindless_index = {
         let logical_device = devices.get_mut(&device_handle).unwrap();
-        let index = logical_device.resource_registry.register_sampler(handle);
+        let index = logical_device
+            .ledger
+            .lock()
+            .unwrap()
+            .resource_registry
+            .register_sampler(handle);
 
         // Update the global descriptor set with this sampler
         if let Some(descriptor_set) = bindless_descriptor_set {
@@ -99,7 +104,11 @@ pub(super) fn destroy(
         if let Some(logical_device) = devices.get_mut(&sampler.device_handle) {
             // Defer reclamation: sampler slot must not be reused until all
             // in-flight submissions that referenced it have retired.
-            logical_device.reclaim_sampler_slots(sampler_handle);
+            logical_device
+                .ledger
+                .lock()
+                .unwrap()
+                .reclaim_sampler_slots(sampler_handle);
 
             unsafe {
                 logical_device.device.device_wait_idle().ok();

--- a/src/backend/vulkan/shader.rs
+++ b/src/backend/vulkan/shader.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 /// Create a shader from Slang source code.
 pub(super) fn create(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     shaders: &mut HashMap<ShaderHandle, ShaderState>,
     next_shader_handle: &mut ShaderHandle,
     desc: crate::backend::shared::ShaderDesc<'_>,
@@ -45,7 +45,7 @@ pub(super) fn create(
 
 /// Destroy a shader and clean up compiled shader modules.
 pub(super) fn destroy(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     shaders: &mut HashMap<ShaderHandle, ShaderState>,
     shader_handle: ShaderHandle,
 ) {
@@ -69,7 +69,7 @@ pub(super) fn destroy(
 /// Compile a shader for a specific stage on demand.
 pub(super) fn ensure_stage_compiled(
     slang_compiler: &crate::slang::SlangCompiler,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     shaders: &mut HashMap<ShaderHandle, ShaderState>,
     shader_handle: ShaderHandle,
     stage: crate::slang::SlangStage,

--- a/src/backend/vulkan/staging.rs
+++ b/src/backend/vulkan/staging.rs
@@ -9,7 +9,7 @@
 
 use super::super::shared::{BeltChunk as BeltChunkTrait, StagingBeltCore};
 use super::super::DeviceHandle;
-use super::types::LogicalDevice;
+use super::types::{ComputeFencePool, LogicalDevice};
 use super::utils::find_memory_type;
 use anyhow::{Context, Result};
 use ash::{vk, Instance};
@@ -70,14 +70,15 @@ impl StagingBelt {
     /// once the corresponding `VkFence` signals (if any remain in the pool).
     pub fn reclaim(
         &mut self,
-        compute_fence_pool: &HashMap<u64, (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>)>,
+        compute_fence_pool: &ComputeFencePool,
         devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
         completed_timeline: u64,
     ) -> Result<()> {
+        let fence_pool = compute_fence_pool.lock().unwrap();
         let mut i = 0;
         while i < self.core.in_flight.len() {
             let (token, _) = &self.core.in_flight[i];
-            let done = if let Some((device_handle, fence, _)) = compute_fence_pool.get(token) {
+            let done = if let Some((device_handle, fence, _)) = fence_pool.get(token) {
                 let logical_device = devices
                     .get(device_handle)
                     .context("StagingBelt::reclaim: device missing")?;

--- a/src/backend/vulkan/staging.rs
+++ b/src/backend/vulkan/staging.rs
@@ -71,7 +71,7 @@ impl StagingBelt {
     pub fn reclaim(
         &mut self,
         compute_fence_pool: &HashMap<u64, (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>)>,
-        devices: &HashMap<DeviceHandle, LogicalDevice>,
+        devices: &HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
         completed_timeline: u64,
     ) -> Result<()> {
         let mut i = 0;

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -55,6 +55,7 @@ use crate::types::{Color, DepthFormat, TextureFormat};
 use anyhow::{Context, Result};
 use ash::{khr, vk, Entry, Instance};
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 
 #[cfg(target_os = "windows")]
 use raw_window_handle::RawWindowHandle;
@@ -1201,7 +1202,7 @@ where
         let ld = devices
             .get(&device_handle)
             .context("Surface's device is invalid")?;
-        ld.timeline_next
+        ld.timeline_next.fetch_add(1, Ordering::Relaxed)
     };
     let wait_acq = vk::SemaphoreSubmitInfo::default()
         .semaphore(image_available_semaphore)
@@ -1234,10 +1235,6 @@ where
         )
     }
     .context("Failed to submit render command buffer")?;
-
-    if let Some(ld) = devices.get_mut(&device_handle) {
-        ld.timeline_next = signal_timeline_value.saturating_add(1);
-    }
 
     if let Some(surface_state) = surfaces.get_mut(&surface_handle) {
         let fs = &mut surface_state.frame_sync[current_frame];
@@ -1276,7 +1273,7 @@ pub(super) fn submit_frame(
         .devices
         .get(&dh)
         .context("Surface's device is invalid")?;
-    Ok(ld.timeline_next.saturating_sub(1))
+    Ok(ld.timeline_next.load(Ordering::Relaxed).saturating_sub(1))
 }
 
 pub(super) fn present_frame(
@@ -1510,7 +1507,7 @@ pub(super) fn present(
                 .devices
                 .get(&device_handle)
                 .context("Surface's device is invalid")?;
-            ld.timeline_next
+            ld.timeline_next.fetch_add(1, Ordering::Relaxed)
         };
 
         let timeline_sem = state
@@ -1578,8 +1575,6 @@ pub(super) fn present(
 
         {
             let _bk = crate::tracy_zone!("vk.present.post_submit");
-            let ld_timeline = state.devices.get_mut(&device_handle).unwrap();
-            ld_timeline.timeline_next = signal_timeline_value.saturating_add(1);
             if let Some(sc) = state.contexts.get_mut(&ctx) {
                 sc.last_submitted_seq = signal_timeline_value;
             }

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -136,7 +136,7 @@ pub(super) fn create_platform_surface(
 pub(super) fn create(
     entry: &Entry,
     instance: &Instance,
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     next_surface_handle: &mut SurfaceHandle,
@@ -457,15 +457,15 @@ pub(super) fn create(
 }
 
 enum DestroyDeviceRef<'a> {
-    Owned(&'a mut LogicalDevice),
-    Map(&'a mut HashMap<DeviceHandle, LogicalDevice>),
+    Owned(&'a types::LogicalDevice),
+    Map(&'a HashMap<DeviceHandle, types::SharedLogicalDevice>),
 }
 
 impl<'a> DestroyDeviceRef<'a> {
-    fn get_mut(&mut self, device_handle: DeviceHandle) -> Option<&mut LogicalDevice> {
+    fn get_ld(&self, device_handle: DeviceHandle) -> Option<&types::LogicalDevice> {
         match self {
             Self::Owned(ld) => Some(ld),
-            Self::Map(map) => map.get_mut(&device_handle),
+            Self::Map(map) => map.get(&device_handle).map(|arc| arc.as_ref()),
         }
     }
 }
@@ -475,7 +475,7 @@ impl<'a> DestroyDeviceRef<'a> {
 pub(super) fn destroy(
     entry: &Entry,
     instance: &Instance,
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     surface_handle: SurfaceHandle,
@@ -496,8 +496,8 @@ pub(super) fn destroy(
 pub(super) fn destroy_with_logical_device(
     entry: &Entry,
     instance: &Instance,
-    logical_device: &mut LogicalDevice,
-    _devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    logical_device: &types::LogicalDevice,
+    _devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     surface_handle: SurfaceHandle,
@@ -516,7 +516,7 @@ pub(super) fn destroy_with_logical_device(
 fn destroy_impl(
     entry: &Entry,
     instance: &Instance,
-    mut device_ref: DestroyDeviceRef<'_>,
+    device_ref: DestroyDeviceRef<'_>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     surface_handle: SurfaceHandle,
@@ -536,7 +536,7 @@ fn destroy_impl(
         .map(|s| std::mem::take(&mut s.swapchain_texture_handles))
     {
         for th in handles {
-            if let Some(logical_device) = device_ref.get_mut(device_handle) {
+            if let Some(logical_device) = device_ref.get_ld(device_handle) {
                 unregister_swapchain_texture_with_device(logical_device, textures, th);
             }
         }
@@ -551,7 +551,7 @@ fn destroy_impl(
         .into_iter()
         .flatten()
         .map(|slot| {
-            if let Some(logical_device) = device_ref.get_mut(device_handle) {
+            if let Some(logical_device) = device_ref.get_ld(device_handle) {
                 unregister_swapchain_texture_with_device(
                     logical_device,
                     textures,
@@ -563,7 +563,7 @@ fn destroy_impl(
         .collect();
 
     if let Some(mut surface_state) = surfaces.remove(&surface_handle) {
-        if let Some(logical_device) = device_ref.get_mut(surface_state.device_handle) {
+        if let Some(logical_device) = device_ref.get_ld(surface_state.device_handle) {
             unsafe {
                 let _ = logical_device.device.device_wait_idle();
 
@@ -671,7 +671,7 @@ pub(super) fn acquire(
         state
             .devices
             .get(&device_handle)
-            .map(|d| d.deletion_queue.len())
+            .map(|d| d.deletion_queue.lock().unwrap().len())
             .unwrap_or(0)
     };
 
@@ -781,7 +781,7 @@ pub(super) fn acquire(
         let ctxs: Vec<_> = state
             .contexts
             .iter()
-            .filter(|(_, sc)| sc.device == device_handle)
+            .filter(|(_, sc)| sc.lock().unwrap().device == device_handle)
             .map(|(k, _)| *k)
             .collect();
         for ctx in ctxs {
@@ -803,9 +803,13 @@ pub(super) fn acquire(
         let _dz = crate::tracy_zone!("vk.surface.deferred_deletions");
         let logical_device = state
             .devices
-            .get_mut(&device_handle)
+            .get(&device_handle)
             .context("Surface's device is invalid")?;
-        let drained = logical_device.deletion_queue.drain_up_to(completed);
+        let drained = logical_device
+            .deletion_queue
+            .lock()
+            .unwrap()
+            .drain_up_to(completed);
         if !drained.is_empty() {
             let ledger_arc = std::sync::Arc::clone(&logical_device.ledger);
             let mut ledger = ledger_arc.lock().unwrap();
@@ -860,8 +864,11 @@ pub(super) fn acquire(
                     surface_state.pending_acquire_count.saturating_add(1);
             }
 
-            if let Some(sc) = state.contexts.get_mut(&ctx) {
-                sc.signal_queue
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc
+                    .lock()
+                    .unwrap()
+                    .signal_queue
                     .push(crate::signal::Signal::SwapchainAcquired { image_index });
             }
 
@@ -901,7 +908,7 @@ pub(super) fn frame_texture(
 /// Render commands to the surface's current swapchain image.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn render<F>(
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     surface_handle: SurfaceHandle,
     _image: SwapchainImageHandle,
@@ -1518,6 +1525,8 @@ pub(super) fn present(
             .contexts
             .get(&ctx)
             .context("Invalid context handle")?
+            .lock()
+            .unwrap()
             .timeline_semaphore;
 
         // WSI submit: [copy_cb]
@@ -1579,8 +1588,8 @@ pub(super) fn present(
 
         {
             let _bk = crate::tracy_zone!("vk.present.post_submit");
-            if let Some(sc) = state.contexts.get_mut(&ctx) {
-                sc.last_submitted_seq = signal_timeline_value;
+            if let Some(sc_arc) = state.contexts.get(&ctx) {
+                sc_arc.lock().unwrap().last_submitted_seq = signal_timeline_value;
             }
 
             // Expose the *compute* timeline value to callers (not the copy's).
@@ -1671,8 +1680,11 @@ pub(super) fn present(
         }
     } else if let Some(surface_state) = state.surfaces.get_mut(&surface_handle) {
         surface_state.pending_acquire_count = surface_state.pending_acquire_count.saturating_sub(1);
-        if let Some(sc) = state.contexts.get(&ctx) {
-            sc.signal_queue
+        if let Some(sc_arc) = state.contexts.get(&ctx) {
+            sc_arc
+                .lock()
+                .unwrap()
+                .signal_queue
                 .push(crate::signal::Signal::SwapchainReturned {
                     image_index: image_idx_for_return,
                 });
@@ -1703,7 +1715,7 @@ pub(super) fn present(
 pub(super) fn resize(
     entry: &Entry,
     instance: &Instance,
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     surfaces: &mut HashMap<SurfaceHandle, SurfaceState>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     next_texture_handle: &mut TextureHandle,
@@ -2083,7 +2095,7 @@ pub(super) fn set_present_mode(
     resize(
         &state.entry,
         &state.instance,
-        &mut state.devices,
+        &state.devices,
         &mut state.surfaces,
         &mut state.textures,
         &mut state.next_texture_handle,
@@ -2208,7 +2220,7 @@ fn ensure_scratch_texture_slot(
         .and_then(|s| s.scratch_texture_slots.get_mut(frame_slot))
         .and_then(|slot| slot.take())
     {
-        unregister_surface_texture(&mut state.devices, &mut state.textures, old.texture_handle);
+        unregister_surface_texture(&state.devices, &mut state.textures, old.texture_handle);
         let ld = state
             .devices
             .get(&device_handle)
@@ -2330,7 +2342,7 @@ fn ensure_scratch_texture_slot(
 
     // Register as a bindless storage-image texture.
     let texture_handle = register_surface_texture(
-        &mut state.devices,
+        &state.devices,
         &mut state.textures,
         &mut state.next_texture_handle,
         device_handle,
@@ -2368,7 +2380,7 @@ fn ensure_scratch_texture_slot(
 /// stores in `SurfaceState::current_texture_handle`.
 #[allow(clippy::too_many_arguments)]
 fn register_surface_texture(
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     next_texture_handle: &mut TextureHandle,
     device_handle: DeviceHandle,
@@ -2382,7 +2394,7 @@ fn register_surface_texture(
     *next_texture_handle += 1;
 
     let logical_device = devices
-        .get_mut(&device_handle)
+        .get(&device_handle)
         .context("Device no longer valid")?;
 
     // Create an image view for compute storage access
@@ -2470,7 +2482,7 @@ fn register_surface_texture(
 /// Unregister a swapchain image texture (destroy view + bindless slot).
 /// Does NOT destroy the VkImage — it is owned by the swapchain.
 fn unregister_swapchain_texture_with_device(
-    logical_device: &mut LogicalDevice,
+    logical_device: &types::LogicalDevice,
     textures: &mut HashMap<TextureHandle, TextureState>,
     tex_handle: TextureHandle,
 ) {
@@ -2492,12 +2504,12 @@ fn unregister_swapchain_texture_with_device(
 /// Unregister a swapchain image texture (destroy view + bindless slot).
 /// Does NOT destroy the VkImage — it is owned by the swapchain.
 fn unregister_swapchain_texture(
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     tex_handle: TextureHandle,
 ) {
     if let Some(tex_state) = textures.remove(&tex_handle) {
-        if let Some(device) = devices.get_mut(&tex_state.device_handle) {
+        if let Some(device) = devices.get(&tex_state.device_handle) {
             device
                 .ledger
                 .lock()
@@ -2515,7 +2527,7 @@ fn unregister_swapchain_texture(
 /// same name used before the rename.  Delegates to `unregister_swapchain_texture`.
 #[inline(always)]
 fn unregister_surface_texture(
-    devices: &mut HashMap<DeviceHandle, LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     tex_handle: TextureHandle,
 ) {

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -806,8 +806,12 @@ pub(super) fn acquire(
             .get_mut(&device_handle)
             .context("Surface's device is invalid")?;
         let drained = logical_device.deletion_queue.drain_up_to(completed);
-        for r in drained {
-            types::destroy_pending_deletion(logical_device, r);
+        if !drained.is_empty() {
+            let ledger_arc = std::sync::Arc::clone(&logical_device.ledger);
+            let mut ledger = ledger_arc.lock().unwrap();
+            for r in drained {
+                types::destroy_pending_deletion(logical_device, &mut ledger, r);
+            }
         }
     }
 
@@ -2400,6 +2404,9 @@ fn register_surface_texture(
     // Register as a storage image in the bindless descriptor set
     let is_storage_image = true;
     let bindless_index = logical_device
+        .ledger
+        .lock()
+        .unwrap()
         .resource_registry
         .register_texture(handle, is_storage_image);
 
@@ -2468,7 +2475,11 @@ fn unregister_swapchain_texture_with_device(
     tex_handle: TextureHandle,
 ) {
     if let Some(tex_state) = textures.remove(&tex_handle) {
-        logical_device.reclaim_texture_slots(tex_handle);
+        logical_device
+            .ledger
+            .lock()
+            .unwrap()
+            .reclaim_texture_slots(tex_handle);
         unsafe {
             logical_device
                 .device
@@ -2487,7 +2498,11 @@ fn unregister_swapchain_texture(
 ) {
     if let Some(tex_state) = textures.remove(&tex_handle) {
         if let Some(device) = devices.get_mut(&tex_state.device_handle) {
-            device.reclaim_texture_slots(tex_handle);
+            device
+                .ledger
+                .lock()
+                .unwrap()
+                .reclaim_texture_slots(tex_handle);
             unsafe {
                 device.device.destroy_image_view(tex_state.view, None);
             }

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -1237,13 +1237,17 @@ where
     let logical_device = devices
         .get(&device_handle)
         .context("Surface's device is invalid")?;
+    let queue_lock = std::sync::Arc::clone(&logical_device.queue_lock);
 
-    unsafe {
-        logical_device.device.queue_submit2(
-            logical_device.queue,
-            std::slice::from_ref(&submit),
-            in_flight_fence,
-        )
+    {
+        let _queue_guard = queue_lock.lock().unwrap();
+        unsafe {
+            logical_device.device.queue_submit2(
+                logical_device.queue,
+                std::slice::from_ref(&submit),
+                in_flight_fence,
+            )
+        }
     }
     .context("Failed to submit render command buffer")?;
 
@@ -1563,9 +1567,11 @@ pub(super) fn present(
             .devices
             .get(&device_handle)
             .context("Surface's device is invalid")?;
+        let queue_lock = std::sync::Arc::clone(&submit_ld.queue_lock);
 
         let r = {
             let _sz = crate::tracy_zone!("vk.present.queue_submit2_copy");
+            let _queue_guard = queue_lock.lock().unwrap();
             unsafe {
                 submit_ld.device.queue_submit2(
                     submit_ld.queue,
@@ -2287,6 +2293,7 @@ fn ensure_scratch_texture_slot(
             .devices
             .get(&device_handle)
             .context("Device invalid")?;
+        let queue_lock = std::sync::Arc::clone(&ld.queue_lock);
         unsafe {
             let alloc_info = vk::CommandBufferAllocateInfo::default()
                 .command_pool(ld.command_pool)
@@ -2329,12 +2336,16 @@ fn ensure_scratch_texture_slot(
             let cb_info = vk::CommandBufferSubmitInfo::default().command_buffer(cb);
             let submit =
                 vk::SubmitInfo2::default().command_buffer_infos(std::slice::from_ref(&cb_info));
+            // Hold queue_lock across both submit and wait_idle: vkQueueWaitIdle
+            // is also externally synchronized on the queue (Vulkan spec).
+            let _queue_guard = queue_lock.lock().unwrap();
             ld.device
                 .queue_submit2(ld.queue, std::slice::from_ref(&submit), vk::Fence::null())
                 .context("Failed to submit scratch texture init")?;
             ld.device
                 .queue_wait_idle(ld.queue)
                 .context("queue_wait_idle after scratch init")?;
+            drop(_queue_guard);
             ld.device
                 .free_command_buffers(ld.command_pool, std::slice::from_ref(&cb));
         }

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -2474,7 +2474,7 @@ fn register_surface_texture(
             staging_memory: None,
             bindless_index: Some(bindless_index),
             sampled_bindless_index: None,
-            current_layout: vk::ImageLayout::GENERAL,
+            current_layout: std::sync::atomic::AtomicI32::new(vk::ImageLayout::GENERAL.as_raw()),
             transient_heap_suballoc: false,
         },
     );

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::Ordering;
 #[allow(clippy::manual_find)]
 pub(super) fn create(
     instance: &ash::Instance,
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     next_texture_handle: &mut TextureHandle,
     device_handle: DeviceHandle,
@@ -144,7 +144,7 @@ pub(super) fn create(
     let is_dual_access = matches!(access, TextureKind::DirectInterpolated);
 
     let bindless_index = {
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         let index = logical_device
             .ledger
             .lock()
@@ -202,7 +202,7 @@ pub(super) fn create(
 
     // For DirectInterpolated, also register a sampled-texture (SRV) slot.
     let sampled_bindless_index = if is_dual_access {
-        let logical_device = devices.get_mut(&device_handle).unwrap();
+        let logical_device = devices.get(&device_handle).unwrap();
         // Register in the sampled pool (is_storage_image = false).
         let index = logical_device
             .ledger
@@ -274,7 +274,7 @@ pub(super) fn create(
 #[allow(clippy::manual_find)]
 pub(super) fn write(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     texture_handle: TextureHandle,
     data: &[u8],
@@ -534,7 +534,7 @@ pub(super) fn write(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn write_region(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     texture_handle: TextureHandle,
     x: u32,
@@ -794,7 +794,7 @@ pub(super) fn write_region(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_to_cpu(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     texture_handle: TextureHandle,
     output: &mut [u8],
@@ -1009,12 +1009,12 @@ pub(super) fn read_to_cpu(
 
 /// Destroy a texture, unregistering it from bindless and cleaning up GPU resources.
 pub(super) fn destroy(
-    devices: &mut HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     texture_handle: TextureHandle,
 ) {
     if let Some(texture) = textures.remove(&texture_handle) {
-        if let Some(logical_device) = devices.get_mut(&texture.device_handle) {
+        if let Some(logical_device) = devices.get(&texture.device_handle) {
             if texture.transient_heap_suballoc {
                 logical_device
                     .ledger
@@ -1032,7 +1032,7 @@ pub(super) fn destroy(
                 .timeline_next
                 .load(Ordering::Relaxed)
                 .saturating_sub(1);
-            logical_device.deletion_queue.queue(
+            logical_device.deletion_queue.lock().unwrap().queue(
                 barrier,
                 types::PendingDeletion::Texture {
                     texture_handle,
@@ -1174,7 +1174,7 @@ pub(super) struct ComputeTextureScratch {
 #[allow(clippy::too_many_arguments)]
 pub(super) fn allocate_compute_texture_staging(
     instance: &ash::Instance,
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &HashMap<TextureHandle, TextureState>,
     pool: &mut super::staging::TextureStagingPool,
     texture_handle: TextureHandle,
@@ -1235,7 +1235,7 @@ pub(super) fn allocate_compute_texture_staging(
 
 /// Record buffer→image copy + layout transitions into an open command buffer.
 pub(super) fn record_compute_texture_upload(
-    devices: &HashMap<DeviceHandle, types::LogicalDevice>,
+    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
     textures: &mut HashMap<TextureHandle, TextureState>,
     cmd: vk::CommandBuffer,
     scratch: &ComputeTextureScratch,

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -260,7 +260,7 @@ pub(super) fn create(
             staging_memory: None,
             bindless_index,
             sampled_bindless_index,
-            current_layout: initial_layout,
+            current_layout: std::sync::atomic::AtomicI32::new(initial_layout.as_raw()),
             transient_heap_suballoc: false,
         },
     );
@@ -286,7 +286,7 @@ pub(super) fn write(
         .context("Invalid texture handle")?;
 
     let device_handle = texture.device_handle;
-    let old_layout = texture.current_layout;
+    let old_layout = texture.image_layout();
     let image = texture.image;
     let tex_width = texture.width;
     let tex_height = texture.height;
@@ -517,8 +517,8 @@ pub(super) fn write(
         logical_device.device.free_memory(staging_memory, None);
     }
 
-    if let Some(tex) = textures.get_mut(&texture_handle) {
-        tex.current_layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+    if let Some(tex) = textures.get(&texture_handle) {
+        tex.set_image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
     }
 
     tracing::debug!(
@@ -551,7 +551,7 @@ pub(super) fn write_region(
     let image = texture.image;
     let tex_width = texture.width;
     let tex_height = texture.height;
-    let old_layout = texture.current_layout;
+    let old_layout = texture.image_layout();
 
     if x + width > tex_width || y + height > tex_height {
         anyhow::bail!(
@@ -774,8 +774,8 @@ pub(super) fn write_region(
         logical_device.device.free_memory(staging_memory, None);
     }
 
-    if let Some(tex) = textures.get_mut(&texture_handle) {
-        tex.current_layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+    if let Some(tex) = textures.get(&texture_handle) {
+        tex.set_image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
     }
 
     tracing::debug!(
@@ -809,7 +809,7 @@ pub(super) fn read_to_cpu(
             texture.height,
             texture.format,
             texture.image,
-            texture.current_layout,
+            texture.image_layout(),
             texture.staging_buffer,
             texture.staging_memory,
         )
@@ -1000,8 +1000,8 @@ pub(super) fn read_to_cpu(
             .context("Failed to unmap staging buffer")?;
     }
 
-    if let Some(tex) = textures.get_mut(&texture_handle) {
-        tex.current_layout = vk::ImageLayout::TRANSFER_SRC_OPTIMAL;
+    if let Some(tex) = textures.get(&texture_handle) {
+        tex.set_image_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL);
     }
 
     Ok(())
@@ -1236,7 +1236,7 @@ pub(super) fn allocate_compute_texture_staging(
 /// Record buffer→image copy + layout transitions into an open command buffer.
 pub(super) fn record_compute_texture_upload(
     devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
-    textures: &mut HashMap<TextureHandle, TextureState>,
+    textures: &HashMap<TextureHandle, TextureState>,
     cmd: vk::CommandBuffer,
     scratch: &ComputeTextureScratch,
 ) -> Result<()> {
@@ -1250,7 +1250,7 @@ pub(super) fn record_compute_texture_upload(
             texture.height,
             texture.format,
             texture.image,
-            texture.current_layout,
+            texture.image_layout(),
         )
     };
 
@@ -1358,8 +1358,8 @@ pub(super) fn record_compute_texture_upload(
         .image_memory_barriers(std::slice::from_ref(&barrier_to_shader));
     unsafe { logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info2) };
 
-    if let Some(tex) = textures.get_mut(&scratch.texture_handle) {
-        tex.current_layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+    if let Some(tex) = textures.get(&scratch.texture_handle) {
+        tex.set_image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
     }
 
     let _ = format;

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -7,6 +7,7 @@ use crate::types::{TextureFlags, TextureFormat, TextureKind};
 use anyhow::{Context, Result};
 use ash::vk;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 
 /// Create a texture with the given dimensions, format, access pattern, and flags.
 #[allow(clippy::too_many_arguments)]
@@ -1017,7 +1018,10 @@ pub(super) fn destroy(
                 return;
             }
 
-            let barrier = logical_device.timeline_next.saturating_sub(1);
+            let barrier = logical_device
+                .timeline_next
+                .load(Ordering::Relaxed)
+                .saturating_sub(1);
             logical_device.deletion_queue.queue(
                 barrier,
                 types::PendingDeletion::Texture {

--- a/src/backend/vulkan/texture.rs
+++ b/src/backend/vulkan/texture.rs
@@ -146,6 +146,9 @@ pub(super) fn create(
     let bindless_index = {
         let logical_device = devices.get_mut(&device_handle).unwrap();
         let index = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_texture(handle, is_storage_image);
 
@@ -202,6 +205,9 @@ pub(super) fn create(
         let logical_device = devices.get_mut(&device_handle).unwrap();
         // Register in the sampled pool (is_storage_image = false).
         let index = logical_device
+            .ledger
+            .lock()
+            .unwrap()
             .resource_registry
             .register_texture(handle, false);
 
@@ -1010,7 +1016,11 @@ pub(super) fn destroy(
     if let Some(texture) = textures.remove(&texture_handle) {
         if let Some(logical_device) = devices.get_mut(&texture.device_handle) {
             if texture.transient_heap_suballoc {
-                logical_device.reclaim_texture_slots(texture_handle);
+                logical_device
+                    .ledger
+                    .lock()
+                    .unwrap()
+                    .reclaim_texture_slots(texture_handle);
                 unsafe {
                     logical_device.device.destroy_image_view(texture.view, None);
                     logical_device.device.destroy_image(texture.image, None);

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -160,17 +160,22 @@ impl DeviceLedger {
 /// retirement data it needs without touching live context state while the ledger is locked.
 pub(super) fn snapshot_context_completed_values(
     device: &ash::Device,
-    contexts: &HashMap<super::ContextHandle, SubmissionContext>,
+    contexts: &HashMap<super::ContextHandle, SharedSubmissionContext>,
     for_device: super::DeviceHandle,
 ) -> HashMap<super::ContextHandle, u64> {
     contexts
         .iter()
-        .filter(|(_, sc)| sc.device == for_device)
-        .map(|(&id, sc)| unsafe {
-            let v = device
-                .get_semaphore_counter_value(sc.timeline_semaphore)
-                .unwrap_or(0);
-            (id, v)
+        .filter_map(|(&id, sc_arc)| {
+            let sc = sc_arc.lock().unwrap();
+            if sc.device != for_device {
+                return None;
+            }
+            let v = unsafe {
+                device
+                    .get_semaphore_counter_value(sc.timeline_semaphore)
+                    .unwrap_or(0)
+            };
+            Some((id, v))
         })
         .collect()
 }
@@ -640,7 +645,8 @@ pub(crate) struct LogicalDevice {
     #[allow(dead_code)] // captured at device init for diagnostics / future use
     pub sparse_memory_type_index: u32,
     /// Sub-allocated DEVICE_LOCAL pages for [`super::sparse::SparsePagePool`].
-    pub sparse_page_pool: Option<super::sparse::SparsePagePool>,
+    /// `Mutex` so `LogicalDevice` can be `Arc`-wrapped (Phase 5a).
+    pub sparse_page_pool: Mutex<Option<super::sparse::SparsePagePool>>,
 
     // Vulkan 1.4 core via KHR extension loaders (ash 0.38 doesn't have core 1.4 wrappers yet)
     pub map_memory2: ash::khr::map_memory2::Device,
@@ -658,14 +664,17 @@ pub(crate) struct LogicalDevice {
     /// `Arc` so Phase 5 can clone it out of `LogicalDevice` before dropping the
     /// global backend lock.
     pub ledger: Arc<Mutex<DeviceLedger>>,
-    /// Deferred deletion queue for resources that are still in-flight
-    pub deletion_queue: DeletionQueue,
+    /// Deferred deletion queue for resources that are still in-flight.
+    /// `Mutex` so `LogicalDevice` can be `Arc`-wrapped (Phase 5a): callers that
+    /// previously took `&mut LogicalDevice` now lock this field individually.
+    pub deletion_queue: Mutex<DeletionQueue>,
     /// Device-global submission sequence (shared value space; contexts signal their own semaphores).
     /// `Arc` allows submit paths to clone the counter out before dropping device/state borrows
     /// (required for Phase 5 lock-free submit).
     pub timeline_next: Arc<AtomicU64>,
     /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
-    pub retired_floor: u64,
+    /// `AtomicU64` so `LogicalDevice` can be `Arc`-wrapped; updated with `fetch_max`.
+    pub retired_floor: AtomicU64,
 
     /// Optional driver pipeline cache persisted to disk (`~/.cache/goldy/pipeline_cache_<adapter>.bin`).
     pub pipeline_cache: vk::PipelineCache,
@@ -1085,7 +1094,7 @@ impl DeletionQueue {
 /// `ledger` must be the already-locked `DeviceLedger` from `ld.ledger`; passing it separately
 /// avoids holding the ledger lock while the caller re-locks it (double-lock hazard).
 pub(crate) fn destroy_pending_deletion(
-    ld: &mut LogicalDevice,
+    ld: &LogicalDevice,
     ledger: &mut DeviceLedger,
     resource: PendingDeletion,
 ) {
@@ -1102,6 +1111,10 @@ pub(crate) fn destroy_pending_deletion(
 
     let device = &ld.device;
     let bind_queue = ld.sparse_binding_queue;
+    // Lock sparse_page_pool once for the duration of this call (needed when freeing
+    // sparse memory pages). Held only here; no other code path holds it concurrently
+    // while the outer backend lock serialises all submits.
+    let mut pool_guard = ld.sparse_page_pool.lock().unwrap();
 
     unsafe {
         match resource {
@@ -1135,7 +1148,7 @@ pub(crate) fn destroy_pending_deletion(
                             tracing::warn!(?e, "sparse unbind on buffer destroy failed");
                         }
                         for (_res_off, mem, mem_off) in &td.binds {
-                            if let Some(pool) = ld.sparse_page_pool.as_mut() {
+                            if let Some(pool) = pool_guard.as_mut() {
                                 pool.free_page(*mem, *mem_off);
                             }
                         }
@@ -1197,7 +1210,7 @@ pub(crate) fn destroy_pending_deletion(
                         tracing::warn!(?e, "sparse unbind on replaced buffer failed");
                     }
                     for (_res_off, mem, mem_off) in &binds {
-                        if let Some(pool) = ld.sparse_page_pool.as_mut() {
+                        if let Some(pool) = pool_guard.as_mut() {
                             pool.free_page(*mem, *mem_off);
                         }
                     }
@@ -1238,11 +1251,10 @@ pub(crate) fn destroy_pending_deletion(
 impl LogicalDevice {
     /// Drop deferred resources whose timeline barrier is `<= completed`.
     ///
-    /// Locks the ledger internally so that `destroy_pending_deletion` can
-    /// route descriptor-slot reclamation through the ledger without a
-    /// double-lock hazard.
-    pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
-        let drained = self.deletion_queue.drain_up_to(completed);
+    /// Locks the deletion queue and ledger internally; takes `&self` so this
+    /// can be called through an `Arc<LogicalDevice>` (Phase 5a).
+    pub(crate) fn process_deletion_queue_up_to(&self, completed: u64) {
+        let drained = self.deletion_queue.lock().unwrap().drain_up_to(completed);
         if drained.is_empty() {
             return;
         }
@@ -1252,7 +1264,29 @@ impl LogicalDevice {
             destroy_pending_deletion(self, &mut ledger, r);
         }
     }
+
+    /// Drain all pending deletions (device teardown).
+    pub(crate) fn flush_deletion_queue(&self) {
+        let batch = self.deletion_queue.lock().unwrap().flush_all_drain();
+        if batch.is_empty() {
+            return;
+        }
+        let ledger_arc = Arc::clone(&self.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
+        for r in batch {
+            destroy_pending_deletion(self, &mut ledger, r);
+        }
+    }
 }
+
+/// `Arc`-wrapped logical device — cloned out of `VulkanState` before dropping the
+/// global backend lock so submit paths can hold per-device state without borrowing
+/// all of `VulkanState` (Phase 5).
+pub(crate) type SharedLogicalDevice = Arc<LogicalDevice>;
+
+/// `Arc<Mutex>`-wrapped per-context state — allows submit paths to lock only the
+/// submitting context rather than all of `VulkanState` (Phase 5).
+pub(crate) type SharedSubmissionContext = Arc<Mutex<SubmissionContext>>;
 
 /// Consolidated Vulkan backend state.
 /// This holds all the resources and state for the Vulkan backend.
@@ -1260,9 +1294,9 @@ pub(super) struct VulkanState {
     pub entry: ash::Entry,
     pub instance: ash::Instance,
     pub physical_devices: Vec<PhysicalDeviceInfo>,
-    pub devices: HashMap<DeviceHandle, LogicalDevice>,
+    pub devices: HashMap<DeviceHandle, SharedLogicalDevice>,
     pub next_device_handle: DeviceHandle,
-    pub contexts: HashMap<super::ContextHandle, SubmissionContext>,
+    pub contexts: HashMap<super::ContextHandle, SharedSubmissionContext>,
     pub next_context_id: super::ContextHandle,
     pub buffers: HashMap<BufferHandle, BufferState>,
     pub next_buffer_handle: BufferHandle,

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -679,6 +679,28 @@ pub(crate) struct LogicalDevice {
     /// Optional driver pipeline cache persisted to disk (`~/.cache/goldy/pipeline_cache_<adapter>.bin`).
     pub pipeline_cache: vk::PipelineCache,
 
+    /// Serialises all `vkQueueSubmit2` calls on this device's queue.
+    ///
+    /// The Vulkan spec marks `vkQueueSubmit2`'s `queue` parameter as externally
+    /// synchronized (VUID-vkQueueSubmit2-queue-parameter): concurrent calls from
+    /// different threads on the same `VkQueue` are undefined behaviour.  The outer
+    /// `Arc<Mutex<Box<dyn GpuBackend>>>` currently provides this serialisation as a
+    /// side-effect, but Phase 5c will replace that coarse lock with fine-grained
+    /// per-context/device locks, leaving the queue unprotected unless we insert an
+    /// explicit guard here.
+    ///
+    /// Each submit call clones this `Arc`, locks it for the duration of
+    /// `vkQueueSubmit2`, then drops the guard — so only the GPU call itself
+    /// serialises; recording and post-submit bookkeeping run concurrently.
+    ///
+    /// NOTE (Phase 5d — intentionally deferred): giving each `SubmissionContext`
+    /// its own `VkQueue` (requested from the same family) would let submits from
+    /// different contexts proceed in parallel without ever touching this lock.
+    /// That approach is deferred because queue count is a driver resource and the
+    /// practical benefit over this per-device lock is small with today's single-
+    /// context-per-device workloads.
+    pub queue_lock: Arc<Mutex<()>>,
+
     /// Timestamp query support (`VkPhysicalDeviceLimits::timestamp_compute_and_graphics`).
     pub vk_timestamp_compute_and_graphics: bool,
     pub vk_timestamp_period_ns: f32,

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -471,6 +471,19 @@ pub(crate) struct SubmissionContext {
     /// Per-context pool for texture-upload staging buffers.
     /// Eliminates per-frame vkAllocateMemory / vkFreeMemory for WriteTexture.
     pub texture_staging_pool: super::staging::TextureStagingPool,
+    /// Per-context deferred deletion queue.
+    ///
+    /// Holds resources whose GPU lifetime is bounded exclusively by **this**
+    /// context's timeline semaphore (e.g. submit-internal temporaries).  Drained
+    /// on each submit using `ctx_completed_value` — never via `device_retired` —
+    /// so no other context's progress can block reclaim here.
+    ///
+    /// User-destroyed resources (buffers, textures, …) whose context is unknown
+    /// at destroy time still go to `LogicalDevice::deletion_queue` and are drained
+    /// in the explicit-wait paths (`wait_until`, `flush_deferred_deletions`,
+    /// surface acquire).  As a result the submit hot path no longer touches the
+    /// device-level queue at all, which is required for Phase 5 (lock-free submit).
+    pub deletion_queue: DeletionQueue,
 }
 
 /// A logical Vulkan device with associated resources.

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -19,7 +19,7 @@ use crate::types::{DepthFormat, TextureFormat};
 use ash::vk;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Maximum number of descriptors per resource type in the global bindless set
 pub const MAX_BINDLESS_RESOURCES: u32 = 16384;
@@ -39,6 +39,140 @@ pub(crate) struct PendingSlotReclamation {
     pub slot: SlotKey,
     /// `(context_handle, min_seq_that_must_retire)`
     pub requirements: Vec<(super::ContextHandle, u64)>,
+}
+
+/// Device-shared descriptor-heap ledger.
+///
+/// Contains the irreducible shared state for bindless slot allocation: the
+/// `ResourceRegistry` (descriptor slot allocator), the per-context
+/// `slot_last_seen` reference table, and the `pending_slot_reclamations`
+/// list.  Wrapped in `Arc<Mutex<DeviceLedger>>` on `LogicalDevice` so that
+/// submit paths can hold the ledger lock independently of the global backend
+/// mutex (Phase 4), and can clone the `Arc` before dropping the global lock
+/// (Phase 5).
+pub(crate) struct DeviceLedger {
+    /// Registry tracking resource indices in the global descriptor set.
+    pub resource_registry: ResourceRegistry,
+    /// Maps bindless slot → per-context last-submitted seq that referenced it.
+    /// Updated at every submit. Entry removed when the slot is queued for reclamation.
+    pub slot_last_seen: HashMap<SlotKey, HashMap<super::ContextHandle, u64>>,
+    /// Slots waiting for referencing contexts to retire before returning to free lists.
+    pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
+}
+
+impl DeviceLedger {
+    pub(crate) fn new() -> Self {
+        Self {
+            resource_registry: ResourceRegistry::new(),
+            slot_last_seen: HashMap::new(),
+            pending_slot_reclamations: Vec::new(),
+        }
+    }
+
+    /// Record that `ctx` submitted `seq` referencing each bindless slot in `slots`.
+    pub(crate) fn record_slot_usage(
+        &mut self,
+        ctx: super::ContextHandle,
+        seq: u64,
+        slots: impl IntoIterator<Item = SlotKey>,
+    ) {
+        for slot in slots {
+            self.slot_last_seen
+                .entry(slot)
+                .or_default()
+                .entry(ctx)
+                .and_modify(|v| *v = (*v).max(seq))
+                .or_insert(seq);
+        }
+    }
+
+    /// Queue a slot for deferred reclamation once all referencing contexts retire.
+    pub(crate) fn queue_slot_reclamation(&mut self, slot: SlotKey) {
+        let requirements: Vec<_> = self
+            .slot_last_seen
+            .remove(&slot)
+            .map(|m| m.into_iter().collect())
+            .unwrap_or_default();
+        if requirements.is_empty() {
+            self.resource_registry.free_slot(slot);
+        } else {
+            self.pending_slot_reclamations
+                .push(PendingSlotReclamation { slot, requirements });
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed buffer handle.
+    pub(crate) fn reclaim_buffer_slots(&mut self, handle: BufferHandle) {
+        let slots = self.resource_registry.extract_buffer_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed texture handle.
+    pub(crate) fn reclaim_texture_slots(&mut self, handle: TextureHandle) {
+        let slots = self.resource_registry.extract_texture_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    /// Reclaim all descriptor slots for a destroyed sampler handle.
+    pub(crate) fn reclaim_sampler_slots(&mut self, handle: SamplerHandle) {
+        let slots = self.resource_registry.extract_sampler_slots(handle);
+        for slot in slots {
+            self.queue_slot_reclamation(slot);
+        }
+    }
+
+    /// Return pending slots to the free list once every referencing context has retired.
+    ///
+    /// Takes a pre-snapshotted map of `(context_handle → completed_timeline_value)` rather
+    /// than querying semaphores directly, so this method is safe to call while holding the
+    /// ledger lock without creating a semaphore-query → ledger-lock ordering hazard.
+    /// A missing entry means the context has been destroyed and is considered fully retired.
+    pub(crate) fn drain_ready_slot_reclamations(
+        &mut self,
+        completed_values: &HashMap<super::ContextHandle, u64>,
+    ) {
+        let mut i = 0;
+        while i < self.pending_slot_reclamations.len() {
+            let ready = self.pending_slot_reclamations[i].requirements.iter().all(
+                |(ctx_id, required_seq)| {
+                    completed_values
+                        .get(ctx_id)
+                        .is_none_or(|&v| v >= *required_seq)
+                },
+            );
+            if ready {
+                let entry = self.pending_slot_reclamations.swap_remove(i);
+                self.resource_registry.free_slot(entry.slot);
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+/// Snapshot the completed timeline value for every context belonging to `for_device`.
+///
+/// Call this **before** locking the ledger so `drain_ready_slot_reclamations` has the
+/// retirement data it needs without touching live context state while the ledger is locked.
+pub(super) fn snapshot_context_completed_values(
+    device: &ash::Device,
+    contexts: &HashMap<super::ContextHandle, SubmissionContext>,
+    for_device: super::DeviceHandle,
+) -> HashMap<super::ContextHandle, u64> {
+    contexts
+        .iter()
+        .filter(|(_, sc)| sc.device == for_device)
+        .map(|(&id, sc)| unsafe {
+            let v = device
+                .get_semaphore_counter_value(sc.timeline_semaphore)
+                .unwrap_or(0);
+            (id, v)
+        })
+        .collect()
 }
 
 /// Binding indices within the global bindless descriptor set
@@ -520,14 +654,12 @@ pub(crate) struct LogicalDevice {
     pub bindless_descriptor_set: Option<vk::DescriptorSet>,
     /// Pipeline layout for bindless rendering (includes the global set)
     pub bindless_pipeline_layout: Option<vk::PipelineLayout>,
-    /// Registry tracking resource indices in the global descriptor set
-    pub resource_registry: ResourceRegistry,
+    /// Descriptor-heap ledger: `ResourceRegistry` + slot reference-tracking.
+    /// `Arc` so Phase 5 can clone it out of `LogicalDevice` before dropping the
+    /// global backend lock.
+    pub ledger: Arc<Mutex<DeviceLedger>>,
     /// Deferred deletion queue for resources that are still in-flight
     pub deletion_queue: DeletionQueue,
-    /// Maps bindless slot → per-context last-submitted seq that referenced it.
-    pub slot_last_seen: HashMap<SlotKey, HashMap<super::ContextHandle, u64>>,
-    /// Slots waiting for referencing contexts to retire before returning to free lists.
-    pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
     /// Device-global submission sequence (shared value space; contexts signal their own semaphores).
     /// `Arc` allows submit paths to clone the counter out before dropping device/state borrows
     /// (required for Phase 5 lock-free submit).
@@ -949,14 +1081,21 @@ impl DeletionQueue {
 }
 
 /// Deferred-delete one entry ([`SparseBufferTeardown`] needs [`LogicalDevice`] for the page pool).
-pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: PendingDeletion) {
+///
+/// `ledger` must be the already-locked `DeviceLedger` from `ld.ledger`; passing it separately
+/// avoids holding the ledger lock while the caller re-locks it (double-lock hazard).
+pub(crate) fn destroy_pending_deletion(
+    ld: &mut LogicalDevice,
+    ledger: &mut DeviceLedger,
+    resource: PendingDeletion,
+) {
     match &resource {
         PendingDeletion::Buffer { buffer_handle, .. }
         | PendingDeletion::BufferView { buffer_handle } => {
-            ld.reclaim_buffer_slots(*buffer_handle);
+            ledger.reclaim_buffer_slots(*buffer_handle);
         }
         PendingDeletion::Texture { texture_handle, .. } => {
-            ld.reclaim_texture_slots(*texture_handle);
+            ledger.reclaim_texture_slots(*texture_handle);
         }
         _ => {}
     }
@@ -1097,88 +1236,20 @@ pub(crate) fn destroy_pending_deletion(ld: &mut LogicalDevice, resource: Pending
 }
 
 impl LogicalDevice {
-    pub(crate) fn record_slot_usage(
-        &mut self,
-        ctx: super::ContextHandle,
-        seq: u64,
-        slots: impl IntoIterator<Item = SlotKey>,
-    ) {
-        for slot in slots {
-            self.slot_last_seen
-                .entry(slot)
-                .or_default()
-                .entry(ctx)
-                .and_modify(|v| *v = (*v).max(seq))
-                .or_insert(seq);
-        }
-    }
-
-    pub(crate) fn queue_slot_reclamation(&mut self, slot: SlotKey) {
-        let requirements: Vec<_> = self
-            .slot_last_seen
-            .remove(&slot)
-            .map(|m| m.into_iter().collect())
-            .unwrap_or_default();
-        if requirements.is_empty() {
-            self.resource_registry.free_slot(slot);
-        } else {
-            self.pending_slot_reclamations
-                .push(PendingSlotReclamation { slot, requirements });
-        }
-    }
-
-    pub(crate) fn reclaim_buffer_slots(&mut self, handle: BufferHandle) {
-        let slots = self.resource_registry.extract_buffer_slots(handle);
-        for slot in slots {
-            self.queue_slot_reclamation(slot);
-        }
-    }
-
-    pub(crate) fn reclaim_texture_slots(&mut self, handle: TextureHandle) {
-        let slots = self.resource_registry.extract_texture_slots(handle);
-        for slot in slots {
-            self.queue_slot_reclamation(slot);
-        }
-    }
-
-    /// Reclaim all descriptor slots for a destroyed sampler handle.
-    pub(crate) fn reclaim_sampler_slots(&mut self, handle: SamplerHandle) {
-        let slots = self.resource_registry.extract_sampler_slots(handle);
-        for slot in slots {
-            self.queue_slot_reclamation(slot);
-        }
-    }
-
-    pub(crate) fn drain_ready_slot_reclamations(
-        &mut self,
-        contexts: &HashMap<super::ContextHandle, SubmissionContext>,
-    ) {
-        let mut i = 0;
-        while i < self.pending_slot_reclamations.len() {
-            let ready = self.pending_slot_reclamations[i].requirements.iter().all(
-                |(ctx_id, required_seq)| {
-                    contexts.get(ctx_id).is_none_or(|ctx| unsafe {
-                        self.device
-                            .get_semaphore_counter_value(ctx.timeline_semaphore)
-                            .unwrap_or(0)
-                            >= *required_seq
-                    })
-                },
-            );
-            if ready {
-                let entry = self.pending_slot_reclamations.swap_remove(i);
-                self.resource_registry.free_slot(entry.slot);
-            } else {
-                i += 1;
-            }
-        }
-    }
-
-    /// Drop deferred resources whose barrier is `<= completed` (device-global retirement horizon).
+    /// Drop deferred resources whose timeline barrier is `<= completed`.
+    ///
+    /// Locks the ledger internally so that `destroy_pending_deletion` can
+    /// route descriptor-slot reclamation through the ledger without a
+    /// double-lock hazard.
     pub(crate) fn process_deletion_queue_up_to(&mut self, completed: u64) {
         let drained = self.deletion_queue.drain_up_to(completed);
+        if drained.is_empty() {
+            return;
+        }
+        let ledger_arc = Arc::clone(&self.ledger);
+        let mut ledger = ledger_arc.lock().unwrap();
         for r in drained {
-            destroy_pending_deletion(self, r);
+            destroy_pending_deletion(self, &mut ledger, r);
         }
     }
 }

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -18,6 +18,8 @@ use crate::timeline::TimelineValue;
 use crate::types::{DepthFormat, TextureFormat};
 use ash::vk;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 /// Maximum number of descriptors per resource type in the global bindless set
 pub const MAX_BINDLESS_RESOURCES: u32 = 16384;
@@ -507,7 +509,9 @@ pub(crate) struct LogicalDevice {
     /// Slots waiting for referencing contexts to retire before returning to free lists.
     pub pending_slot_reclamations: Vec<PendingSlotReclamation>,
     /// Device-global submission sequence (shared value space; contexts signal their own semaphores).
-    pub timeline_next: u64,
+    /// `Arc` allows submit paths to clone the counter out before dropping device/state borrows
+    /// (required for Phase 5 lock-free submit).
+    pub timeline_next: Arc<AtomicU64>,
     /// Minimum completed horizon after a context is destroyed (never lowers `device_retired`).
     pub retired_floor: u64,
 

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -464,6 +464,13 @@ pub(crate) struct SubmissionContext {
     pub retained_compute_cb: Option<RetainedVkCb>,
     /// Command buffers to free once this context's timeline reaches the key.
     pub timeline_cmd_buffers: std::collections::HashMap<u64, Vec<vk::CommandBuffer>>,
+    /// Per-context staging belt for DEVICE_LOCAL WriteBuffer uploads.
+    /// Pools HOST_VISIBLE chunks across submits so no staging memory is reused
+    /// before its GPU copy finishes (keyed by this context's timeline values).
+    pub staging_belt: super::staging::StagingBelt,
+    /// Per-context pool for texture-upload staging buffers.
+    /// Eliminates per-frame vkAllocateMemory / vkFreeMemory for WriteTexture.
+    pub texture_staging_pool: super::staging::TextureStagingPool,
 }
 
 /// A logical Vulkan device with associated resources.
@@ -1194,13 +1201,6 @@ pub(super) struct VulkanState {
     /// Per-submission fences for non-blocking compute; token -> (device, `VkFence`, `Option<VkCommandBuffer>`).
     /// The command buffer is kept alive until the fence signals (Vulkan spec: must not free a pending CB).
     pub compute_fence_pool: HashMap<u64, (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>)>,
-    /// Per-device pools that recycle texture-upload staging buffers across frames.
-    /// Entries are released with a GPU timeline value and reclaimed once that
-    /// timeline completes, avoiding per-frame vkAllocateMemory / vkFreeMemory.
-    pub texture_staging_pools:
-        HashMap<DeviceHandle, crate::backend::vulkan::staging::TextureStagingPool>,
-    /// Per-device staging belts for batched WriteBuffer uploads.
-    pub(super) staging_belts: HashMap<DeviceHandle, crate::backend::vulkan::staging::StagingBelt>,
     /// Set to `true` when any Vulkan call returns `VK_ERROR_DEVICE_LOST`.
     /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.
     pub device_lost: std::sync::atomic::AtomicBool,

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -18,7 +18,7 @@ use crate::timeline::TimelineValue;
 use crate::types::{DepthFormat, TextureFormat};
 use ash::vk;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 /// Maximum number of descriptors per resource type in the global bindless set
@@ -862,7 +862,7 @@ pub(crate) struct RenderTargetState {
     /// Command buffer for rendering
     pub command_buffer: vk::CommandBuffer,
     /// Track if we've rendered (for readback validation)
-    pub has_rendered: bool,
+    pub has_rendered: AtomicBool,
 }
 
 /// GPU texture state.
@@ -884,9 +884,20 @@ pub(crate) struct TextureState {
     /// For `TextureKind::DirectInterpolated` textures, the sampled-texture (SRV) slot.
     pub sampled_bindless_index: Option<u32>,
     /// Current image layout (for subregion writes / transitions)
-    pub current_layout: vk::ImageLayout,
+    pub current_layout: AtomicI32,
     /// Sub-allocated from a transient heap; `memory` is shared with the heap.
     pub transient_heap_suballoc: bool,
+}
+
+impl TextureState {
+    pub fn image_layout(&self) -> vk::ImageLayout {
+        vk::ImageLayout::from_raw(self.current_layout.load(Ordering::Relaxed))
+    }
+
+    pub fn set_image_layout(&self, layout: vk::ImageLayout) {
+        self.current_layout
+            .store(layout.as_raw(), Ordering::Relaxed);
+    }
 }
 
 /// GPU sampler state.
@@ -1310,6 +1321,12 @@ pub(crate) type SharedLogicalDevice = Arc<LogicalDevice>;
 /// submitting context rather than all of `VulkanState` (Phase 5).
 pub(crate) type SharedSubmissionContext = Arc<Mutex<SubmissionContext>>;
 
+/// Per-submit fence and optional command-buffer kept alive until completion.
+pub(super) type ComputeFencePoolEntry = (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>);
+
+/// Per-backend non-blocking compute fence pool keyed by submission token.
+pub(super) type ComputeFencePool = Mutex<HashMap<u64, ComputeFencePoolEntry>>;
+
 /// Consolidated Vulkan backend state.
 /// This holds all the resources and state for the Vulkan backend.
 pub(super) struct VulkanState {
@@ -1340,7 +1357,7 @@ pub(super) struct VulkanState {
     pub slang_compiler: crate::slang::SlangCompiler,
     /// Per-submission fences for non-blocking compute; token -> (device, `VkFence`, `Option<VkCommandBuffer>`).
     /// The command buffer is kept alive until the fence signals (Vulkan spec: must not free a pending CB).
-    pub compute_fence_pool: HashMap<u64, (DeviceHandle, vk::Fence, Option<vk::CommandBuffer>)>,
+    pub compute_fence_pool: ComputeFencePool,
     /// Set to `true` when any Vulkan call returns `VK_ERROR_DEVICE_LOST`.
     /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.
     pub device_lost: std::sync::atomic::AtomicBool,

--- a/tests/compute_integration.rs
+++ b/tests/compute_integration.rs
@@ -3451,7 +3451,7 @@ fn two_contexts_reclaim_independently() {
     let instance = Instance::new().expect("instance");
     let device = request_default_device(&instance);
     let ctx_a = submission_context(&device);
-    let ctx_b = submission_context(&device);
+    let _ctx_b = submission_context(&device);
 
     // Allocate a buffer and do some work on ctx_a.
     let buf = device


### PR DESCRIPTION
Updated the handling of the timeline_next field across multiple files in the Vulkan backend to utilize atomic operations for improved thread safety. This change enhances synchronization during command submission and resource reclamation, contributing to better stability and performance of the Vulkan resource management system.