### PR TITLE
Enhance parcel management with context-specific timeline stamps

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use crate::backend::ContextHandle;
 use crate::device::Device;
 use crate::error::GoldyError;
 use crate::task_graph::TaskGraph;
-use crate::timeline::TimelineValue;
+use crate::timeline::{is_ready, ReferenceTable, TimelineValue};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -147,6 +147,10 @@ impl Context {
         self.inner.high_water_timeline.load(Ordering::Relaxed)
     }
 
+    pub(crate) fn advance_high_water_timeline(&self, tv: TimelineValue) {
+        self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
+    }
+
     /// Drain pending backend signals (GPU completion, swapchain, oversubscribed).
     pub fn poll_signals(&self) -> Vec<crate::signal::Signal> {
         let mut backend = self.inner.device.inner.backend.lock().unwrap();
@@ -252,7 +256,7 @@ impl Context {
                     drop(backend);
                     self.classify(e)
                 })?;
-            graph.apply_reference_stamps(tv);
+            graph.apply_reference_stamps(self.backend_handle(), &self.inner.device.inner, tv);
             self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
             return Ok(tv);
         }
@@ -260,7 +264,7 @@ impl Context {
         let tv = self
             .submit_with_placement_heap(graph, true)
             .map_err(|e| self.classify(e))?;
-        graph.apply_reference_stamps(tv);
+        graph.apply_reference_stamps(self.backend_handle(), &self.inner.device.inner, tv);
         self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
         Ok(tv)
     }
@@ -276,7 +280,7 @@ impl Context {
                     drop(backend);
                     self.classify(e)
                 })?;
-            graph.apply_reference_stamps(tv);
+            graph.apply_reference_stamps(self.backend_handle(), &self.inner.device.inner, tv);
             self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
             return Ok(tv);
         }
@@ -284,7 +288,7 @@ impl Context {
         let tv = self
             .submit_with_placement_heap(graph, false)
             .map_err(|e| self.classify(e))?;
-        graph.apply_reference_stamps(tv);
+        graph.apply_reference_stamps(self.backend_handle(), &self.inner.device.inner, tv);
         self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
         Ok(tv)
     }
@@ -300,9 +304,40 @@ impl Context {
                 drop(backend);
                 self.classify(e)
             })?;
-        graph.apply_reference_stamps(tv);
+        graph.apply_reference_stamps(self.backend_handle(), &self.inner.device.inner, tv);
         self.inner.high_water_timeline.fetch_max(tv, Ordering::Relaxed);
         Ok(tv)
