### PR TITLE
Implement VRAM observer system for enhanced resource tracking

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,9 +3,10 @@
 use crate::backend::{BufferHandle, GpuBackend};
 use crate::device::Device;
 use crate::types::{BufferFlags, BufferKind, ResourceAccess, ResourceCategory, ResourceHandle};
-use crate::vram_allocator::{ParcelType, VramAllocator};
+use crate::vram_allocator::ParcelType;
+use crate::vram_observer::{ParcelDeed, VramFreeEvent};
 use anyhow::Result;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 
 /// Types allowed as elements in [`Device::alloc_buffer_with_data`](crate::Device::alloc_buffer_with_data) and [`BufferPool::alloc_with_data`].
 ///
@@ -45,8 +46,8 @@ pub struct Buffer {
     peak_committed_bytes: u64,
     /// Number of completed [`Self::resize_to`] / [`Self::resize_to_uninitialized`] calls.
     resize_count: u32,
-    /// Allocator deed for accounting on drop; set only when allocated via [`Device::alloc_buffer`].
-    deed: Option<Weak<dyn VramAllocator>>,
+    /// Accounting deed for observer + allocator notification on drop.
+    deed: Option<ParcelDeed>,
 }
 
 #[allow(dead_code)]
@@ -56,8 +57,8 @@ impl Buffer {
         self.handle
     }
 
-    /// Attach the allocator deed (called from [`Device::alloc_buffer`] paths only).
-    pub(crate) fn set_deed(&mut self, deed: Weak<dyn VramAllocator>) {
+    /// Attach the accounting deed (called from [`Device::alloc_buffer`] paths only).
+    pub(crate) fn set_deed(&mut self, deed: ParcelDeed) {
         self.deed = Some(deed);
     }
 
@@ -480,8 +481,12 @@ impl Drop for Buffer {
         tracing::trace!(size = self.size, access = ?self.access, "Destroying buffer");
         let mut backend = self.backend.lock().unwrap();
         backend.destroy_buffer(self.handle);
-        if let Some(allocator) = self.deed.as_ref().and_then(Weak::upgrade) {
-            allocator.notify_freed(self.allocated_size, self.size, ParcelType::Buffer);
+        if let Some(deed) = self.deed.as_ref() {
+            deed.notify_freed(&VramFreeEvent {
+                reserved: self.allocated_size,
+                committed: self.size,
+                kind: ParcelType::Buffer,
+            });
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -300,6 +300,7 @@ impl Adapter {
                 adapter: self.clone(),
                 library_registry: Arc::new(Mutex::new(registry)),
                 vram_allocator: Arc::new(crate::vram_allocator::DefaultVramAllocator::new()),
+                resource_hub: crate::vram_observer::ResourceHub::new(),
                 owns_backend_device: true,
             }),
         })
@@ -425,6 +426,7 @@ pub(crate) struct DeviceInner {
     adapter: Adapter,
     library_registry: Arc<Mutex<ShaderLibraryRegistry>>,
     vram_allocator: Arc<dyn crate::vram_allocator::VramAllocator>,
+    resource_hub: Arc<crate::vram_observer::ResourceHub>,
     /// When `false`, this [`Device`] is a logical alias (e.g. [`Device::with_vram_allocator`]);
     /// dropping it must not call [`GpuBackend::destroy_device`] on the shared handle.
     pub(crate) owns_backend_device: bool,
@@ -579,9 +581,60 @@ impl Device {
                 adapter: self.inner.adapter.clone(),
                 library_registry: Arc::clone(&self.inner.library_registry),
                 vram_allocator: allocator,
+                resource_hub: Arc::clone(&self.inner.resource_hub),
                 owns_backend_device: false,
             }),
         }
