### PR TITLE
Add lavapipe CI container image and GHCR publish workflow (#195, PR 1)

### DIFF
--- a/.github/workflows/publish-lavapipe-ci-image.yml
+++ b/.github/workflows/publish-lavapipe-ci-image.yml
@@ -1,0 +1,66 @@
+# Build and publish the lavapipe CI container to GHCR.
+# CI jobs (test-vulkan, python-linux, cpp-linux) pull this image instead of
+# running apt-get upgrade/install on every run.
+#
+# Bootstrap: merge this workflow first, run workflow_dispatch to seed :latest,
+# then merge CI changes that reference ghcr.io/koubaa/goldy/lavapipe-ci:latest.
+
+name: Publish lavapipe CI image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/lavapipe-ci/**'
+      - '.github/workflows/publish-lavapipe-ci-image.yml'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/koubaa/goldy/lavapipe-ci
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/lavapipe-ci
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test and tag Mesa version
+        run: |
+          docker pull ${{ env.IMAGE }}:latest
+          docker run --rm ${{ env.IMAGE }}:latest bash -c \
+            'DISPLAY= vulkaninfo --summary' | tee vulkaninfo-summary.txt
+          grep -E 'apiVersion[[:space:]]+= 1\.4\.' vulkaninfo-summary.txt
+          grep -Ei 'deviceName.*(llvmpipe|lavapipe)' vulkaninfo-summary.txt
+
+          MESA_VERSION="$(docker run --rm ${{ env.IMAGE }}:latest dpkg-query -W -f='${Version}' mesa-vulkan-drivers)"
+          echo "Mesa version: ${MESA_VERSION}"
+          docker tag ${{ env.IMAGE }}:latest ${{ env.IMAGE }}:mesa-${MESA_VERSION}
+          docker push ${{ env.IMAGE }}:mesa-${MESA_VERSION}

--- a/docker/lavapipe-ci/Dockerfile
+++ b/docker/lavapipe-ci/Dockerfile
@@ -1,0 +1,47 @@
+# CI image for Goldy lavapipe (Mesa software Vulkan) jobs on GitHub Actions.
+# Bakes in Mesa 25.0+ / Vulkan 1.4 so CI jobs skip repeated apt-get upgrade/install.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get upgrade -y mesa-vulkan-drivers libgl1-mesa-dri \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        g++-13 \
+        git \
+        libgl1-mesa-dri \
+        libvulkan-dev \
+        libvulkan1 \
+        libxcb-render0-dev \
+        libxcb-shape0-dev \
+        libxcb-xfixes0-dev \
+        libxcb1-dev \
+        libxkbcommon-dev \
+        mesa-vulkan-drivers \
+        ninja-build \
+        pkg-config \
+        vulkan-tools \
+        vulkan-validationlayers \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VK_LAYER_PATH=""
+ENV CXX=g++-13
+
+# Resolve lavapipe ICD at build time (Ubuntu may ship lvp_icd.json or lvp_icd.x86_64.json).
+RUN LVP_ICD="$(find /usr/share/vulkan/icd.d -name 'lvp_icd*.json' | head -1)" \
+    && test -n "$LVP_ICD" \
+    && ln -sf "$LVP_ICD" /etc/goldy-lavapipe-icd.json \
+    && echo "VK_ICD_FILENAMES=/etc/goldy-lavapipe-icd.json" >> /etc/environment
+ENV VK_ICD_FILENAMES=/etc/goldy-lavapipe-icd.json
+
+# Fail the image build if lavapipe does not expose Vulkan 1.4.
+RUN DISPLAY= vulkaninfo --summary 2>&1 | tee /tmp/vulkaninfo-summary.txt \
+    && grep -E 'apiVersion[[:space:]]+= 1\.4\.' /tmp/vulkaninfo-summary.txt \
+    && grep -Ei 'deviceName.*(llvmpipe|lavapipe)' /tmp/vulkaninfo-summary.txt
+
+WORKDIR /workspace


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First half of #195: define a pre-built lavapipe CI container and publish it to GHCR. **No changes to `ci.yml` yet** — CI still uses apt-get until this image is seeded.

### Added

- **`docker/lavapipe-ci/Dockerfile`** — Ubuntu 24.04 image with:
  - Mesa 25+ upgrade (`mesa-vulkan-drivers`, `libgl1-mesa-dri`)
  - Union of Vulkan/XCB deps used by `test-vulkan`, `python-linux`, and `cpp-linux`
  - Build tooling: `cmake`, `ninja-build`, `g++-13`, `build-essential`, etc.
  - Baked env: `VK_LAYER_PATH=""`, `CXX=g++-13`, `VK_ICD_FILENAMES` via stable symlink to discovered `lvp_icd*.json`
  - Build-time smoke test: `vulkaninfo --summary` must report device `apiVersion = 1.4.x` and llvmpipe

- **`.github/workflows/publish-lavapipe-ci-image.yml`** — Builds and pushes `ghcr.io/koubaa/goldy/lavapipe-ci` with tags:
  - `:latest`
  - `:sha-<commit>`
  - `:mesa-<version>` (after post-push smoke test)
  - Triggers: push to `main` (Dockerfile/workflow paths), weekly cron, `workflow_dispatch`

### Validation

- Host-side validation on Ubuntu 24.04: same apt packages + `vulkaninfo --summary` reports **apiVersion 1.4.318** with llvmpipe (Mesa 25.2.8).
- Docker build could not complete on the Cloud VM (overlayfs mount limitation); GHA `ubuntu-latest` runners should build normally.

### Bootstrap sequence (after merge)

1. Merge this PR.
2. Run **Publish lavapipe CI image** via `workflow_dispatch` to seed `:latest`.
3. Make the GHCR package **public** (Settings → Package visibility) so fork PRs can pull without auth.
4. Merge PR 2 switching `test-vulkan`, `python-linux`, and `cpp-linux` to `container:` and removing apt-get blocks.

### Follow-up (PR 2)

- Wire `ci.yml` jobs to `ghcr.io/koubaa/goldy/lavapipe-ci:latest`
- Remove duplicated apt/verify steps
- Optional: pin image digest for reproducibility

Fixes #195 (partial — image definition + publish only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8707fac4-b75e-44b1-ae26-9f1766b001f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8707fac4-b75e-44b1-ae26-9f1766b001f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