+    }
+
+    /// Record that this context's submission at `tv` referenced `parcel`.
+    pub fn stamp_parcel(&self, parcel: &crate::Parcel, tv: TimelineValue) {
+        parcel.mark_referenced(self.backend_handle(), tv);
+    }
+
+    /// True when every context in `refs` has retired the stamped timeline values.
+    pub fn parcel_ready(&self, refs: &ReferenceTable) -> bool {
+        if refs.is_empty() {
+            return true;
+        }
+        let backend = self.inner.device.inner.backend.lock().unwrap();
+        let mut progress = HashMap::with_capacity(refs.len());
+        for &ctx in refs.keys() {
+            progress.insert(ctx, backend.gpu_progress(ctx));
+        }
+        drop(backend);
+        is_ready(refs, &progress)
+    }
+
+    /// Block until every context in `refs` has retired the stamped timeline values.
+    pub fn wait_until_parcel_ready(&self, refs: &ReferenceTable) -> Result<(), GoldyError> {
+        for (&ctx_handle, &tv) in refs {
+            let mut backend = self.inner.device.inner.backend.lock().unwrap();
+            backend.wait_until(ctx_handle, tv).map_err(|e| {
+                drop(backend);
+                self.classify(e)
+            })?;
+        }
+        Ok(())
     }
 
     pub fn try_resubmit_retained(&self, key: u64) -> Result<Option<TimelineValue>, GoldyError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use buffer::{Buffer, BufferPool, BufferSource, BufferView, StructuredBufferE
 pub use common_types::{FrameUniforms, Instance2D, Particle2D, Particle3D, Transform2D};
 pub use compute::{ComputeEncoder, ComputePass, ComputePipeline};
 pub use signal::{OversubscribedReason, Signal};
-pub use timeline::TimelineValue;
+pub use timeline::{Epoch, ReferenceTable, TimelineValue};
 
 pub use backend::GraphCommand;
 pub use backend::{BufferHeapStats, TextureHeapStats};

--- a/src/parcel.rs
+++ b/src/parcel.rs
@@ -122,8 +122,7 @@ impl Drop for BookkeepingGuard {
 
 /// A deed-held GPU parcel (buffer or texture). Gate-free while retained.
 ///
-/// Relinquish by [`crate::retained_pool::RetainedPool::transfer_out`] (stamped for the
-/// transient pool) or by dropping the value (implicit relinquish).
+/// Release by [`crate::retained_pool::RetainedPool::release`] (runtime reclaims when safe) or by dropping the parcel.
 pub struct Parcel {
     storage: ParcelStorage,
     stamp: ParcelStamp,
@@ -285,7 +284,7 @@ impl Parcel {
         }
     }
 
-    /// Release pool bookkeeping so [`Drop`] does not double-decrement after `transfer_out`.
+    /// Release pool bookkeeping so [`Drop`] does not double-decrement after [`RetainedPool::release`].
     pub(crate) fn release_bookkeeping(&mut self) {
         self.bookkeeping = None;
     }

--- a/src/parcel.rs
+++ b/src/parcel.rs
@@ -4,18 +4,35 @@
 //! Resource indices for shader binding are exposed via [`Parcel::resource_index`];
 //! the runtime uses internal resource IDs when wiring [`crate::TaskGraph`] nodes.
 
+use crate::backend::ContextHandle;
 use crate::buffer::{Buffer, BufferPool, BufferView};
+use crate::device::DeviceInner;
 use crate::task_graph::ResourceId;
 use crate::texture::Texture;
-use crate::timeline::TimelineValue;
+use crate::timeline::{mark_reference, ReferenceTable, TimelineValue};
 use crate::types::{ResourceAccess, ResourceHandle};
 use crate::vram_allocator::ParcelType;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 
 /// Index into a [`Parcel`] mosaic's sub-ranges (returned by [`crate::retained_pool::MosaicBuilder`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MosaicSlot(pub u32);
+
+/// Shared stamp cell and home-device identity for [`TaskGraph`] submit stamping.
+pub(crate) struct ParcelStamp {
+    pub(crate) references: Arc<Mutex<ReferenceTable>>,
+    pub(crate) home_device: Weak<DeviceInner>,
+}
+
+impl ParcelStamp {
+    pub(crate) fn new(home_device: Weak<DeviceInner>) -> Self {
+        Self {
+            references: Arc::new(Mutex::new(ReferenceTable::new())),
+            home_device,
+        }
+    }
+}
 
 /// One backing buffer subdivided into multiple bindless sub-ranges (lifetime-homogeneous).
 struct Mosaic {
@@ -109,32 +126,36 @@ impl Drop for BookkeepingGuard {
 /// transient pool) or by dropping the value (implicit relinquish).
 pub struct Parcel {
     storage: ParcelStorage,
-    /// Last referencing timeline; `0` means never referenced by GPU work.
-    last_referenced: Arc<AtomicU64>,
+    stamp: ParcelStamp,
     bookkeeping: Option<BookkeepingGuard>,
 }
 
 impl Parcel {
-    pub(crate) fn from_buffer(buf: Buffer, bookkeeping: BookkeepingGuard) -> Self {
+    pub(crate) fn from_buffer(buf: Buffer, bookkeeping: BookkeepingGuard, home_device: Weak<DeviceInner>) -> Self {
         Self {
             storage: ParcelStorage::Buffer(buf),
-            last_referenced: Arc::new(AtomicU64::new(0)),
+            stamp: ParcelStamp::new(home_device),
             bookkeeping: Some(bookkeeping),
         }
     }
 
-    pub(crate) fn from_texture(tex: Texture, bookkeeping: BookkeepingGuard) -> Self {
+    pub(crate) fn from_texture(tex: Texture, bookkeeping: BookkeepingGuard, home_device: Weak<DeviceInner>) -> Self {
         Self {
             storage: ParcelStorage::Texture(tex),
-            last_referenced: Arc::new(AtomicU64::new(0)),
+            stamp: ParcelStamp::new(home_device),
             bookkeeping: Some(bookkeeping),
         }
     }
 
-    pub(crate) fn from_mosaic(pool: BufferPool, views: Vec<BufferView>, bookkeeping: BookkeepingGuard) -> Self {
+    pub(crate) fn from_mosaic(
+        pool: BufferPool,
+        views: Vec<BufferView>,
+        bookkeeping: BookkeepingGuard,
+        home_device: Weak<DeviceInner>,
+    ) -> Self {
         Self {
             storage: ParcelStorage::Mosaic(Mosaic { pool, views }),
-            last_referenced: Arc::new(AtomicU64::new(0)),
+            stamp: ParcelStamp::new(home_device),
             bookkeeping: Some(bookkeeping),
         }
     }
@@ -205,26 +226,34 @@ impl Parcel {
         }
     }
 
-    /// Record the timeline of the most recent GPU work that referenced this parcel.
+    /// Record the timeline of the most recent GPU work that referenced this parcel on `ctx`.
     ///
-    /// Monotonic: only increases; a smaller epoch is ignored.
-    pub fn mark_referenced(&self, epoch: TimelineValue) {
-        self.last_referenced.fetch_max(epoch, Ordering::Relaxed);
+    /// Monotonic per context: only increases; a smaller epoch is ignored.
+    pub fn mark_referenced(&self, ctx: ContextHandle, epoch: TimelineValue) {
+        let mut table = self.stamp.references.lock().unwrap();
+        mark_reference(&mut table, ctx, epoch);
     }
 
-    /// Last recorded referencing timeline, if any.
-    pub fn last_referenced(&self) -> Option<TimelineValue> {
-        let v = self.last_referenced.load(Ordering::Relaxed);
-        if v == 0 {
-            None
-        } else {
-            Some(v)
-        }
+    /// Context-qualified last-referencing timelines.
+    pub fn last_referenced(&self) -> ReferenceTable {
+        self.stamp.references.lock().unwrap().clone()
+    }
+
+    /// Last referencing timeline for a single context, if any.
+    pub fn last_referenced_on(&self, ctx: ContextHandle) -> Option<TimelineValue> {
+        self.stamp.references.lock().unwrap().get(&ctx).copied()
     }
 
     /// Shared stamp cell updated by [`crate::TaskGraph`] at submit.
-    pub(crate) fn stamp_handle(&self) -> Arc<AtomicU64> {
-        Arc::clone(&self.last_referenced)
+    pub(crate) fn stamp_handle(&self) -> Arc<ParcelStamp> {
+        Arc::new(ParcelStamp {
+            references: Arc::clone(&self.stamp.references),
+            home_device: self.stamp.home_device.clone(),
+        })
+    }
+
+    pub(crate) fn home_device(&self) -> &Weak<DeviceInner> {
+        &self.stamp.home_device
     }
 
     /// Task-graph resource identity (runtime only).

--- a/src/retained_pool.rs
+++ b/src/retained_pool.rs
@@ -7,9 +7,10 @@
 //! Reuse-gate, transient pool, and backpressure are deferred.
 
 use crate::buffer::{BufferPool, StructuredBufferElement};
+use crate::context::Context;
 use crate::device::Device;
 use crate::parcel::{BookkeepingGuard, BytesByKind, MosaicSlot, Parcel, PoolBookkeeping};
-use crate::timeline::TimelineValue;
+use crate::timeline::ReferenceTable;
 use crate::types::{BufferKind, TextureFlags, TextureFormat, TextureKind};
 use crate::vram_allocator::ParcelType;
 use anyhow::Result;
@@ -31,8 +32,8 @@ pub struct MosaicBuilder<'a> {
 /// A parcel relinquished from the retained pool, stamped for handoff to the transient pool.
 pub struct StampedParcel {
     pub parcel: Parcel,
-    /// Timeline after which the parcel may be reused; `None` if never referenced by GPU work.
-    pub ready_after: Option<TimelineValue>,
+    /// Per-context timelines after which the parcel may be reused; empty if never referenced.
+    pub ready_after: ReferenceTable,
 }
 
 /// Deed-governed pool: allocates retained parcels; no epoch gate while held.
@@ -115,8 +116,14 @@ impl RetainedPool {
     }
 
     /// Relinquish a parcel from the retained pool. The unit moves to the transient seam;
-    /// `ready_after` is the last referencing timeline (if any).
-    pub fn transfer_out(&mut self, mut parcel: Parcel) -> StampedParcel {
+    /// `ready_after` captures per-context referencing timelines (if any).
+    pub fn transfer_out(&mut self, ctx: &Context, mut parcel: Parcel) -> StampedParcel {
+        if let Some(home) = parcel.home_device().upgrade() {
+            debug_assert!(
+                Arc::ptr_eq(&home, &ctx.device().inner),
+                "transfer_out: parcel home_device must match submitting context's device"
+            );
+        }
         let ready_after = parcel.last_referenced();
         parcel.release_bookkeeping();
         StampedParcel { parcel, ready_after }
@@ -127,12 +134,16 @@ impl RetainedPool {
         self.bookkeeping.snapshot()
     }
 
+    fn home_device(&self) -> std::sync::Weak<crate::device::DeviceInner> {
+        Arc::downgrade(&self.device.inner)
+    }
+
     fn wrap_texture(&self, tex: crate::texture::Texture) -> Result<Parcel> {
         let bytes = tex.byte_size() as u64;
         let kind = ParcelType::Texture;
         self.bookkeeping.add(kind, bytes);
         let guard = BookkeepingGuard::new(Arc::downgrade(&self.bookkeeping), kind, bytes);
-        Ok(Parcel::from_texture(tex, guard))
+        Ok(Parcel::from_texture(tex, guard, self.home_device()))
     }
 
     fn wrap_buffer(&self, buf: crate::buffer::Buffer) -> Result<Parcel> {
@@ -140,7 +151,7 @@ impl RetainedPool {
         let kind = ParcelType::Buffer;
         self.bookkeeping.add(kind, bytes);
         let guard = BookkeepingGuard::new(Arc::downgrade(&self.bookkeeping), kind, bytes);
-        Ok(Parcel::from_buffer(buf, guard))
+        Ok(Parcel::from_buffer(buf, guard, self.home_device()))
     }
 }
 
@@ -193,7 +204,12 @@ impl<'a> MosaicBuilder<'a> {
         let kind = ParcelType::Buffer;
         self.bookkeeping.add(kind, bytes);
         let guard = BookkeepingGuard::new(Arc::downgrade(self.bookkeeping), kind, bytes);
-        Ok(Parcel::from_mosaic(pool, views, guard))
+        Ok(Parcel::from_mosaic(
+            pool,
+            views,
+            guard,
+            Arc::downgrade(&self.device.inner),
+        ))
     }
 }
 
@@ -205,6 +221,10 @@ mod tests {
 
     fn test_device() -> Arc<Device> {
         Arc::new(Device::from_backend(Box::new(MockBackend::new())).expect("mock device"))
+    }
+
+    fn test_ctx(device: &Arc<Device>) -> Context {
+        device.create_context().unwrap()
     }
 
     fn rgba_interpolated() -> (TextureFormat, TextureKind, TextureFlags) {
@@ -253,53 +273,64 @@ mod tests {
 
     #[test]
     fn mark_referenced_is_monotonic_max() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let (fmt, acc, flags) = rgba_interpolated();
         let p = pool.acquire_texture(8, 8, fmt, acc, flags, None).unwrap();
-        p.mark_referenced(10);
-        p.mark_referenced(5);
-        assert_eq!(p.last_referenced(), Some(10));
-        p.mark_referenced(20);
-        assert_eq!(p.last_referenced(), Some(20));
+        let h = ctx.backend_handle();
+        p.mark_referenced(h, 10);
+        p.mark_referenced(h, 5);
+        assert_eq!(p.last_referenced_on(h), Some(10));
+        p.mark_referenced(h, 20);
+        assert_eq!(p.last_referenced_on(h), Some(20));
     }
 
     #[test]
     fn transfer_out_referenced_has_ready_after() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let (fmt, acc, flags) = rgba_interpolated();
         let p = pool.acquire_texture(8, 8, fmt, acc, flags, None).unwrap();
-        p.mark_referenced(42);
-        let stamped = pool.transfer_out(p);
-        assert_eq!(stamped.ready_after, Some(42));
+        p.mark_referenced(ctx.backend_handle(), 42);
+        let stamped = pool.transfer_out(&ctx, p);
+        assert_eq!(stamped.ready_after.get(&ctx.backend_handle()), Some(&42));
         assert_eq!(pool.bytes_by_kind().texture, 0);
     }
 
     #[test]
     fn transfer_out_unreferenced_has_none_ready_after() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let (fmt, acc, flags) = rgba_interpolated();
         let p = pool.acquire_texture(8, 8, fmt, acc, flags, None).unwrap();
-        let stamped = pool.transfer_out(p);
-        assert_eq!(stamped.ready_after, None);
+        let stamped = pool.transfer_out(&ctx, p);
+        assert!(stamped.ready_after.is_empty());
     }
 
     #[test]
     fn transfer_out_preserves_texture_handle() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let (fmt, acc, flags) = rgba_interpolated();
         let p = pool.acquire_texture(8, 8, fmt, acc, flags, None).unwrap();
         let h_before = p.texture_handle().unwrap();
-        let stamped = pool.transfer_out(p);
+        let stamped = pool.transfer_out(&ctx, p);
         assert_eq!(stamped.parcel.texture_handle(), Some(h_before));
     }
 
     #[test]
     fn bytes_by_kind_zero_after_transfer_and_drop() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let (fmt, acc, flags) = rgba_interpolated();
         let p = pool.acquire_texture(16, 16, fmt, acc, flags, None).unwrap();
         assert!(pool.bytes_by_kind().texture > 0);
-        let stamped = pool.transfer_out(p);
+        let stamped = pool.transfer_out(&ctx, p);
         assert_eq!(pool.bytes_by_kind().texture, 0);
         drop(stamped);
     }
@@ -333,7 +364,9 @@ mod tests {
 
     #[test]
     fn mosaic_bytes_by_kind_and_transfer_out() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let mut m = pool.mosaic();
         m.emplace(&[0u32; 16]);
         let parcel = m.build().unwrap();
@@ -341,7 +374,7 @@ mod tests {
         assert!(pool.bytes_by_kind().buffer >= bytes_before);
 
         let h_before = parcel.buffer_handle().unwrap();
-        let stamped = pool.transfer_out(parcel);
+        let stamped = pool.transfer_out(&ctx, parcel);
         assert_eq!(pool.bytes_by_kind().buffer, 0);
         assert_eq!(stamped.parcel.buffer_handle(), Some(h_before));
         drop(stamped);
@@ -349,15 +382,18 @@ mod tests {
 
     #[test]
     fn mosaic_mark_referenced_is_monotonic() {
-        let mut pool = RetainedPool::new(test_device());
+        let device = test_device();
+        let ctx = test_ctx(&device);
+        let mut pool = RetainedPool::new(device);
         let mut m = pool.mosaic();
         m.emplace(&[1u32]);
         let parcel = m.build().unwrap();
-        parcel.mark_referenced(10);
-        parcel.mark_referenced(5);
-        assert_eq!(parcel.last_referenced(), Some(10));
-        parcel.mark_referenced(20);
-        assert_eq!(parcel.last_referenced(), Some(20));
+        let h = ctx.backend_handle();
+        parcel.mark_referenced(h, 10);
+        parcel.mark_referenced(h, 5);
+        assert_eq!(parcel.last_referenced_on(h), Some(10));
+        parcel.mark_referenced(h, 20);
+        assert_eq!(parcel.last_referenced_on(h), Some(20));
     }
 
     #[test]

--- a/src/retained_pool.rs
+++ b/src/retained_pool.rs
@@ -2,7 +2,7 @@
 //!
 //! [`RetainedPool::acquire_texture`], [`RetainedPool::acquire_buffer`], and
 //! [`RetainedPool::mosaic`] are the supported ways to create retained parcels. Parcels are
-//! opaque [`Parcel`] values; relinquish via [`RetainedPool::transfer_out`] or by dropping the parcel.
+//! opaque [`Parcel`] values; relinquish via [`RetainedPool::release`] or by dropping the parcel.
 //!
 //! Reuse-gate, transient pool, and backpressure are deferred.
 
@@ -115,9 +115,15 @@ impl RetainedPool {
         }
     }
 
-    /// Relinquish a parcel from the retained pool. The unit moves to the transient seam;
-    /// `ready_after` captures per-context referencing timelines (if any).
-    pub fn transfer_out(&mut self, ctx: &Context, mut parcel: Parcel) -> StampedParcel {
+    /// Release a held parcel. The runtime reclaims GPU memory when safe; callers
+    /// do not observe timeline tokens.
+    pub fn release(&mut self, ctx: &Context, parcel: Parcel) {
+        drop(self.transfer_out(ctx, parcel));
+    }
+
+    /// Internal release path. Returns stamped metadata for the future transient seam;
+    /// public clients should call [`Self::release`] instead.
+    pub(crate) fn transfer_out(&mut self, ctx: &Context, mut parcel: Parcel) -> StampedParcel {
         if let Some(home) = parcel.home_device().upgrade() {
             debug_assert!(
                 Arc::ptr_eq(&home, &ctx.device().inner),
@@ -463,7 +469,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("a", &pipeline)
-            .bind_parcel(&parcel, ResourceAccess::Read)
+            .bind_parcel(&parcel, crate::task_graph::NodeAccess::Read)
             .dispatch(1, 1, 1);
 
         let binding = graph.ir().nodes[0].bindings[0].resource;

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -905,7 +905,7 @@ mod tests {
         let sc = graph.declare_swapchain_output();
         graph
             .node("fine", &pipeline)
-            .bind_parcel(&parcel, ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .bind_swapchain_output(sc, NodeAccess::Write)
             .dispatch(1, 1, 1);
 
@@ -942,7 +942,7 @@ mod tests {
         let sc = graph.declare_swapchain_output();
         graph
             .node("fine", &pipeline)
-            .bind_parcel(&parcel, ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .bind_swapchain_output(sc, NodeAccess::Write)
             .dispatch(1, 1, 1);
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -43,6 +43,9 @@ pub struct Frame {
     /// Deferred to the VramAllocator ring at present time. Uses a Mutex so
     /// submit_compute can push to it via &self without requiring &mut Frame.
     keepalive: Mutex<DeferredPayload>,
+    /// Parcel stamp cells moved from a [`TaskGraph`] at [`Surface::submit_graph`] time;
+    /// applied at [`Self::submit_frame`].
+    stamp_targets: Vec<Arc<crate::parcel::ParcelStamp>>,
 }
 
 impl Surface {
@@ -145,6 +148,7 @@ impl Surface {
             presented: false,
             submit_tv: None,
             keepalive: Mutex::new(DeferredPayload::new()),
+            stamp_targets: Vec::new(),
         })
     }
 
@@ -274,7 +278,7 @@ impl Surface {
         }
 
         // ── Step 5: deferred surface acquire ─────────────────────────────────
-        let frame = {
+        let mut frame = {
             let _tz = tracy_zone!("surface.deferred_acquire");
             self.begin()?
         };
@@ -306,6 +310,7 @@ impl Surface {
             backend.record_gpu_work(&frame.token, &final_cmds)?;
         }
 
+        frame.stamp_targets = graph.take_stamp_targets();
         Ok(frame)
     }
 
@@ -314,7 +319,7 @@ impl Surface {
     /// This preserves `SwapchainOutput` as an abstract graph resource while allowing callers to
     /// request the WSI image at the beginning of frame recording. Early partitions still run before
     /// the swapchain-touching partition; the late partition is resolved against `frame`.
-    pub fn submit_graph_to_frame(&self, graph: &mut TaskGraph, frame: Frame) -> Result<Frame> {
+    pub fn submit_graph_to_frame(&self, graph: &mut TaskGraph, mut frame: Frame) -> Result<Frame> {
         let _tz = tracy_zone!("surface.submit_graph_to_frame");
 
         if frame.token.surface != self.handle {
@@ -381,6 +386,7 @@ impl Surface {
             backend.record_gpu_work(&frame.token, &final_cmds)?;
         }
 
+        frame.stamp_targets = graph.take_stamp_targets();
         Ok(frame)
     }
 
@@ -527,6 +533,15 @@ impl Frame {
         }
         let mut backend = self.backend.lock().unwrap();
         let tv = backend.submit_frame(&self.token)?;
+        if !self.stamp_targets.is_empty() {
+            crate::task_graph::apply_stamp_targets(
+                &self.stamp_targets,
+                self.ctx_handle,
+                &self.context.device().inner,
+                tv,
+            );
+            self.context.advance_high_water_timeline(tv);
+        }
         self.submit_tv = Some(tv);
         Ok(tv)
     }
@@ -860,5 +875,81 @@ mod tests {
         let surface = Surface::new(&ctx, &window).unwrap();
 
         let _frame = surface.begin().unwrap();
+    }
+
+    #[test]
+    fn submit_graph_stamps_bound_parcel_at_submit_frame() {
+        use std::sync::Arc;
+
+        use crate::compute::ComputePipeline;
+        use crate::retained_pool::RetainedPool;
+        use crate::shader::ShaderModule;
+        use crate::task_graph::NodeAccess;
+        use crate::types::{BufferFlags, BufferKind, ResourceAccess};
+
+        let device = Arc::new(create_test_device());
+        let ctx = device.create_context().unwrap();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&ctx, &window).unwrap();
+
+        let mut pool = RetainedPool::new(device.clone());
+        let parcel = pool
+            .acquire_buffer(256, BufferKind::Scattered, None, BufferFlags::empty(), None)
+            .unwrap();
+        assert!(parcel.last_referenced().is_empty());
+
+        let shader = ShaderModule::from_slang(&device, "void main() {}").unwrap();
+        let pipeline = ComputePipeline::new(&device, &shader).unwrap();
+
+        let mut graph = TaskGraph::new();
+        let sc = graph.declare_swapchain_output();
+        graph
+            .node("fine", &pipeline)
+            .bind_parcel(&parcel, ResourceAccess::ReadWrite)
+            .bind_swapchain_output(sc, NodeAccess::Write)
+            .dispatch(1, 1, 1);
+
+        let mut frame = surface.submit_graph(&mut graph).unwrap();
+        let tv = frame.submit_frame().unwrap();
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv));
+        let _ = frame.present();
+    }
+
+    #[test]
+    fn submit_graph_to_frame_stamps_bound_parcel_at_submit_frame() {
+        use std::sync::Arc;
+
+        use crate::compute::ComputePipeline;
+        use crate::retained_pool::RetainedPool;
+        use crate::shader::ShaderModule;
+        use crate::task_graph::NodeAccess;
+        use crate::types::{BufferFlags, BufferKind, ResourceAccess};
+
+        let device = Arc::new(create_test_device());
+        let ctx = device.create_context().unwrap();
+        let window = MockWindow::new(800, 600);
+        let surface = Surface::new(&ctx, &window).unwrap();
+
+        let mut pool = RetainedPool::new(device.clone());
+        let parcel = pool
+            .acquire_buffer(256, BufferKind::Scattered, None, BufferFlags::empty(), None)
+            .unwrap();
+
+        let shader = ShaderModule::from_slang(&device, "void main() {}").unwrap();
+        let pipeline = ComputePipeline::new(&device, &shader).unwrap();
+
+        let mut graph = TaskGraph::new();
+        let sc = graph.declare_swapchain_output();
+        graph
+            .node("fine", &pipeline)
+            .bind_parcel(&parcel, ResourceAccess::ReadWrite)
+            .bind_swapchain_output(sc, NodeAccess::Write)
+            .dispatch(1, 1, 1);
+
+        let acquired = surface.begin().unwrap();
+        let mut frame = surface.submit_graph_to_frame(&mut graph, acquired).unwrap();
+        let tv = frame.submit_frame().unwrap();
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv));
+        let _ = frame.present();
     }
 }

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -21,8 +21,7 @@ use crate::types::TextureFormat;
 use anyhow::Result;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::Ordering;
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::Arc;
 
 fn gcd(mut a: u64, mut b: u64) -> u64 {
     while b != 0 {
@@ -172,7 +171,26 @@ pub struct TaskGraph {
     schedule_validated_node_count: usize,
     /// Stamp cells for [`crate::Parcel`]s bound via [`NodeBuilder::bind_parcel`].
     /// Cleared in [`Self::clear`]; stamped in [`Self::apply_reference_stamps`] at submit.
-    stamp_targets: Vec<Arc<AtomicU64>>,
+    stamp_targets: Vec<Arc<crate::parcel::ParcelStamp>>,
+}
+
+/// Stamp every parcel bound via [`NodeBuilder::bind_parcel`] with a context-qualified timeline.
+pub(crate) fn apply_stamp_targets(
+    targets: &[Arc<crate::parcel::ParcelStamp>],
+    ctx: crate::backend::ContextHandle,
+    submit_device: &std::sync::Arc<crate::device::DeviceInner>,
+    tv: TimelineValue,
+) {
+    for stamp in targets {
+        if let Some(home) = stamp.home_device.upgrade() {
+            debug_assert!(
+                std::sync::Arc::ptr_eq(&home, submit_device),
+                "parcel home_device must match submitting context's device"
+            );
+        }
+        let mut table = stamp.references.lock().unwrap();
+        crate::timeline::mark_reference(&mut table, ctx, tv);
+    }
 }
 
 /// Cache entry holding both the wave schedule and the emitted compute command stream.
@@ -1018,11 +1036,19 @@ impl TaskGraph {
     }
 
     /// Stamp every [`crate::Parcel`] bound via [`NodeBuilder::bind_parcel`] with the
-    /// timeline value of the submission that just completed.
-    pub(crate) fn apply_reference_stamps(&self, tv: TimelineValue) {
-        for stamp in &self.stamp_targets {
-            stamp.fetch_max(tv, Ordering::Relaxed);
-        }
+    /// context-qualified timeline value of the submission that just completed.
+    pub(crate) fn apply_reference_stamps(
+        &self,
+        ctx: crate::backend::ContextHandle,
+        submit_device: &std::sync::Arc<crate::device::DeviceInner>,
+        tv: TimelineValue,
+    ) {
+        apply_stamp_targets(&self.stamp_targets, ctx, submit_device, tv);
+    }
+
+    /// Move parcel stamp cells off the graph for surface submit (applied at [`crate::Frame::submit_frame`]).
+    pub(crate) fn take_stamp_targets(&mut self) -> Vec<Arc<crate::parcel::ParcelStamp>> {
+        std::mem::take(&mut self.stamp_targets)
     }
 
     /// Access the raw IR for internal use (e.g. transient lowering from outside the task_graph module).
@@ -2669,7 +2695,7 @@ mod tests {
         let ctx = device.create_context().unwrap();
         let mut pool = crate::RetainedPool::new(device.clone());
         let parcel = retained_buffer_parcel(&mut pool);
-        assert_eq!(parcel.last_referenced(), None);
+        assert!(parcel.last_referenced().is_empty());
 
         let shader = mock_shader(&device);
         let pipeline = mock_pipeline(&device, &shader);
@@ -2681,7 +2707,7 @@ mod tests {
             .dispatch(1, 1, 1);
 
         let tv = graph.submit(&ctx).unwrap();
-        assert_eq!(parcel.last_referenced(), Some(tv));
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv));
     }
 
     #[test]
@@ -2707,11 +2733,11 @@ mod tests {
             .dispatch(1, 1, 1);
         let tv2 = graph.submit(&ctx).unwrap();
         assert!(tv2 > tv1);
-        assert_eq!(parcel.last_referenced(), Some(tv2));
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv2));
 
         // Lower epoch must not regress the stamp.
-        graph.apply_reference_stamps(tv1);
-        assert_eq!(parcel.last_referenced(), Some(tv2));
+        graph.apply_reference_stamps(ctx.backend_handle(), &device.inner, tv1);
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv2));
     }
 
     #[test]
@@ -2732,8 +2758,8 @@ mod tests {
             .dispatch(1, 1, 1);
 
         let tv = graph.submit(&ctx).unwrap();
-        assert_eq!(p1.last_referenced(), Some(tv));
-        assert_eq!(p2.last_referenced(), Some(tv));
+        assert_eq!(p1.last_referenced_on(ctx.backend_handle()), Some(tv));
+        assert_eq!(p2.last_referenced_on(ctx.backend_handle()), Some(tv));
     }
 
     #[test]
@@ -2752,8 +2778,8 @@ mod tests {
             .bind_parcel(&bound, crate::types::ResourceAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv = graph.submit(&ctx).unwrap();
-        assert_eq!(bound.last_referenced(), Some(tv));
-        assert_eq!(unbound.last_referenced(), None);
+        assert_eq!(bound.last_referenced_on(ctx.backend_handle()), Some(tv));
+        assert!(unbound.last_referenced().is_empty());
     }
 
     #[test]
@@ -2772,17 +2798,18 @@ mod tests {
             .dispatch(1, 1, 1);
         let tv = graph.submit(&ctx).unwrap();
 
-        let stamped = pool.transfer_out(parcel);
-        assert_eq!(stamped.ready_after, Some(tv));
+        let stamped = pool.transfer_out(&ctx, parcel);
+        assert_eq!(stamped.ready_after.get(&ctx.backend_handle()), Some(&tv));
     }
 
     #[test]
     fn transfer_out_unreferenced_has_none_ready_after() {
         let device = Arc::new(mock_device());
+        let ctx = device.create_context().unwrap();
         let mut pool = crate::RetainedPool::new(device);
         let parcel = retained_buffer_parcel(&mut pool);
-        let stamped = pool.transfer_out(parcel);
-        assert_eq!(stamped.ready_after, None);
+        let stamped = pool.transfer_out(&ctx, parcel);
+        assert!(stamped.ready_after.is_empty());
     }
 
     #[test]
@@ -2802,7 +2829,7 @@ mod tests {
         graph.clear();
 
         let tv = graph.submit(&ctx).unwrap();
-        assert_eq!(parcel.last_referenced(), None);
+        assert!(parcel.last_referenced().is_empty());
         let _ = tv;
     }
 
@@ -2822,7 +2849,7 @@ mod tests {
             .dispatch(1, 1, 1);
 
         let tv = ctx.submit_pipelined(&mut graph).unwrap();
-        assert_eq!(parcel.last_referenced(), Some(tv));
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv));
     }
 
     #[test]
@@ -2841,6 +2868,32 @@ mod tests {
             .dispatch(1, 1, 1);
 
         let tv = ctx.submit_pipelined_and_retain(&mut graph).unwrap();
-        assert_eq!(parcel.last_referenced(), Some(tv));
+        assert_eq!(parcel.last_referenced_on(ctx.backend_handle()), Some(tv));
+    }
+
+    #[test]
+    fn bind_parcel_stamp_is_context_specific() {
+        let device = Arc::new(mock_device());
+        let ctx_a = device.create_context().unwrap();
+        let ctx_b = device.create_context().unwrap();
+        let mut pool = crate::RetainedPool::new(device.clone());
+        let parcel = retained_buffer_parcel(&mut pool);
+        let shader = mock_shader(&device);
+        let pipeline = mock_pipeline(&device, &shader);
+
+        let mut graph = TaskGraph::new();
+        graph
+            .node("work", &pipeline)
+            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .dispatch(1, 1, 1);
+        let tv_a = graph.submit(&ctx_a).unwrap();
+
+        assert_eq!(parcel.last_referenced_on(ctx_a.backend_handle()), Some(tv_a));
+        assert_eq!(parcel.last_referenced_on(ctx_b.backend_handle()), None);
+        assert_eq!(ctx_b.gpu_progress(), 0, "context B must not observe A's submit");
+        assert!(
+            ctx_b.parcel_ready(&parcel.last_referenced()),
+            "readiness checks the stamping context's progress, not the caller's"
+        );
     }
 }

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -1465,11 +1465,11 @@ impl<'a> NodeBuilder<'a> {
     ///
     /// The backend resource handle is resolved inside the runtime; the client does not
     /// pass a raw handle.
-    pub fn bind_parcel(mut self, parcel: &crate::Parcel, access: crate::types::ResourceAccess) -> Self {
+    pub fn bind_parcel(mut self, parcel: &crate::Parcel, access: NodeAccess) -> Self {
         self.graph.stamp_targets.push(parcel.stamp_handle());
         self.bindings.push(ResourceBinding {
             resource: parcel.resource_id(),
-            access: access.into(),
+            access,
         });
         self
     }
@@ -2703,7 +2703,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
 
         let tv = graph.submit(&ctx).unwrap();
@@ -2722,14 +2722,14 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv1 = graph.submit(&ctx).unwrap();
 
         graph.clear();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv2 = graph.submit(&ctx).unwrap();
         assert!(tv2 > tv1);
@@ -2753,8 +2753,8 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&p1, crate::types::ResourceAccess::Write)
-            .bind_parcel(&p2, crate::types::ResourceAccess::Read)
+            .bind_parcel(&p1, NodeAccess::Write)
+            .bind_parcel(&p2, NodeAccess::Read)
             .dispatch(1, 1, 1);
 
         let tv = graph.submit(&ctx).unwrap();
@@ -2775,7 +2775,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&bound, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&bound, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv = graph.submit(&ctx).unwrap();
         assert_eq!(bound.last_referenced_on(ctx.backend_handle()), Some(tv));
@@ -2794,7 +2794,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv = graph.submit(&ctx).unwrap();
 
@@ -2824,7 +2824,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         graph.clear();
 
@@ -2845,7 +2845,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
 
         let tv = ctx.submit_pipelined(&mut graph).unwrap();
@@ -2864,7 +2864,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
 
         let tv = ctx.submit_pipelined_and_retain(&mut graph).unwrap();
@@ -2884,7 +2884,7 @@ mod tests {
         let mut graph = TaskGraph::new();
         graph
             .node("work", &pipeline)
-            .bind_parcel(&parcel, crate::types::ResourceAccess::ReadWrite)
+            .bind_parcel(&parcel, NodeAccess::ReadWrite)
             .dispatch(1, 1, 1);
         let tv_a = graph.submit(&ctx_a).unwrap();
 

--- a/src/task_graph/mod.rs
+++ b/src/task_graph/mod.rs
@@ -86,6 +86,7 @@ pub(crate) mod analysis;
 mod graph;
 mod ir;
 
+pub(crate) use graph::apply_stamp_targets;
 pub use graph::{NodeBuilder, RenderPassBuilder, TaskGraph};
 pub use ir::{BarrierUsage, GraphIR, NodeAccess, NodeAccessUnion, SlotUsageSet, UsageKindFlags};
 

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -15,4 +15,42 @@
 //! implementation cannot always detect the hazard — submit (or bracket a frame) before
 //! dropping resources that must outlive those commands.
 
+use crate::backend::ContextHandle;
+use std::collections::HashMap;
+
 pub type TimelineValue = u64;
+
+/// A context-qualified timeline stamp: which context's semaphore must reach `value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Epoch {
+    pub context: ContextHandle,
+    pub value: TimelineValue,
+}
+
+/// Per-context last-referencing timeline values for a retained parcel.
+pub type ReferenceTable = HashMap<ContextHandle, TimelineValue>;
+
+/// Record `tv` for `ctx`, monotonically per context.
+pub fn mark_reference(table: &mut ReferenceTable, ctx: ContextHandle, tv: TimelineValue) {
+    table.entry(ctx).and_modify(|v| *v = (*v).max(tv)).or_insert(tv);
+}
+
+/// True when `progress` has retired every entry in `table`.
+pub fn is_ready(table: &ReferenceTable, progress: &HashMap<ContextHandle, TimelineValue>) -> bool {
+    table
+        .iter()
+        .all(|(ctx, &tv)| progress.get(ctx).copied().unwrap_or(0) >= tv)
+}
+
+/// Fast single-context readiness check.
+pub fn is_ready_on(table: &ReferenceTable, ctx: ContextHandle, progress: TimelineValue) -> bool {
+    table.get(&ctx).is_none_or(|&tv| progress >= tv)
+}
+
+/// Collect `table` entries as [`Epoch`] values.
+pub fn epochs_from(table: &ReferenceTable) -> Vec<Epoch> {
+    table
+        .iter()
+        .map(|(&context, &value)| Epoch { context, value })
+        .collect()
+}


### PR DESCRIPTION
This commit introduces several improvements to the parcel management system, including the addition of context-qualified timeline stamps for parcels. The `mark_referenced` method now records timeline values per context, allowing for more precise tracking of resource usage. The `Parcel` struct has been updated to include a `ParcelStamp` that holds references and home device information. Additionally, the `TaskGraph` now applies these stamps during submission, ensuring that each context's progress is accurately reflected. Tests have been added to verify the correct behavior of these changes, including context-specific readiness checks and the handling of parcel transfers.