+    }
+
+    /// Register an opt-in VRAM observer (telemetry, budget enforcement, etc.).
+    ///
+    /// When no observers are registered, [`Device::alloc_buffer`] / [`Device::alloc_texture`]
+    /// skip observer notification on the hot path.
+    pub fn add_vram_observer(
+        &self,
+        observer: Arc<dyn crate::vram_observer::VramObserver>,
+    ) -> crate::vram_observer::VramObserverId {
+        self.inner.resource_hub.add_observer(observer)
+    }
+
+    /// Remove a previously registered VRAM observer. Returns `false` if `id` was not found.
+    pub fn remove_vram_observer(&self, id: crate::vram_observer::VramObserverId) -> bool {
+        self.inner.resource_hub.remove_observer(id)
+    }
+
+    /// Returns `true` when at least one VRAM observer is registered.
+    pub fn has_vram_observers(&self) -> bool {
+        self.inner.resource_hub.has_observers()
+    }
+
+    fn parcel_deed(&self) -> crate::vram_observer::ParcelDeed {
+        crate::vram_observer::ParcelDeed {
+            hub: Arc::downgrade(&self.inner.resource_hub),
+            allocator: Arc::downgrade(&self.inner.vram_allocator),
+        }
+    }
+
+    fn finish_buffer_alloc(&self, mut buf: crate::buffer::Buffer) -> anyhow::Result<crate::buffer::Buffer> {
+        if self.inner.resource_hub.has_observers() {
+            let event = crate::vram_observer::VramAllocEvent::from_buffer(&buf);
+            if let Err(e) = self.inner.resource_hub.notify_allocated(&event) {
+                return Err(e);
+            }
+        }
+        buf.set_deed(self.parcel_deed());
+        Ok(buf)
+    }
+
+    fn finish_texture_alloc(&self, mut tex: crate::texture::Texture) -> anyhow::Result<crate::texture::Texture> {
+        if self.inner.resource_hub.has_observers() {
+            let event = crate::vram_observer::VramAllocEvent::from_texture(&tex);
+            if let Err(e) = self.inner.resource_hub.notify_allocated(&event) {
+                return Err(e);
+            }
+        }
+        tex.set_deed(self.parcel_deed());
+        Ok(tex)
     }
 
     /// Allocate a GPU buffer through the device's [`VramAllocator`].
@@ -599,12 +652,11 @@ impl Device {
         element_stride: Option<u32>,
         flags: BufferFlags,
     ) -> anyhow::Result<crate::buffer::Buffer> {
-        let mut buf = self
+        let buf = self
             .inner
             .vram_allocator
             .alloc_buffer(self, size, access, element_stride, flags)?;
-        buf.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
-        Ok(buf)
+        self.finish_buffer_alloc(buf)
     }
 
     /// Allocate a GPU buffer with a capacity hint through the device's [`VramAllocator`].
@@ -617,12 +669,11 @@ impl Device {
         access: BufferKind,
         flags: BufferFlags,
     ) -> anyhow::Result<crate::buffer::Buffer> {
-        let mut buf =
+        let buf =
             self.inner
                 .vram_allocator
                 .alloc_buffer_with_capacity(self, initial_size, expected_max, access, flags)?;
-        buf.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
-        Ok(buf)
+        self.finish_buffer_alloc(buf)
     }
 
     /// Allocate a buffer initialized with typed data (element stride from `T`).
@@ -679,12 +730,11 @@ impl Device {
         access: TextureKind,
         flags: TextureFlags,
     ) -> anyhow::Result<crate::texture::Texture> {
-        let mut tex = self
+        let tex = self
             .inner
             .vram_allocator
             .alloc_texture(self, width, height, format, access, flags)?;
-        tex.set_deed(std::sync::Arc::downgrade(&self.inner.vram_allocator));
-        Ok(tex)
+        self.finish_texture_alloc(tex)
     }
 
     // =======================================================================
@@ -1022,6 +1072,7 @@ impl Device {
                 adapter,
                 library_registry: Arc::new(Mutex::new(registry)),
                 vram_allocator: Arc::new(crate::vram_allocator::DefaultVramAllocator::new()),
+                resource_hub: crate::vram_observer::ResourceHub::new(),
                 owns_backend_device: true,
             }),
         })

