### PR TITLE
Publish lavapipe CI image only on manual dispatch

### DIFF
--- a/.github/workflows/publish-lavapipe-ci-image.yml
+++ b/.github/workflows/publish-lavapipe-ci-image.yml
@@ -2,19 +2,12 @@
 # CI jobs (test-vulkan, python-linux, cpp-linux) pull this image instead of
 # running apt-get upgrade/install on every run.
 #
-# Bootstrap: merge this workflow first, run workflow_dispatch to seed :latest,
-# then merge CI changes that reference ghcr.io/koubaa/goldy/lavapipe-ci:latest.
+# Run manually via workflow_dispatch when the image should be rebuilt
+# (Dockerfile changes, Mesa updates, etc.).
 
 name: Publish lavapipe CI image
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docker/lavapipe-ci/**'
-      - '.github/workflows/publish-lavapipe-ci-image.yml'
-  schedule:
-    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The publish workflow was configured to run on push to `main` (when Dockerfile/workflow paths change) and on a weekly cron. That was intentional in the original #195 plan, but it caused an automatic run on merge.

This change limits triggers to **`workflow_dispatch` only** — rebuild the GHCR image only when someone runs it manually from the Actions tab.

## Changes

- Remove `push` trigger (paths under `docker/lavapipe-ci/**` and this workflow file)
- Remove weekly `schedule` cron
- Keep `workflow_dispatch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8707fac4-b75e-44b1-ae26-9f1766b001f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8707fac4-b75e-44b1-ae26-9f1766b001f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