--- a/src/device.rs
+++ b/src/device.rs
@@ -618,9 +618,7 @@ impl Device {
     fn finish_buffer_alloc(&self, mut buf: crate::buffer::Buffer) -> anyhow::Result<crate::buffer::Buffer> {
         if self.inner.resource_hub.has_observers() {
             let event = crate::vram_observer::VramAllocEvent::from_buffer(&buf);
-            if let Err(e) = self.inner.resource_hub.notify_allocated(&event) {
-                return Err(e);
-            }
+            self.inner.resource_hub.notify_allocated(&event)?;
         }
         buf.set_deed(self.parcel_deed());
         Ok(buf)
@@ -629,9 +627,7 @@ impl Device {
     fn finish_texture_alloc(&self, mut tex: crate::texture::Texture) -> anyhow::Result<crate::texture::Texture> {
         if self.inner.resource_hub.has_observers() {
             let event = crate::vram_observer::VramAllocEvent::from_texture(&tex);
-            if let Err(e) = self.inner.resource_hub.notify_allocated(&event) {
-                return Err(e);
-            }
+            self.inner.resource_hub.notify_allocated(&event)?;
         }
         tex.set_deed(self.parcel_deed());
         Ok(tex)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,14 @@ pub mod signal;
 pub mod timeline;
 pub mod transient_allocator;
 pub mod vram_allocator;
+pub mod vram_observer;
 pub use error::GoldyError;
 pub use frame_orchestrator::{FrameHandle, FrameOrchestrator, RetiredFrame};
 pub use gpu_guard::GpuGuard;
 pub use parcel::{BytesByKind, MosaicSlot, Parcel};
 pub use retained_pool::{MosaicBuilder, RetainedPool, StampedParcel};
 pub use vram_allocator::{DeferredPayload, ParcelType};
+pub use vram_observer::{VramAllocEvent, VramByteTracker, VramFreeEvent, VramObserver, VramObserverId};
 
 // Re-export main types
 pub use buffer::{Buffer, BufferPool, BufferSource, BufferView, StructuredBufferElement};

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -7,9 +7,10 @@
 use crate::backend::{GpuBackend, TextureHandle};
 use crate::device::Device;
 use crate::types::{ResourceAccess, ResourceCategory, ResourceHandle, TextureFlags, TextureFormat, TextureKind};
-use crate::vram_allocator::{ParcelType, VramAllocator};
+use crate::vram_allocator::ParcelType;
+use crate::vram_observer::{ParcelDeed, VramFreeEvent};
 use anyhow::Result;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 
 /// A GPU texture that can be sampled in shaders.
 ///
@@ -26,13 +27,13 @@ pub struct Texture {
     access: TextureKind,
     flags: TextureFlags,
     owned: bool,
-    /// Allocator deed for accounting on drop; set only when allocated via [`Device::alloc_texture`].
-    deed: Option<Weak<dyn VramAllocator>>,
+    /// Accounting deed for observer + allocator notification on drop.
+    deed: Option<ParcelDeed>,
 }
 
 impl Texture {
-    /// Attach the allocator deed (called from [`Device::alloc_texture`] only).
-    pub(crate) fn set_deed(&mut self, deed: Weak<dyn VramAllocator>) {
+    /// Attach the accounting deed (called from [`Device::alloc_texture`] only).
+    pub(crate) fn set_deed(&mut self, deed: ParcelDeed) {
         self.deed = Some(deed);
     }
 
@@ -381,9 +382,13 @@ impl Drop for Texture {
         if let Ok(mut backend) = self.backend.lock() {
             backend.destroy_texture(self.handle);
         }
-        if let Some(allocator) = self.deed.as_ref().and_then(Weak::upgrade) {
+        if let Some(deed) = self.deed.as_ref() {
             let byte_size = self.byte_size() as u64;
-            allocator.notify_freed(byte_size, byte_size, ParcelType::Texture);
+            deed.notify_freed(&VramFreeEvent {
+                reserved: byte_size,
+                committed: byte_size,
+                kind: ParcelType::Texture,
+            });
         }
     }
 }

--- a/src/vram_allocator.rs
+++ b/src/vram_allocator.rs
@@ -73,10 +73,10 @@ use crate::device::Device;
 use crate::texture::Texture;
 use crate::timeline::TimelineValue;
 use crate::types::*;
+use crate::vram_observer::VramByteTracker;
 use anyhow::Result;
 use std::any::Any;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 
 // -----------------------------------------------------------------------
@@ -384,10 +384,7 @@ impl VramAllocator for DefaultVramAllocator {
 /// ```
 pub struct TrackingVramAllocator {
     inner: Arc<dyn VramAllocator>,
-    /// Signed to handle potential over-decrement from mismatched free notifications
-    /// without panicking. Steady-state value is non-negative.
-    live_bytes: AtomicI64,
-    budget_bytes: Option<u64>,
+    tracker: Arc<VramByteTracker>,
 }
 
 impl TrackingVramAllocator {
@@ -395,8 +392,7 @@ impl TrackingVramAllocator {
     pub fn new(inner: Arc<dyn VramAllocator>) -> Self {
         Self {
             inner,
-            live_bytes: AtomicI64::new(0),
-            budget_bytes: None,
+            tracker: Arc::new(VramByteTracker::new()),
         }
     }
 
@@ -404,24 +400,18 @@ impl TrackingVramAllocator {
     pub fn with_budget(inner: Arc<dyn VramAllocator>, budget_bytes: u64) -> Self {
         Self {
             inner,
-            live_bytes: AtomicI64::new(0),
-            budget_bytes: Some(budget_bytes),
+            tracker: Arc::new(VramByteTracker::with_budget(budget_bytes)),
         }
     }
 
-    fn check_budget(&self, additional: u64) -> Result<()> {
-        if let Some(cap) = self.budget_bytes {
-            let current = self.live_bytes.load(Ordering::Relaxed) as u64;
-            if current.saturating_add(additional) > cap {
-                anyhow::bail!(
-                    "VramAllocator budget exceeded: {current} + {additional} > {cap} \
-                     (allocator={}, budget={})",
-                    self.inner.name(),
-                    bytesize(cap),
-                );
-            }
-        }
-        Ok(())
+    /// Shared byte tracker used for accounting (also implements [`VramObserver`](crate::vram_observer::VramObserver)).
+    pub fn tracker(&self) -> &VramByteTracker {
+        &self.tracker
+    }
+
+    /// Net bytes allocated through this wrapper (allocations minus frees).
+    pub fn allocated_bytes(&self) -> u64 {
+        self.tracker.allocated_bytes()
     }
 }
 
@@ -434,10 +424,9 @@ impl VramAllocator for TrackingVramAllocator {
         element_stride: Option<u32>,
         flags: BufferFlags,
     ) -> Result<Buffer> {
-        self.check_budget(size)?;
+        self.tracker.check_budget_for_alloc(size)?;
         let buf = self.inner.alloc_buffer(device, size, access, element_stride, flags)?;
-        self.live_bytes
-            .fetch_add(buf.allocated_size() as i64, Ordering::Relaxed);
+        self.tracker.add_allocated(buf.allocated_size());
         Ok(buf)
     }
 
@@ -449,12 +438,11 @@ impl VramAllocator for TrackingVramAllocator {
         access: BufferKind,
         flags: BufferFlags,
     ) -> Result<Buffer> {
-        self.check_budget(expected_max.max(initial_size))?;
+        self.tracker.check_budget_for_alloc(expected_max.max(initial_size))?;
         let buf = self
             .inner
             .alloc_buffer_with_capacity(device, initial_size, expected_max, access, flags)?;
-        self.live_bytes
-            .fetch_add(buf.allocated_size() as i64, Ordering::Relaxed);
+        self.tracker.add_allocated(buf.allocated_size());
         Ok(buf)
     }
 
@@ -468,23 +456,23 @@ impl VramAllocator for TrackingVramAllocator {
         flags: TextureFlags,
     ) -> Result<Texture> {
         let estimated = (width as u64) * (height as u64) * (format.bytes_per_pixel() as u64);
-        self.check_budget(estimated)?;
+        self.tracker.check_budget_for_alloc(estimated)?;
         let tex = self.inner.alloc_texture(device, width, height, format, access, flags)?;
-        self.live_bytes.fetch_add(tex.byte_size() as i64, Ordering::Relaxed);
+        self.tracker.add_allocated(tex.byte_size() as u64);
         Ok(tex)
     }
 
     fn notify_freed(&self, reserved: u64, committed: u64, kind: ParcelType) {
-        self.live_bytes.fetch_sub(reserved as i64, Ordering::Relaxed);
+        self.tracker.sub_freed(reserved);
         self.inner.notify_freed(reserved, committed, kind);
     }
 
     fn allocated_bytes(&self) -> u64 {
-        self.live_bytes.load(Ordering::Relaxed).max(0) as u64
+        self.tracker.allocated_bytes()
     }
 
     fn budget(&self) -> Option<u64> {
-        self.budget_bytes
+        self.tracker.budget()
     }
 
     fn name(&self) -> &'static str {
@@ -516,7 +504,7 @@ impl VramAllocator for TrackingVramAllocator {
 // Helpers
 // -----------------------------------------------------------------------
 
-fn bytesize(bytes: u64) -> String {
+pub(crate) fn bytesize(bytes: u64) -> String {
     if bytes >= 1024 * 1024 * 1024 {
         format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
     } else if bytes >= 1024 * 1024 {
@@ -680,6 +668,47 @@ mod tests {
         assert!(tracking.allocated_bytes() >= 2048);
         drop(buf);
         assert_eq!(tracking.allocated_bytes(), 0);
+    }
+
+    #[test]
+    fn device_vram_observer_tracks_device_alloc_path() {
+        use std::sync::Arc;
+
+        use crate::vram_observer::VramByteTracker;
+
+        let device = test_device();
+        assert!(!device.has_vram_observers());
+
+        let tracker = Arc::new(VramByteTracker::new());
+        let id = device.add_vram_observer(tracker.clone());
+        assert!(device.has_vram_observers());
+
+        let buf = device
+            .alloc_buffer(4096, BufferKind::Scattered, None, BufferFlags::empty())
+            .unwrap();
+        assert!(tracker.allocated_bytes() >= 4096);
+        drop(buf);
+        assert_eq!(tracker.allocated_bytes(), 0);
+
+        assert!(device.remove_vram_observer(id));
+        assert!(!device.has_vram_observers());
+    }
+
+    #[test]
+    fn device_vram_observer_budget_rejects_alloc() {
+        use std::sync::Arc;
+
+        use crate::vram_observer::VramByteTracker;
+
+        let device = test_device();
+        let tracker = Arc::new(VramByteTracker::with_budget(8192));
+        device.add_vram_observer(tracker);
+
+        let _buf = device
+            .alloc_buffer(4096, BufferKind::Scattered, None, BufferFlags::empty())
+            .unwrap();
+        let err = device.alloc_buffer(8192, BufferKind::Scattered, None, BufferFlags::empty());
+        assert!(err.is_err(), "observer budget should reject second alloc");
     }
 
     #[test]

--- a/src/vram_allocator.rs
+++ b/src/vram_allocator.rs
@@ -153,7 +153,7 @@ pub enum ParcelType {
 /// memory budgets, placement-heap strategies, and telemetry without changing call sites.
 ///
 /// Methods take `&self` and must be internally synchronized (the trait is `Send + Sync`).
-/// Use [`AtomicI64`] / [`AtomicU64`](std::sync::atomic::AtomicU64) for lock-free counters,
+/// Use [`AtomicI64`](std::sync::atomic::AtomicI64) / [`AtomicU64`](std::sync::atomic::AtomicU64) for lock-free counters,
 /// or a `Mutex` for more complex state.
 pub trait VramAllocator: Send + Sync {
     /// Allocate a GPU buffer.

--- a/src/vram_observer.rs
+++ b/src/vram_observer.rs
@@ -1,0 +1,331 @@
+//! Opt-in VRAM accounting observers for [`Device`](crate::device::Device).
+//!
+//! Clients that want byte-level telemetry or budget enforcement register a
+//! [`VramObserver`] via [`Device::add_vram_observer`](crate::device::Device::add_vram_observer).
+//! When no observers are registered, the hot path skips observer notification entirely.
+//!
+//! [`TrackingVramAllocator`](crate::vram_allocator::TrackingVramAllocator) composes
+//! [`VramByteTracker`] internally for the legacy `with_vram_allocator` wrapper path.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+
+use anyhow::Result;
+
+use crate::buffer::Buffer;
+use crate::texture::Texture;
+use crate::vram_allocator::{ParcelType, VramAllocator};
+
+/// Stable handle returned by [`Device::add_vram_observer`](crate::device::Device::add_vram_observer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VramObserverId(u64);
+
+impl VramObserverId {
+    pub(crate) fn from_raw(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Raw id value (diagnostics only).
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Allocation event emitted after a deed-holding parcel is created through [`Device::alloc_*`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VramAllocEvent {
+    /// Reserved backing size (`Buffer::allocated_size` / texture byte size).
+    pub reserved: u64,
+    /// Committed logical size handed to the runtime.
+    pub committed: u64,
+    pub kind: ParcelType,
+}
+
+impl VramAllocEvent {
+    pub fn from_buffer(buf: &Buffer) -> Self {
+        Self {
+            reserved: buf.allocated_size(),
+            committed: buf.size(),
+            kind: ParcelType::Buffer,
+        }
+    }
+
+    pub fn from_texture(tex: &Texture) -> Self {
+        let byte_size = tex.byte_size() as u64;
+        Self {
+            reserved: byte_size,
+            committed: byte_size,
+            kind: ParcelType::Texture,
+        }
+    }
+}
+
+/// Free event emitted when a deed-holding parcel is dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VramFreeEvent {
+    pub reserved: u64,
+    pub committed: u64,
+    pub kind: ParcelType,
+}
+
+/// Opt-in observer for VRAM allocation and free events on a [`Device`](crate::device::Device).
+pub trait VramObserver: Send + Sync {
+    /// Called after a successful allocation. May reject (e.g. budget enforcement).
+    fn on_allocated(&self, event: &VramAllocEvent) -> Result<()>;
+
+    /// Called when a deed-holding parcel is dropped.
+    fn on_freed(&self, event: &VramFreeEvent);
+}
+
+/// Byte-level VRAM tracker suitable as a [`VramObserver`] or composed by
+/// [`TrackingVramAllocator`](crate::vram_allocator::TrackingVramAllocator).
+pub struct VramByteTracker {
+    live_bytes: AtomicI64,
+    budget_bytes: Option<u64>,
+}
+
+impl VramByteTracker {
+    /// Track allocations with no budget cap.
+    pub fn new() -> Self {
+        Self {
+            live_bytes: AtomicI64::new(0),
+            budget_bytes: None,
+        }
+    }
+
+    /// Track allocations and reject those that would exceed `budget_bytes`.
+    pub fn with_budget(budget_bytes: u64) -> Self {
+        Self {
+            live_bytes: AtomicI64::new(0),
+            budget_bytes: Some(budget_bytes),
+        }
+    }
+
+    /// Net bytes currently tracked (allocations minus frees).
+    pub fn allocated_bytes(&self) -> u64 {
+        self.live_bytes.load(Ordering::Relaxed).max(0) as u64
+    }
+
+    /// Optional byte budget, if configured.
+    pub fn budget(&self) -> Option<u64> {
+        self.budget_bytes
+    }
+
+    fn check_budget(&self, additional: u64) -> Result<()> {
+        if let Some(cap) = self.budget_bytes {
+            let current = self.live_bytes.load(Ordering::Relaxed) as u64;
+            if current.saturating_add(additional) > cap {
+                anyhow::bail!(
+                    "VramObserver budget exceeded: {current} + {additional} > {cap} \
+                     (budget={})",
+                    crate::vram_allocator::bytesize(cap),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Budget check used by [`TrackingVramAllocator`] before delegating allocation.
+    pub(crate) fn check_budget_for_alloc(&self, additional: u64) -> Result<()> {
+        self.check_budget(additional)
+    }
+
+    pub(crate) fn add_allocated(&self, reserved: u64) {
+        self.live_bytes.fetch_add(reserved as i64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn sub_freed(&self, reserved: u64) {
+        self.live_bytes.fetch_sub(reserved as i64, Ordering::Relaxed);
+    }
+
+    /// Record an allocation (budget check + increment).
+    pub fn record_allocated(&self, reserved: u64) -> Result<()> {
+        self.check_budget(reserved)?;
+        self.add_allocated(reserved);
+        Ok(())
+    }
+
+    /// Record a free (decrement).
+    pub fn record_freed(&self, reserved: u64) {
+        self.sub_freed(reserved);
+    }
+}
+
+impl Default for VramByteTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VramObserver for VramByteTracker {
+    fn on_allocated(&self, event: &VramAllocEvent) -> Result<()> {
+        self.record_allocated(event.reserved)
+    }
+
+    fn on_freed(&self, event: &VramFreeEvent) {
+        self.record_freed(event.reserved);
+    }
+}
+
+struct ObserverEntry {
+    id: VramObserverId,
+    observer: Arc<dyn VramObserver>,
+}
+
+impl Clone for ObserverEntry {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            observer: Arc::clone(&self.observer),
+        }
+    }
+}
+
+/// Event aggregator on [`Device`](crate::device::Device) for resource lifecycle signals.
+///
+/// Today this fans out deed (alloc/free) events to [`VramObserver`]s and the installed
+/// [`VramAllocator`]. The hub is intentionally generic so additional event kinds can be
+/// wired through it later without changing parcel drop paths.
+pub(crate) struct ResourceHub {
+    next_id: AtomicU64,
+    observers: Mutex<Arc<[ObserverEntry]>>,
+}
+
+impl ResourceHub {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            next_id: AtomicU64::new(1),
+            observers: Mutex::new(Arc::from([])),
+        })
+    }
+
+    pub fn has_observers(&self) -> bool {
+        !self.observers.lock().unwrap().is_empty()
+    }
+
+    pub fn add_observer(&self, observer: Arc<dyn VramObserver>) -> VramObserverId {
+        let id = VramObserverId::from_raw(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let mut guard = self.observers.lock().unwrap();
+        let mut entries: Vec<ObserverEntry> = guard.iter().cloned().collect();
+        entries.push(ObserverEntry { id, observer });
+        *guard = entries.into();
+        id
+    }
+
+    pub fn remove_observer(&self, id: VramObserverId) -> bool {
+        let mut guard = self.observers.lock().unwrap();
+        let entries: Vec<ObserverEntry> = guard.iter().filter(|e| e.id != id).cloned().collect();
+        let removed = entries.len() != guard.len();
+        *guard = entries.into();
+        removed
+    }
+
+    pub fn notify_allocated(&self, event: &VramAllocEvent) -> Result<()> {
+        let observers = Arc::clone(&*self.observers.lock().unwrap());
+        for entry in observers.iter() {
+            entry.observer.on_allocated(event)?;
+        }
+        Ok(())
+    }
+
+    pub fn notify_freed(&self, event: &VramFreeEvent, allocator: Option<&dyn VramAllocator>) {
+        let observers = Arc::clone(&*self.observers.lock().unwrap());
+        for entry in observers.iter() {
+            entry.observer.on_freed(event);
+        }
+        if let Some(alloc) = allocator {
+            alloc.notify_freed(event.reserved, event.committed, event.kind);
+        }
+    }
+}
+
+/// Deed attached to GPU parcels allocated through [`Device::alloc_*`].
+#[derive(Clone)]
+pub(crate) struct ParcelDeed {
+    pub hub: Weak<ResourceHub>,
+    pub allocator: Weak<dyn VramAllocator>,
+}
+
+impl ParcelDeed {
+    pub fn notify_freed(&self, event: &VramFreeEvent) {
+        if let Some(hub) = self.hub.upgrade() {
+            let allocator = self.allocator.upgrade();
+            hub.notify_freed(event, allocator.as_deref());
+        } else if let Some(alloc) = self.allocator.upgrade() {
+            alloc.notify_freed(event.reserved, event.committed, event.kind);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+    struct CountingObserver {
+        allocs: AtomicU32,
+        frees: AtomicU32,
+    }
+
+    impl CountingObserver {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                allocs: AtomicU32::new(0),
+                frees: AtomicU32::new(0),
+            })
+        }
+    }
+
+    impl VramObserver for CountingObserver {
+        fn on_allocated(&self, _event: &VramAllocEvent) -> Result<()> {
+            self.allocs.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(())
+        }
+
+        fn on_freed(&self, _event: &VramFreeEvent) {
+            self.frees.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn resource_hub_notifies_observers() {
+        let hub = ResourceHub::new();
+        let counter = CountingObserver::new();
+        let _id = hub.add_observer(counter.clone());
+
+        let event = VramAllocEvent {
+            reserved: 1024,
+            committed: 1024,
+            kind: ParcelType::Buffer,
+        };
+        hub.notify_allocated(&event).unwrap();
+        assert_eq!(counter.allocs.load(AtomicOrdering::Relaxed), 1);
+
+        let free = VramFreeEvent {
+            reserved: 1024,
+            committed: 1024,
+            kind: ParcelType::Buffer,
+        };
+        hub.notify_freed(&free, None);
+        assert_eq!(counter.frees.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn byte_tracker_budget() {
+        let tracker = VramByteTracker::with_budget(8192);
+        tracker
+            .on_allocated(&VramAllocEvent {
+                reserved: 4096,
+                committed: 4096,
+                kind: ParcelType::Buffer,
+            })
+            .unwrap();
+        assert_eq!(tracker.allocated_bytes(), 4096);
+        let err = tracker.on_allocated(&VramAllocEvent {
+            reserved: 8192,
+            committed: 8192,
+            kind: ParcelType::Buffer,
+        });
+        assert!(err.is_err());
+    }
+}

--- a/src/vram_observer.rs
+++ b/src/vram_observer.rs
@@ -31,7 +31,7 @@ impl VramObserverId {
     }
 }
 
-/// Allocation event emitted after a deed-holding parcel is created through [`Device::alloc_*`].
+/// Allocation event emitted after a deed-holding parcel is created through the `Device::alloc_*` helpers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VramAllocEvent {
     /// Reserved backing size (`Buffer::allocated_size` / texture byte size).


### PR DESCRIPTION
This update introduces a VRAM observer system to the device, allowing for opt-in telemetry and budget enforcement during resource allocation. The `ResourceHub` aggregates allocation and free events, notifying registered observers. The `TrackingVramAllocator` now utilizes a `VramByteTracker` for tracking allocated bytes and enforcing budgets. Additionally, the `Buffer` and `Texture` structures have been updated to use `ParcelDeed` for accounting on drop, improving resource management. Tests have been added to verify the correct behavior of the observer system and budget enforcement.