### PR TITLE
Port per-context frame-table refactor onto frame-table

### DIFF
--- a/shaders/goldy_exp/access.slang
+++ b/shaders/goldy_exp/access.slang
@@ -81,19 +81,22 @@ public typealias ByteAddressView = RWByteAddressBuffer;
 // =============================================================================
 // Frame-table protocol (record/execute index routing)
 //
-// Two bindless slots are reserved at device init:
-//   GOLDY_FRAME_SELECTOR_SLOT — u32 row index for this submission
-//   GOLDY_FRAME_TABLE_SLOT    — device-local u32 table (row * STRIDE + slot)
+// Each submission context owns a selector cell + device-local index table at
+// per-context bindless slots.  The slots are carried in push constants:
+//   `_rs1` / PushLayout._reserved[1] — selector slot (u32 row index cell)
+//   `_rs2` / PushLayout._reserved[2] — table slot (row * STRIDE + slot)
 //
 // Push constant `_rs0` / PushLayout._reserved[0] carries the dispatch base
 // offset within the row.  Virtual-main preambles call goldy_frame_table_index.
+//
 // =============================================================================
 
-static const uint GOLDY_FRAME_SELECTOR_SLOT = 0;
-static const uint GOLDY_FRAME_TABLE_SLOT = 1;
 static const uint GOLDY_FRAME_TABLE_ROW_STRIDE = 512;
 
 /// Resolve bindless index `slot_k` for dispatch table base `dispatch_base`.
+///
+/// `selector_slot` / `table_slot` are the bindless slots
+/// (from push constants `_rs1` / `_rs2`).
 ///
 /// On DX12/Vulkan, `dispatch_base` is the within-row offset and a selector cell
 /// (written by the GPU prologue copy) provides the current row.
@@ -102,14 +105,14 @@ static const uint GOLDY_FRAME_TABLE_ROW_STRIDE = 512;
 /// `dispatch_base` (= row * ROW_STRIDE + within-row offset), so no selector
 /// read is needed.  This avoids the shared-mutable-selector race that would
 /// occur when multiple command buffers are in flight simultaneously.
-public uint goldy_frame_table_index(uint dispatch_base, uint slot_k)
+public uint goldy_frame_table_index(uint dispatch_base, uint slot_k, uint selector_slot, uint table_slot)
 {
 #if defined(__METAL__)
-    return goldy_scattered<uint>(GOLDY_FRAME_TABLE_SLOT)[dispatch_base + slot_k];
+    return goldy_scattered<uint>(table_slot)[dispatch_base + slot_k];
 #else
-    uint sel = goldy_scattered<uint>(GOLDY_FRAME_SELECTOR_SLOT)[0];
+    uint sel = goldy_scattered<uint>(selector_slot)[0];
     uint row_offset = sel * GOLDY_FRAME_TABLE_ROW_STRIDE + dispatch_base + slot_k;
-    return goldy_scattered<uint>(GOLDY_FRAME_TABLE_SLOT)[row_offset];
+    return goldy_scattered<uint>(table_slot)[row_offset];
 #endif
 }
 

--- a/src/backend/dx12/buffer.rs
+++ b/src/backend/dx12/buffer.rs
@@ -1338,50 +1338,73 @@ pub(super) fn set_logical_size(
 /// descriptor slots for deferred deletion after in-flight GPU work completes.
 /// For views, only the descriptor slots are deferred.
 pub(super) fn destroy(state: &mut Dx12State, buffer_handle: BufferHandle) {
-    if let Some(buffer) = state.buffers.write().unwrap().entries.remove(&buffer_handle) {
-        if let Some(device) = state.devices.get(&buffer.device_handle) {
-            let last_fence = device
-                .timeline_next
-                .load(std::sync::atomic::Ordering::Relaxed)
-                .saturating_sub(1);
+    // Drop the buffers write lock before context attribution: the submission worker
+    // holds sc Mutex then buffers.read() (bind_to_bindless_heap); holding buffers.write()
+    // here while waiting on sc would invert that order and deadlock.
+    let Some(buffer) = ({
+        let mut buffers = state.buffers.write().unwrap();
+        buffers.entries.remove(&buffer_handle)
+    }) else {
+        return;
+    };
+    let Some(device) = state.devices.get(&buffer.device_handle) else {
+        return;
+    };
+    let barrier = super::context::reclamation_barrier(state, buffer.device_handle);
+    let last_fence = {
+        let registry = device.descriptors.lock().unwrap();
+        registry.bindless_retirement_fence_for_buffer(buffer_handle, barrier)
+    };
+    let ctx_h = super::context::destroy_attribution_context(state, buffer.device_handle);
 
-            if buffer.is_view {
-                device
-                    .deletion_queue
-                    .lock()
-                    .unwrap()
-                    .queue(last_fence, super::types::PendingDeletion::BufferView { buffer_handle });
-                return;
-            }
+    if buffer.is_view {
+        let deletion = super::types::PendingDeletion::BufferView { buffer_handle };
+        queue_pending_deletion(state, device, ctx_h, last_fence, deletion);
+        return;
+    }
 
-            if buffer.transient_placed {
-                device.descriptors.lock().unwrap().reclaim_buffer_slots(buffer_handle);
-                return;
-            }
-            if buffer.coherent_readback_mapped.is_some() {
-                let no_write = D3D12_RANGE { Begin: 0, End: 0 };
-                if buffer.is_grant_readback {
-                    // Grant readback maps the primary READBACK resource directly.
-                    unsafe { buffer.resource.Unmap(0, Some(&no_write)) };
-                } else if let Some(ref rb) = buffer.coherent_readback {
-                    unsafe { rb.Unmap(0, Some(&no_write)) };
-                }
-            }
-            device.deletion_queue.lock().unwrap().queue(
-                last_fence,
-                super::types::PendingDeletion::Buffer {
-                    buffer_handle,
-                    resource: buffer.resource,
-                    upload_buffer: buffer.upload_buffer,
-                    coherent_readback: buffer.coherent_readback,
-                    reserved_tiles: if buffer.is_reserved {
-                        Some(buffer.reserved_tiles)
-                    } else {
-                        None
-                    },
-                },
-            );
+    if buffer.transient_placed {
+        device.descriptors.lock().unwrap().reclaim_buffer_slots(buffer_handle);
+        return;
+    }
+    if buffer.coherent_readback_mapped.is_some() {
+        let no_write = D3D12_RANGE { Begin: 0, End: 0 };
+        if buffer.is_grant_readback {
+            // Grant readback maps the primary READBACK resource directly.
+            unsafe { buffer.resource.Unmap(0, Some(&no_write)) };
+        } else if let Some(ref rb) = buffer.coherent_readback {
+            unsafe { rb.Unmap(0, Some(&no_write)) };
         }
+    }
+    let deletion = super::types::PendingDeletion::Buffer {
+        buffer_handle,
+        resource: buffer.resource,
+        upload_buffer: buffer.upload_buffer,
+        coherent_readback: buffer.coherent_readback,
+        reserved_tiles: if buffer.is_reserved {
+            Some(buffer.reserved_tiles)
+        } else {
+            None
+        },
+    };
+    queue_pending_deletion(state, device, ctx_h, last_fence, deletion);
+}
+
+fn queue_pending_deletion(
+    state: &Dx12State,
+    device: &super::types::LogicalDevice,
+    ctx_h: Option<super::ContextHandle>,
+    last_fence: u64,
+    deletion: super::types::PendingDeletion,
+) {
+    if let Some(ctx_h) = ctx_h {
+        if let Some(sc_arc) = state.contexts.read().unwrap().get(&ctx_h) {
+            sc_arc.lock().unwrap().deletion_queue.queue(last_fence, deletion);
+        } else {
+            device.deletion_queue.lock().unwrap().queue(last_fence, deletion);
+        }
+    } else {
+        device.deletion_queue.lock().unwrap().queue(last_fence, deletion);
     }
 }
 

--- a/src/backend/dx12/compute.rs
+++ b/src/backend/dx12/compute.rs
@@ -679,7 +679,7 @@ pub(super) fn scope_from_state(state: &Dx12State, ctx: ContextHandle) -> Result<
             .with_context(|| format!("Invalid context handle {ctx}"))?,
     );
     let device_handle = sc.lock().unwrap().device;
-    let record = record_state_from_backend(state, device_handle)?;
+    let record = record_state_from_backend(state, ctx, device_handle)?;
     let use_global_buffer_barriers = record.ld.adapter_id == super::WARP_ADAPTER_ID;
     Ok(Dx12SubmitScope {
         ctx,
@@ -766,6 +766,8 @@ struct CmdCtx<'a> {
     dispatch_idx: u32,
     current_compute_pipeline: Option<ComputePipelineHandle>,
     pending_deletions: Vec<super::types::PendingDeletion>,
+    /// Frame table row chosen at prologue record time (stable under concurrent submits).
+    frame_table_row: Option<u32>,
 }
 
 /// Emit one `GpuCommand` onto the open command list in `ctx`.
@@ -786,14 +788,15 @@ fn record_gpu_command(
     let cl7 = ctx.command_list7;
     match cmd {
         GpuCommand::FrameTableStaging { data } => {
-            super::frame_table::record_prologue(
+            let row = super::frame_table::record_prologue(
                 scope.contexts(),
+                _ctx_handle,
                 scope.frame_table(),
                 &scope.buffers().read().unwrap().entries,
-                device_handle,
                 cl7,
                 data,
             )?;
+            ctx.frame_table_row = Some(row);
         }
         GpuCommand::SetPipeline(handle) => {
             let _tz = tracy_zone!("dx12.set_pipeline");
@@ -867,6 +870,10 @@ fn record_gpu_command(
             }
             let mut layout = types::PushLayout::default();
             shared::fill_frame_table_dispatch(&mut layout, *frame_table_base, raw_user);
+            {
+                let ft = scope.frame_table();
+                shared::set_frame_table_slots(&mut layout, ft.selector_slot, ft.table_slot);
+            }
             unsafe {
                 cl.SetComputeRoot32BitConstants(
                     0,
@@ -1008,6 +1015,21 @@ fn record_gpu_command(
                 .devices()
                 .get(&device_handle)
                 .context("DispatchBatch: invalid device")?;
+
+            // Arg data is built during context-agnostic lowering; patch in this
+            // context's frame-table slots (`_rs1`/`_rs2`) at record time.
+            let arg_data = {
+                let ft = scope.frame_table();
+                let mut patched = arg_data.to_vec();
+                crate::backend::shared::patch_dispatch_batch_frame_table_slots(
+                    &mut patched,
+                    *count as usize,
+                    ft.selector_slot,
+                    ft.table_slot,
+                );
+                patched
+            };
+            let arg_data = &arg_data;
 
             if let Some(batch_sig) = logical_device.compute_batch_dispatch_signature.clone() {
                 let buf_size = arg_data.len() as u64;
@@ -1607,6 +1629,7 @@ struct SubmitFinish {
     retain_key: Option<u64>,
     used_slots: Vec<DeferredSlot>,
     frame_table_staging: Option<std::sync::Arc<[u32]>>,
+    frame_table_row: Option<u32>,
     pending_deletions: Vec<super::types::PendingDeletion>,
 }
 
@@ -1655,6 +1678,7 @@ fn execute_signal_and_finish(
         retain_key,
         used_slots,
         frame_table_staging,
+        frame_table_row,
         pending_deletions,
     } = submit;
     let StagingFinish {
@@ -1730,10 +1754,8 @@ fn execute_signal_and_finish(
                     old_slot.retained = false;
                 }
             }
-            let frame_table_row = frame_table_staging
-                .as_ref()
-                .and_then(|_| super::frame_table::last_prologue_row(scope.frame_table()));
-            if let Some(row) = frame_table_row {
+            let pin_row_index = frame_table_staging.is_some().then_some(frame_table_row).flatten();
+            if let Some(row) = pin_row_index {
                 super::frame_table::pin_row(scope.frame_table(), row)?;
             }
             if let Some(cl) = sc
@@ -1749,7 +1771,7 @@ fn execute_signal_and_finish(
                         slot_idx,
                         used_slots,
                         frame_table_staging,
-                        frame_table_row,
+                        frame_table_row: pin_row_index,
                     },
                 );
             }
@@ -1977,7 +1999,7 @@ pub(super) fn submit_with_scope(
         prof
     };
 
-    let (belt_idx_final, pending_deletions) = {
+    let (belt_idx_final, pending_deletions, frame_table_row) = {
         let _tz_cmds = tracy_zone!("dx12.submit.record_commands");
         let mut cmd_ctx = CmdCtx {
             command_list: &command_list,
@@ -1991,6 +2013,7 @@ pub(super) fn submit_with_scope(
             dispatch_idx: 0,
             current_compute_pipeline: None,
             pending_deletions: Vec::new(),
+            frame_table_row: None,
         };
         for cmd in &commands {
             record_gpu_command(scope, device_handle, ctx, &mut cmd_ctx, cmd)?;
@@ -2000,7 +2023,7 @@ pub(super) fn submit_with_scope(
             staged_texture_uploads.len(),
             "WriteTexture command count mismatch vs staging pre-pass"
         );
-        (cmd_ctx.belt_idx, cmd_ctx.pending_deletions)
+        (cmd_ctx.belt_idx, cmd_ctx.pending_deletions, cmd_ctx.frame_table_row)
     };
 
     // Tail barrier: make UAV and copy writes visible to subsequent operations.
@@ -2038,6 +2061,7 @@ pub(super) fn submit_with_scope(
             retain_key: None,
             used_slots,
             frame_table_staging,
+            frame_table_row,
             pending_deletions,
         },
         StagingFinish {
@@ -2239,7 +2263,7 @@ pub(super) fn submit_graph_with_scope(
     };
 
     let mut rendered_targets: Vec<RenderTargetHandle> = Vec::new();
-    let (belt_idx_final, pending_deletions);
+    let (belt_idx_final, pending_deletions, frame_table_row);
     {
         let _tz_cmds = tracy_zone!("dx12.submit_graph.record_commands");
         let mut cmd_ctx = CmdCtx {
@@ -2254,6 +2278,7 @@ pub(super) fn submit_graph_with_scope(
             dispatch_idx: 0,
             current_compute_pipeline: None,
             pending_deletions: Vec::new(),
+            frame_table_row: None,
         };
 
         let mut frame_table_prologue_in_cb = false;
@@ -2296,14 +2321,18 @@ pub(super) fn submit_graph_with_scope(
                     };
                     unsafe { barriers::barrier_globals(cmd_ctx.command_list7, &[pre_render_barrier]) };
 
-                    let touched = super::render_target::record_render_pass_to_list_with_record(
+                    let (touched, prologue_row) = super::render_target::record_render_pass_to_list_with_record(
                         &scope.record,
                         device_handle,
+                        Some(ctx),
                         *target,
                         render_cmds,
                         &command_list7,
                         frame_table_prologue_in_cb,
                     )?;
+                    if let Some(row) = prologue_row {
+                        cmd_ctx.frame_table_row = Some(row);
+                    }
                     frame_table_prologue_in_cb |= touched;
                     {
                         let render_targets_read = scope.render_targets().read().unwrap();
@@ -2336,6 +2365,7 @@ pub(super) fn submit_graph_with_scope(
         );
         belt_idx_final = cmd_ctx.belt_idx;
         pending_deletions = cmd_ctx.pending_deletions;
+        frame_table_row = cmd_ctx.frame_table_row;
     }
 
     let tail = D3D12_GLOBAL_BARRIER {
@@ -2372,6 +2402,7 @@ pub(super) fn submit_graph_with_scope(
             retain_key,
             used_slots,
             frame_table_staging,
+            frame_table_row,
             pending_deletions,
         },
         StagingFinish {
@@ -2529,51 +2560,26 @@ fn evict_retained_on_context(
     }
 }
 
-/// Evict every retained graph on contexts for `device_handle` that pins `row`.
-///
-/// Called when the frame-table ring wraps and a new prologue needs to overwrite staging
-/// bytes for a row still held by a retained command list from partitioned retention.
-pub(super) fn evict_retained_pinning_row(
+pub(super) fn evict_retained_pinning_row_for_context(
     contexts: &types::SharedContextMap,
     frame_table: &super::frame_table::FrameTableDevice,
-    device_handle: DeviceHandle,
+    ctx: ContextHandle,
     row: u32,
 ) {
-    // Collect all (ctx, key) pairs that pin `row` under a single short-lived read guard,
-    // then drop the guard before calling evict_retained_on_context.
-    //
-    // evict_retained_on_context takes its own contexts.read() internally.  Windows
-    // SRWLOCK has write-priority: if any thread queues a write (e.g. context::destroy)
-    // between the outer read acquisition and the inner one, the inner read blocks while
-    // the outer read prevents the writer from completing — deadlock.  Releasing the
-    // guard before calling evict avoids the re-entrant read.
-    let evict_list: Vec<(ContextHandle, Vec<u64>)> = {
+    let keys: Vec<u64> = {
         let contexts_read = contexts.read().unwrap();
-        contexts_read
+        let Some(sc_arc) = contexts_read.get(&ctx) else {
+            return;
+        };
+        let sc = sc_arc.lock().unwrap();
+        sc.retained_graphs
             .iter()
-            .filter(|(_, sc_arc)| sc_arc.lock().unwrap().device == device_handle)
-            .filter_map(|(ctx_h, sc_arc)| {
-                let keys: Vec<u64> = sc_arc
-                    .lock()
-                    .unwrap()
-                    .retained_graphs
-                    .iter()
-                    .filter(|(_, g)| g.frame_table_row == Some(row))
-                    .map(|(k, _)| *k)
-                    .collect();
-                if keys.is_empty() {
-                    None
-                } else {
-                    Some((*ctx_h, keys))
-                }
-            })
+            .filter(|(_, g)| g.frame_table_row == Some(row))
+            .map(|(k, _)| *k)
             .collect()
-    }; // contexts_read dropped here — no read guard held during eviction
-
-    for (ctx, keys) in evict_list {
-        for key in keys {
-            evict_retained_on_context(contexts, frame_table, ctx, key);
-        }
+    };
+    for key in keys {
+        evict_retained_on_context(contexts, frame_table, ctx, key);
     }
 }
 

--- a/src/backend/dx12/context.rs
+++ b/src/backend/dx12/context.rs
@@ -26,11 +26,23 @@ pub(super) fn device_retired(state: &Dx12State, device: DeviceHandle) -> u64 {
         .get(&device)
         .map(|d| unsafe { d.fence.GetCompletedValue() })
         .unwrap_or(0);
-    floor.max(max_ctx).max(device_sync)
+    let retired = floor.max(max_ctx).max(device_sync);
+    if retired == u64::MAX {
+        if let Some(ld) = state.devices.get(&device) {
+            super::diagnostic::first_touch_device_removed(
+                &ld.device,
+                &state.device_removed,
+                "dx12::context::device_retired",
+                0,
+                retired,
+            );
+        }
+    }
+    retired
 }
 
 pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<ContextHandle> {
-    let ld = state.devices.get(&device).context("Invalid device handle")?;
+    let ld = state.devices.get(&device).context("Invalid device handle")?.clone();
 
     let fence: ID3D12Fence = unsafe { ld.device.CreateFence(0, D3D12_FENCE_FLAG_NONE) }
         .context("Failed to create per-context DX12 fence")?;
@@ -62,6 +74,8 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
     let id = state.next_context_id;
     state.next_context_id = state.next_context_id.saturating_add(1);
 
+    let frame_table = super::frame_table::init_context(state, device, &ld)?;
+
     // Register the fence in the lock-free index before inserting the context so that
     // any concurrent drain_ready_slot_reclamations sees a consistent view.
     state
@@ -83,9 +97,89 @@ pub(super) fn create(state: &mut Dx12State, device: DeviceHandle) -> Result<Cont
             staging_belt: super::staging::StagingBelt::new(super::staging::DEFAULT_STAGING_CHUNK_SIZE),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
             deletion_queue: super::types::DeletionQueue::new(),
+            frame_table,
+            reclamation_context: None,
         })),
     );
     Ok(id)
+}
+
+/// Context handles live on `device`, filtered via the lock-free `context_fences` map
+/// (keyed by `DeviceHandle` without requiring any `sc_arc` mutex acquisition).
+///
+/// Critical for avoiding cross-test/cross-device lock contention: `state.contexts` is a
+/// single global map shared by every `Device` in the process, so scanning it and locking
+/// every `sc_arc` just to filter by device would serialize buffer destroys against
+/// unrelated, concurrently-running tests' in-flight GPU waits (see issue: `cargo test`
+/// runs tests in parallel by default, each with its own `Device`/contexts).
+fn contexts_on_device(state: &Dx12State, device: DeviceHandle) -> Vec<ContextHandle> {
+    let result: Vec<ContextHandle> = state
+        .context_fences
+        .read()
+        .unwrap()
+        .iter()
+        .filter(|(_, (dev, _))| *dev == device)
+        .map(|(h, _)| *h)
+        .collect();
+    result
+}
+
+/// Returns the `ContextHandle` whose reclamation context is installed on the current thread.
+pub(super) fn context_handle_for_thread(state: &Dx12State, device: DeviceHandle) -> Option<ContextHandle> {
+    let thread = std::thread::current().id();
+    let contexts = state.contexts.read().unwrap();
+    contexts_on_device(state, device).into_iter().find_map(|h| {
+        let sc_arc = contexts.get(&h)?;
+        let sc = sc_arc.lock().expect("context Mutex poisoned");
+        if let Some((t, _)) = sc.reclamation_context {
+            if t == thread {
+                return Some(h);
+            }
+        }
+        None
+    })
+}
+
+/// When exactly one live context exists on `device`, return it for destroy attribution.
+pub(super) fn sole_context_on_device(state: &Dx12State, device: DeviceHandle) -> Option<ContextHandle> {
+    let mut on_device = contexts_on_device(state, device);
+    if on_device.len() == 1 {
+        on_device.pop()
+    } else {
+        None
+    }
+}
+
+/// Context to receive a user-initiated buffer destroy (thread reclamation scope, else sole context).
+pub(super) fn destroy_attribution_context(state: &Dx12State, device: DeviceHandle) -> Option<ContextHandle> {
+    context_handle_for_thread(state, device).or_else(|| sole_context_on_device(state, device))
+}
+
+/// Fence barrier for deferred buffer destruction on `device`.
+pub(super) fn reclamation_barrier(state: &Dx12State, device: DeviceHandle) -> u64 {
+    let thread = std::thread::current().id();
+    let candidates = contexts_on_device(state, device);
+    if !candidates.is_empty() {
+        let contexts = state.contexts.read().unwrap();
+        for h in candidates {
+            if let Some(sc_arc) = contexts.get(&h) {
+                let sc = sc_arc.lock().expect("context Mutex poisoned");
+                if let Some((t, epoch)) = sc.reclamation_context {
+                    if t == thread {
+                        return epoch;
+                    }
+                }
+            }
+        }
+    }
+    state
+        .devices
+        .get(&device)
+        .map(|d| {
+            let timeline_next = d.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
+            timeline_next.saturating_sub(1)
+        })
+        .unwrap_or(0)
 }
 
 pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
@@ -118,9 +212,7 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
 
     for old in sc.retained_graphs.drain().map(|(_, g)| g) {
         if let Some(row) = old.frame_table_row {
-            if let Some(ft) = state.frame_tables.read().unwrap().get(&device) {
-                super::frame_table::unpin_row(ft, row);
-            }
+            super::frame_table::unpin_row(&sc.frame_table, row);
         }
         if let Some(slot) = sc.compute_allocator_pool.get_mut(old.slot_idx) {
             slot.retained = false;
@@ -141,6 +233,24 @@ pub(super) fn destroy(state: &mut Dx12State, ctx: ContextHandle) {
                 super::types::destroy_pending_deletion(ld, &mut registry, resource);
             }
         }
+    }
+
+    super::frame_table::destroy_context(state, device, &sc.frame_table);
+}
+
+/// Drain per-context deferred deletions retired up to `completed` on the render/wait thread.
+pub(super) fn drain_context_deletion_queue_up_to(
+    ld: &super::types::LogicalDevice,
+    sc: &mut super::types::Dx12SubmissionContext,
+    completed: u64,
+) {
+    let batch = sc.deletion_queue.drain_up_to_completed(completed);
+    if batch.is_empty() {
+        return;
+    }
+    let mut registry = ld.descriptors.lock().unwrap();
+    for resource in batch {
+        super::types::destroy_pending_deletion(ld, &mut registry, resource);
     }
 }
 

--- a/src/backend/dx12/device.rs
+++ b/src/backend/dx12/device.rs
@@ -416,17 +416,22 @@ pub(super) fn create(state: &mut Dx12State, adapter_id: u32) -> Result<DeviceHan
             compute_batch_dispatch_signature,
             zero_buffer,
             deletion_queue: std::sync::Mutex::new(super::types::DeletionQueue::new()),
+            pending_buffer_gpu_releases: std::sync::Mutex::new(Vec::new()),
+            device_removed: std::sync::Arc::clone(&state.device_removed),
             descriptors: std::sync::Arc::new(std::sync::Mutex::new(super::types::DescriptorRegistry::new())),
             pso_cache: std::sync::Arc::new(std::sync::RwLock::new(super::types::PsoCache::new(
                 graphics_pso_blobs,
                 compute_pso_blobs,
             ))),
             queue_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
+            legacy_frame_table: std::sync::Mutex::new(None),
         }),
     );
 
-    let ld = state.devices.get(&handle).unwrap().clone();
-    super::frame_table::init_device(state, handle, &ld)?;
+    {
+        let ld = state.devices.get(&handle).unwrap();
+        super::frame_table::reserve_device_bindless_slots(ld);
+    }
 
     tracing::info!("Created DX12 device {} for adapter {}", handle, adapter_id);
     Ok(handle)

--- a/src/backend/dx12/diagnostic.rs
+++ b/src/backend/dx12/diagnostic.rs
@@ -26,6 +26,139 @@ pub(crate) fn log_warp_module_path_once() {
     });
 }
 
+/// Set `D3D12_ENABLE_DRED=1` before the first D3D12 DLL load.
+#[cfg(windows)]
+pub(crate) fn prepare_dred_env() {
+    if std::env::var("D3D12_ENABLE_DRED").is_err() {
+        // SAFETY: `DEBUG_LAYER_INIT` runs once before any D3D12 device creation.
+        unsafe { std::env::set_var("D3D12_ENABLE_DRED", "1") };
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn prepare_dred_env() {}
+
+/// Enable DRED auto-breadcrumbs and page-fault capture via the settings interface.
+/// Must run after `EnableDebugLayer` and before `D3D12CreateDevice`.
+///
+/// DRED settings are a separate COM object from [`ID3D12Debug`] — obtain them with their
+/// own `D3D12GetDebugInterface` query (casting from `ID3D12Debug` fails on all platforms).
+#[cfg(windows)]
+pub(crate) fn enable_dred_settings() {
+    use windows::Win32::Graphics::Direct3D12::{
+        D3D12GetDebugInterface, ID3D12DeviceRemovedExtendedDataSettings, ID3D12DeviceRemovedExtendedDataSettings1,
+        D3D12_DRED_ENABLEMENT_FORCED_ON,
+    };
+
+    let mut settings1: Option<ID3D12DeviceRemovedExtendedDataSettings1> = None;
+    if unsafe { D3D12GetDebugInterface(&mut settings1) }.is_ok() {
+        if let Some(settings1) = settings1 {
+            unsafe {
+                settings1.SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+                settings1.SetPageFaultEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+                settings1.SetWatsonDumpEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+                settings1.SetBreadcrumbContextEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+            }
+            tracing::info!("D3D12 DRED enabled (ID3D12DeviceRemovedExtendedDataSettings1)");
+            return;
+        }
+    }
+
+    let mut settings: Option<ID3D12DeviceRemovedExtendedDataSettings> = None;
+    if unsafe { D3D12GetDebugInterface(&mut settings) }.is_ok() {
+        if let Some(settings) = settings {
+            unsafe {
+                settings.SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+                settings.SetPageFaultEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+                settings.SetWatsonDumpEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+            }
+            tracing::info!("D3D12 DRED enabled (ID3D12DeviceRemovedExtendedDataSettings)");
+            return;
+        }
+    }
+
+    tracing::warn!(
+        target: "goldy::backend::dx12::diagnostic",
+        "ID3D12DeviceRemovedExtendedDataSettings not available — DRED API setup skipped \
+         (D3D12_ENABLE_DRED=1 was set; breadcrumbs may still be active on Win11 22H2+ / recent Agility SDK)"
+    );
+}
+
+#[cfg(not(windows))]
+pub(crate) fn enable_dred_settings() {}
+
+/// First detection of fence `u64::MAX` / device removal: log DRED once and dump the del ring.
+pub(crate) fn first_touch_device_removed(
+    device: &windows::Win32::Graphics::Direct3D12::ID3D12Device10,
+    device_removed: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    _location: &str,
+    _wait_value: u64,
+    completed: u64,
+) {
+    if completed != u64::MAX {
+        return;
+    }
+    if device_removed
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        )
+        .is_ok()
+    {
+        log_dred_on_device_removed(device);
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn first_touch_device_removed(
+    _device: &(),
+    _device_removed: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    _location: &str,
+    _wait_value: u64,
+    _completed: u64,
+) {
+}
+
+/// Log safe, scalar DRED metadata after device removal (TDR/hang).
+///
+/// Does **not** walk DRED linked-list pointers — those can be stale immediately after removal
+/// and have caused access violations when queried from error paths such as `ResizeBuffers`.
+/// Full breadcrumb dumps belong in WinDbg / PIX after attaching post-mortem.
+#[cfg(windows)]
+pub(crate) fn log_dred_on_device_removed(device: &windows::Win32::Graphics::Direct3D12::ID3D12Device10) {
+    use windows::core::Interface;
+    use windows::Win32::Graphics::Direct3D12::ID3D12DeviceRemovedExtendedData2;
+
+    let reason = unsafe { device.GetDeviceRemovedReason() };
+    tracing::error!(target: "goldy::dx12::dred", ?reason, "GetDeviceRemovedReason");
+
+    if let Ok(dred) = device.cast::<ID3D12DeviceRemovedExtendedData2>() {
+        let state = unsafe { dred.GetDeviceState() };
+        tracing::error!(target: "goldy::dx12::dred", ?state, "DRED device state");
+
+        let mut fault = Default::default();
+        if unsafe { dred.GetPageFaultAllocationOutput2(&mut fault) }.is_ok() {
+            tracing::error!(
+                target: "goldy::dx12::dred",
+                page_fault_va = fault.PageFaultVA,
+                page_fault_flags = fault.PageFaultFlags.0,
+                "DRED page fault (see WinDbg/PIX for allocation breadcrumb lists)"
+            );
+        }
+    }
+
+    tracing::error!(
+        target: "goldy::dx12::dred",
+        "DRED auto-breadcrumb linked lists omitted here (unsafe to walk from process after TDR); \
+         attach WinDbg or enable WDDM DRED dump collection for full command history"
+    );
+}
+
+#[cfg(not(windows))]
+pub(crate) fn log_dred_on_device_removed(_device: &()) {}
+
 #[cfg(windows)]
 mod windows_impl {
     use std::ffi::{c_void, OsString};

--- a/src/backend/dx12/frame_table.rs
+++ b/src/backend/dx12/frame_table.rs
@@ -1,45 +1,59 @@
 //! DX12 frame-table buffers and prologue (staging upload + device-local copy).
 
-use super::types::{BufferState, Dx12State, LogicalDevice};
+use super::types::{BufferState, Dx12State, LogicalDevice, SharedFrameTableDevice};
 use super::BufferHandle;
 use crate::backend::GpuCommand;
 use crate::frame_table::{
-    FRAME_TABLE_DEVICE_SLOT, FRAME_TABLE_MAX_ROWS, FRAME_TABLE_ROW_STRIDE, FRAME_TABLE_SELECTOR_SLOT,
-    FRAME_TABLE_STAGING_BYTES, FRAME_TABLE_TABLE_U32S, FRAME_TABLE_USER_SLOT_BASE,
+    FRAME_TABLE_MAX_ROWS, FRAME_TABLE_ROW_STRIDE, FRAME_TABLE_STAGING_BYTES, FRAME_TABLE_TABLE_U32S,
+    FRAME_TABLE_USER_SLOT_BASE,
 };
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use windows::Win32::Graphics::Direct3D12::*;
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_UNKNOWN, DXGI_SAMPLE_DESC};
 
-/// Per-device frame-table GPU resources.
+/// Per-context frame-table GPU resources and ring state.
 pub(crate) struct FrameTableDevice {
     pub selector: BufferHandle,
     pub device_table: BufferHandle,
+    /// Bindless heap slot of this context's selector cell (shader `_rs1`).
+    pub selector_slot: u32,
+    /// Bindless heap slot of this context's device-local table (shader `_rs2`).
+    pub table_slot: u32,
     pub staging: ID3D12Resource,
     pub staging_mapped: usize,
     pub submission_counter: AtomicU32,
     /// Bitmask of rows pinned by retained command lists (must not be overwritten).
     pub pinned_rows: AtomicU32,
-    /// Last `submission_counter` value that wrote each row (ring reuse guard).
-    pub last_sub_for_row: [AtomicU32; FRAME_TABLE_MAX_ROWS as usize],
 }
 
-/// Create frame-table buffers at reserved bindless slots 0 and 1.
-pub(crate) fn init_device(state: &mut Dx12State, device_handle: super::DeviceHandle, ld: &LogicalDevice) -> Result<()> {
-    let selector = create_scattered_u32_buffer_at_slot(
+/// Reserve user bindless slots once per device (low protocol slots stay unused).
+pub(crate) fn reserve_device_bindless_slots(ld: &LogicalDevice) {
+    ld.descriptors
+        .lock()
+        .unwrap()
+        .resource_registry
+        .ensure_cbv_start(FRAME_TABLE_USER_SLOT_BASE);
+}
+
+/// Create per-context frame-table buffers at per-context bindless slots.
+///
+/// Slots come from the device's descriptor registry (like any other buffer),
+/// so concurrent contexts on one device never share mutable descriptor slots
+/// and no rebinding at execute time is needed. The slot indices reach shaders
+/// via push constants (`_rs1`/`_rs2`).
+pub(crate) fn init_context(
+    state: &mut Dx12State,
+    device_handle: super::DeviceHandle,
+    ld: &LogicalDevice,
+) -> Result<SharedFrameTableDevice> {
+    let (selector, selector_slot) =
+        create_scattered_u32_buffer_registered(state, device_handle, ld, 1, "goldy_frame_table_selector")?;
+    let (device_table, table_slot) = create_scattered_u32_buffer_registered(
         state,
         device_handle,
         ld,
-        FRAME_TABLE_SELECTOR_SLOT,
-        1,
-        "goldy_frame_table_selector",
-    )?;
-    let device_table = create_scattered_u32_buffer_at_slot(
-        state,
-        device_handle,
-        ld,
-        FRAME_TABLE_DEVICE_SLOT,
         FRAME_TABLE_TABLE_U32S as u32,
         "goldy_frame_table_device",
     )?;
@@ -63,29 +77,104 @@ pub(crate) fn init_device(state: &mut Dx12State, device_handle: super::DeviceHan
         .unwrap()
         .element_stride = Some(4);
 
-    {
-        let dev = state.devices.get(&device_handle).context("init frame table")?;
-        dev.descriptors
-            .lock()
-            .unwrap()
-            .resource_registry
-            .ensure_cbv_start(FRAME_TABLE_USER_SLOT_BASE);
+    let ft = SharedFrameTableDevice::new(FrameTableDevice {
+        selector,
+        device_table,
+        selector_slot,
+        table_slot,
+        staging,
+        staging_mapped,
+        submission_counter: AtomicU32::new(0),
+        pinned_rows: AtomicU32::new(0),
+    });
+
+    let buffers = state.buffers.read().unwrap();
+    bind_to_bindless_heap(ld, &ft, &buffers.entries)?;
+
+    Ok(ft)
+}
+
+/// Lazy-init the device-owned frame table used by legacy `render_to_target`.
+///
+/// Standalone render passes have no submission context; they must not borrow a
+/// live context's ring buffer or advance its `submission_counter`.
+pub(crate) fn ensure_legacy_frame_table(
+    state: &mut Dx12State,
+    device_handle: super::DeviceHandle,
+) -> Result<SharedFrameTableDevice> {
+    let ld = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?
+        .clone();
+    let mut guard = ld.legacy_frame_table.lock().unwrap();
+    if let Some(ft) = guard.as_ref() {
+        return Ok(std::sync::Arc::clone(ft));
     }
+    let ft = init_context(state, device_handle, &ld)?;
+    *guard = Some(std::sync::Arc::clone(&ft));
+    Ok(ft)
+}
 
-    state.frame_tables.write().unwrap().insert(
-        device_handle,
-        std::sync::Arc::new(FrameTableDevice {
-            selector,
-            device_table,
-            staging,
-            staging_mapped,
-            submission_counter: AtomicU32::new(0),
-            pinned_rows: AtomicU32::new(0),
-            last_sub_for_row: std::array::from_fn(|_| AtomicU32::new(0)),
-        }),
-    );
-
+/// Write this context's selector/table UAV descriptors at its per-context slots.
+///
+/// Called once at context init; the slots are context-private for the context's
+/// lifetime, so no rebinding at execute time is ever needed.
+pub(crate) fn bind_to_bindless_heap(
+    ld: &LogicalDevice,
+    ft: &FrameTableDevice,
+    buffers: &HashMap<BufferHandle, BufferState>,
+) -> Result<()> {
+    let selector = buffers.get(&ft.selector).context("frame table selector")?;
+    let device_table = buffers.get(&ft.device_table).context("frame table device table")?;
+    write_uav_at_slot(ld, ft.selector_slot, &selector.resource, 1)?;
+    write_uav_at_slot(ld, ft.table_slot, &device_table.resource, FRAME_TABLE_TABLE_U32S as u32)?;
     Ok(())
+}
+
+fn write_uav_at_slot(ld: &LogicalDevice, bindless_slot: u32, resource: &ID3D12Resource, num_u32s: u32) -> Result<()> {
+    let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
+        Format: DXGI_FORMAT_UNKNOWN,
+        ViewDimension: D3D12_UAV_DIMENSION_BUFFER,
+        Anonymous: D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
+            Buffer: D3D12_BUFFER_UAV {
+                FirstElement: 0,
+                NumElements: num_u32s,
+                StructureByteStride: 4,
+                CounterOffsetInBytes: 0,
+                Flags: D3D12_BUFFER_UAV_FLAG_NONE,
+            },
+        },
+    };
+    let cpu_handle = unsafe {
+        let mut h = ld.cbv_srv_uav_heap.GetCPUDescriptorHandleForHeapStart();
+        h.ptr += (bindless_slot * ld.cbv_srv_uav_descriptor_size) as usize;
+        h
+    };
+    unsafe {
+        ld.device
+            .CreateUnorderedAccessView(resource, None, Some(&uav_desc), cpu_handle);
+    }
+    Ok(())
+}
+
+/// Destroy per-context frame-table resources: staging memory, the selector and
+/// table buffer entries, and their per-context bindless slots.
+///
+/// Caller guarantees the context's GPU work has fully retired.
+pub(crate) fn destroy_context(state: &Dx12State, device_handle: super::DeviceHandle, ft: &FrameTableDevice) {
+    unsafe {
+        ft.staging.Unmap(0, None);
+    }
+    let mut buffers = state.buffers.write().unwrap();
+    buffers.entries.remove(&ft.selector);
+    buffers.entries.remove(&ft.device_table);
+    drop(buffers);
+    if let Some(ld) = state.devices.get(&device_handle) {
+        let mut registry = ld.descriptors.lock().unwrap();
+        registry.reclaim_buffer_slots(ft.selector);
+        registry.reclaim_buffer_slots(ft.device_table);
+    }
 }
 
 fn create_upload_table_buffer(ld: &LogicalDevice) -> Result<(ID3D12Resource, usize)> {
@@ -131,16 +220,14 @@ fn create_upload_table_buffer(ld: &LogicalDevice) -> Result<(ID3D12Resource, usi
     Ok((resource, ptr as usize))
 }
 
-fn create_scattered_u32_buffer_at_slot(
+fn create_scattered_u32_buffer_registered(
     state: &mut Dx12State,
     device_handle: super::DeviceHandle,
     ld: &LogicalDevice,
-    bindless_slot: u32,
     num_u32s: u32,
     debug_name: &str,
-) -> Result<BufferHandle> {
+) -> Result<(BufferHandle, u32)> {
     let logical_size = (num_u32s as u64) * 4;
-    // D3D12 buffer resources require 256-byte alignment for UAV/CBV views on some drivers.
     let size = logical_size.max(256);
     let heap = D3D12_HEAP_PROPERTIES {
         Type: D3D12_HEAP_TYPE_DEFAULT,
@@ -179,30 +266,13 @@ fn create_scattered_u32_buffer_at_slot(
         let _ = unsafe { resource.SetName(&name) };
     }
 
-    let uav_desc = D3D12_UNORDERED_ACCESS_VIEW_DESC {
-        Format: DXGI_FORMAT_UNKNOWN,
-        ViewDimension: D3D12_UAV_DIMENSION_BUFFER,
-        Anonymous: D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
-            Buffer: D3D12_BUFFER_UAV {
-                FirstElement: 0,
-                NumElements: num_u32s,
-                StructureByteStride: 4,
-                CounterOffsetInBytes: 0,
-                Flags: D3D12_BUFFER_UAV_FLAG_NONE,
-            },
-        },
-    };
-    let cpu_handle = unsafe {
-        let mut h = ld.cbv_srv_uav_heap.GetCPUDescriptorHandleForHeapStart();
-        h.ptr += (bindless_slot * ld.cbv_srv_uav_descriptor_size) as usize;
-        h
-    };
-    unsafe {
-        ld.device
-            .CreateUnorderedAccessView(&resource, None, Some(&uav_desc), cpu_handle);
-    }
-
     let handle = state.buffers.write().unwrap().alloc_handle();
+    let bindless_slot = ld
+        .descriptors
+        .lock()
+        .unwrap()
+        .resource_registry
+        .register_buffer_uav(handle);
     state.buffers.write().unwrap().entries.insert(
         handle,
         BufferState {
@@ -230,7 +300,7 @@ fn create_scattered_u32_buffer_at_slot(
             texture_copy_footprint: None,
         },
     );
-    Ok(handle)
+    Ok((handle, bindless_slot))
 }
 
 fn transition_buffer(
@@ -275,56 +345,32 @@ pub(crate) fn unpin_row(ft: &FrameTableDevice, row: u32) {
     ft.pinned_rows.fetch_and(!bit, Ordering::AcqRel);
 }
 
-/// Row used by the most recent prologue (before counter bump on next submission).
-pub(crate) fn last_prologue_row(ft: &FrameTableDevice) -> Option<u32> {
-    let sub = ft.submission_counter.load(Ordering::Relaxed);
-    if sub == 0 {
-        None
-    } else {
-        Some((sub - 1) % FRAME_TABLE_MAX_ROWS)
-    }
-}
-
-fn assert_row_available(ft: &FrameTableDevice, sub: u32, row: u32) -> Result<()> {
-    let pinned = ft.pinned_rows.load(Ordering::Acquire);
-    if pinned & (1 << row) != 0 {
+fn assert_row_available(ft: &FrameTableDevice, row: u32) -> Result<()> {
+    if ft.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0 {
         anyhow::bail!(
-            "frame table row {row} is still pinned after evicting retained graphs \
-             (sub={sub}); retained command list lifecycle bug"
+            "frame table row {row} is still pinned after evicting retained graphs; \
+             retained command list lifecycle bug"
         );
-    }
-    if sub >= FRAME_TABLE_MAX_ROWS {
-        let prev = ft.last_sub_for_row[row as usize].load(Ordering::Acquire);
-        let gap = sub - prev;
-        if gap < FRAME_TABLE_MAX_ROWS {
-            anyhow::bail!(
-                "frame table row capacity exceeded: row {row} may still be in flight \
-                 (sub={sub}, last_sub_for_row={prev}, need gap >= {FRAME_TABLE_MAX_ROWS})"
-            );
-        }
     }
     Ok(())
 }
 
-/// CPU staging write before a retained resubmit (row bump + table bytes; GPU copy is in the CB).
+/// CPU staging write before a submission (row bump + table bytes; GPU copy is in the CB).
 pub(crate) fn write_staging_for_submission(
     contexts: &super::types::SharedContextMap,
+    ctx: super::ContextHandle,
     frame_table: &FrameTableDevice,
-    device_handle: super::DeviceHandle,
     data: &[u32],
 ) -> Result<u32> {
     let sub = frame_table.submission_counter.fetch_add(1, Ordering::Relaxed);
     let row = sub % FRAME_TABLE_MAX_ROWS;
-    let row_pinned = frame_table.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0;
-    if row_pinned {
-        super::compute::evict_retained_pinning_row(contexts, frame_table, device_handle, row);
+    if frame_table.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0 {
+        super::compute::evict_retained_pinning_row_for_context(contexts, frame_table, ctx, row);
     }
+    assert_row_available(frame_table, row)?;
     let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
     let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
     let staging_ptr = frame_table.staging_mapped as *mut u32;
-    assert_row_available(frame_table, sub, row)?;
-    frame_table.last_sub_for_row[row as usize].store(sub, Ordering::Release);
-    // Staging selector word `row` always holds the value `row` (matches baked copy offset).
     unsafe {
         let payload_dst =
             staging_ptr.add(crate::frame_table::FRAME_TABLE_STAGING_SELECTOR_U32S + row as usize * row_u32s);
@@ -394,17 +440,30 @@ pub(crate) fn sync_table_row_to_device(
     Ok(())
 }
 
-/// CPU staging write + GPU copy prologue.
-pub(crate) fn record_prologue(
-    contexts: &super::types::SharedContextMap,
+/// CPU staging write for legacy standalone render (no context eviction).
+fn write_staging_standalone(frame_table: &FrameTableDevice, data: &[u32]) -> Result<u32> {
+    let sub = frame_table.submission_counter.fetch_add(1, Ordering::Relaxed);
+    let row = sub % FRAME_TABLE_MAX_ROWS;
+    assert_row_available(frame_table, row)?;
+    let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
+    let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
+    let staging_ptr = frame_table.staging_mapped as *mut u32;
+    unsafe {
+        let payload_dst =
+            staging_ptr.add(crate::frame_table::FRAME_TABLE_STAGING_SELECTOR_U32S + row as usize * row_u32s);
+        std::ptr::copy_nonoverlapping(data.as_ptr(), payload_dst, copy_u32s);
+        std::ptr::write(staging_ptr.add(row as usize), row);
+    }
+    Ok(row)
+}
+
+fn record_prologue_gpu_copies(
     frame_table: &FrameTableDevice,
-    buffers: &std::collections::HashMap<BufferHandle, BufferState>,
-    device_handle: super::DeviceHandle,
+    buffers: &HashMap<BufferHandle, BufferState>,
     cl: &ID3D12GraphicsCommandList7,
     data: &[u32],
+    row: u32,
 ) -> Result<()> {
-    let row = write_staging_for_submission(contexts, frame_table, device_handle, data)?;
-
     let device_table = buffers.get(&frame_table.device_table).context("device table")?;
     let selector_state = buffers.get(&frame_table.selector).context("selector")?;
     let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
@@ -462,8 +521,39 @@ pub(crate) fn record_prologue(
         D3D12_RESOURCE_STATE_COPY_SOURCE,
         D3D12_RESOURCE_STATE_GENERIC_READ,
     );
-
     Ok(())
+}
+
+/// CPU staging write + GPU copy prologue for legacy `render_to_target`.
+pub(crate) fn record_prologue_legacy(
+    frame_table: &FrameTableDevice,
+    buffers: &HashMap<BufferHandle, BufferState>,
+    cl: &ID3D12GraphicsCommandList7,
+    data: &[u32],
+) -> Result<u32> {
+    let row = write_staging_standalone(frame_table, data)?;
+    record_prologue_gpu_copies(frame_table, buffers, cl, data, row)?;
+    Ok(row)
+}
+
+/// CPU staging write + GPU copy prologue.
+///
+/// The prologue copies the active row index into this context's selector buffer.
+/// That buffer is shared across all command lists on the context; correctness
+/// assumes every submission for the context runs on the same FIFO queue so
+/// command lists retire in submit order and a later prologue cannot clobber the
+/// selector while an earlier list's dispatches are still executing.
+pub(crate) fn record_prologue(
+    contexts: &super::types::SharedContextMap,
+    ctx: super::ContextHandle,
+    frame_table: &FrameTableDevice,
+    buffers: &HashMap<BufferHandle, BufferState>,
+    cl: &ID3D12GraphicsCommandList7,
+    data: &[u32],
+) -> Result<u32> {
+    let row = write_staging_for_submission(contexts, ctx, frame_table, data)?;
+    record_prologue_gpu_copies(frame_table, buffers, cl, data, row)?;
+    Ok(row)
 }
 
 pub(crate) fn extract_staging_from_commands(commands: &[GpuCommand]) -> Option<std::sync::Arc<[u32]>> {
@@ -553,9 +643,10 @@ pub(crate) fn prepare_render_commands(
 /// Lower render commands and build staging (backend state lookup).
 pub(crate) fn prepare_render_commands_state(
     state: &Dx12State,
+    ctx: super::ContextHandle,
     device_handle: super::DeviceHandle,
     commands: &[crate::backend::RenderCommand],
 ) -> Result<(Vec<u32>, Vec<crate::backend::RenderCommand>, bool)> {
-    let record = super::submit_session::record_state_from_backend(state, device_handle)?;
+    let record = super::submit_session::record_state_from_backend(state, ctx, device_handle)?;
     prepare_render_commands(&record, commands)
 }

--- a/src/backend/dx12/mod.rs
+++ b/src/backend/dx12/mod.rs
@@ -134,6 +134,13 @@ pub fn is_debug_mode() -> bool {
     !no_debug && (cfg!(debug_assertions) || std::env::var("GOLDY_DX12_DEBUG").is_ok_and(|v| v == "1" || v == "true"))
 }
 
+pub(crate) fn env_enable_dred() -> bool {
+    if std::env::var("GOLDY_DX12_NO_DRED").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")) {
+        return false;
+    }
+    is_debug_mode() || std::env::var("GOLDY_DX12_DRED").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
 /// Get or create a DX12 backend for one [`crate::Instance`].
 ///
 /// Each instance owns independent `Dx12State` (resource tables, contexts, devices) so
@@ -183,8 +190,7 @@ impl Dx12Backend {
             next_dsv_offset: 0,
             free_dsv_offsets: Vec::new(),
             slang_compiler,
-            device_removed: std::sync::atomic::AtomicBool::new(false),
-            frame_tables: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
+            device_removed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         Ok(Self { state })
@@ -194,7 +200,7 @@ impl Dx12Backend {
     fn wait_for_gpu(&self, device: &LogicalDevice) -> Result<()> {
         let fence_value = device.timeline_next.load(std::sync::atomic::Ordering::Relaxed);
         unsafe { device.command_queue.Signal(&device.fence, fence_value) }.context("Failed to signal fence")?;
-        utils::wait_for_fence(&device.fence, fence_value)
+        utils::wait_for_fence_on_device(&device.fence, fence_value, Some(device))
     }
 }
 
@@ -210,7 +216,12 @@ impl Dx12Backend {
             logical_device
                 .timeline_next
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            logical_device.flush_deletion_queue();
+            let fences = self.state.context_fences.read().unwrap();
+            logical_device.flush_deletion_queue(&fences);
+
+            if let Some(ft) = logical_device.legacy_frame_table.lock().unwrap().take() {
+                frame_table::destroy_context(&self.state, device_handle, &ft);
+            }
 
             let pso_cache = logical_device.pso_cache.read().unwrap();
             if pso_cache.dirty {
@@ -389,20 +400,29 @@ impl crate::backend::GpuBackendTimelineWait for Dx12Backend {
         // Detect TDR: device removal signals all fences with u64::MAX.
         let completed = unsafe { fence.GetCompletedValue() };
         if completed == u64::MAX {
-            self.state
-                .device_removed
-                .store(true, std::sync::atomic::Ordering::Relaxed);
             if let Some(ld) = self.state.devices.get(&device_handle) {
+                diagnostic::first_touch_device_removed(
+                    &ld.device,
+                    &self.state.device_removed,
+                    "dx12::finish_timeline_wait",
+                    value,
+                    completed,
+                );
                 let reason = unsafe { ld.device.GetDeviceRemovedReason() };
                 anyhow::bail!("GPU device removed (TDR): {:?}", reason);
             }
             anyhow::bail!("GPU device removed (TDR)");
         }
         let retired = context::device_retired(&self.state, device_handle);
+        let drain_to = value.min(retired);
         if let Some(ld) = self.state.devices.get(&device_handle) {
-            ld.process_deletion_queue_up_to(value.min(retired));
-            let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
+            if let Some(sc_arc) = self.state.contexts.read().unwrap().get(&ctx).cloned() {
+                let mut sc = sc_arc.lock().unwrap();
+                context::drain_context_deletion_queue_up_to(ld, &mut sc, drain_to);
+            }
             let fences = self.state.context_fences.read().unwrap();
+            ld.process_deletion_queue_up_to(drain_to, &fences);
+            let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
             descriptors_arc.lock().unwrap().drain_ready_slot_reclamations(&fences);
         }
         Ok(())
@@ -515,6 +535,18 @@ impl GpuBackend for Dx12Backend {
             ld: std::sync::Arc::clone(self.state.devices.get(&device_handle)?),
             context_fences: std::sync::Arc::clone(&self.state.context_fences),
         }))
+    }
+
+    fn clone_context_reclamation_scope(
+        &self,
+        ctx: ContextHandle,
+    ) -> std::sync::Arc<dyn crate::backend::ContextReclamationScope> {
+        if let Some(sc) = self.state.contexts.read().unwrap().get(&ctx) {
+            return std::sync::Arc::new(Dx12ContextReclamationScope {
+                sc: std::sync::Arc::clone(sc),
+            });
+        }
+        std::sync::Arc::new(crate::backend::NoOpReclamationScope)
     }
 
     fn context_device(&self, ctx: ContextHandle) -> DeviceHandle {
@@ -817,6 +849,7 @@ impl GpuBackend for Dx12Backend {
             frame.surface,
             frame.image,
             frame.present_slot,
+            frame.context,
             commands,
         )
     }
@@ -960,20 +993,29 @@ impl GpuBackend for Dx12Backend {
             // Detect TDR: device removal signals all fences with u64::MAX.
             let completed = unsafe { fence.GetCompletedValue() };
             if completed == u64::MAX {
-                self.state
-                    .device_removed
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
                 if let Some(ld) = self.state.devices.get(&device_handle) {
+                    diagnostic::first_touch_device_removed(
+                        &ld.device,
+                        &self.state.device_removed,
+                        "dx12::wait_for_context_timeout",
+                        value,
+                        completed,
+                    );
                     let reason = unsafe { ld.device.GetDeviceRemovedReason() };
                     anyhow::bail!("GPU device removed (TDR): {:?}", reason);
                 }
                 anyhow::bail!("GPU device removed (TDR)");
             }
             let retired = context::device_retired(&self.state, device_handle);
+            let drain_to = value.min(retired);
             if let Some(dev) = self.state.devices.get(&device_handle) {
-                dev.process_deletion_queue_up_to(value.min(retired));
-                let descriptors_arc = std::sync::Arc::clone(&dev.descriptors);
+                if let Some(sc_arc) = self.state.contexts.read().unwrap().get(&ctx).cloned() {
+                    let mut sc = sc_arc.lock().unwrap();
+                    context::drain_context_deletion_queue_up_to(dev, &mut sc, drain_to);
+                }
                 let fences = self.state.context_fences.read().unwrap();
+                dev.process_deletion_queue_up_to(drain_to, &fences);
+                let descriptors_arc = std::sync::Arc::clone(&dev.descriptors);
                 descriptors_arc.lock().unwrap().drain_ready_slot_reclamations(&fences);
             }
         }
@@ -1231,20 +1273,39 @@ impl GpuBackend for Dx12Backend {
         let device_handle = self.context_device(ctx);
         let retired = context::device_retired(&self.state, device_handle);
         if let Some(ld) = self.state.devices.get(&device_handle) {
-            ld.process_deletion_queue_up_to(retired);
-            let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
+            let ctx_batch: Vec<_> = self
+                .state
+                .contexts
+                .read()
+                .unwrap()
+                .get(&ctx)
+                .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to_completed(retired))
+                .unwrap_or_default();
+            if !ctx_batch.is_empty() {
+                let mut registry = ld.descriptors.lock().unwrap();
+                for resource in ctx_batch {
+                    types::destroy_pending_deletion(ld, &mut registry, resource);
+                }
+            }
             let fences = self.state.context_fences.read().unwrap();
+            ld.process_deletion_queue_up_to(retired, &fences);
+            let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
             descriptors_arc.lock().unwrap().drain_ready_slot_reclamations(&fences);
         }
     }
 
     fn deferred_deletion_pending_count(&self, ctx: ContextHandle) -> usize {
-        let device_handle = self.context_device(ctx);
-        self.state
-            .devices
-            .get(&device_handle)
-            .map(|d| d.deletion_queue.lock().unwrap().pending_len())
-            .unwrap_or(0)
+        let ctx_pending = self
+            .state
+            .contexts
+            .read()
+            .unwrap()
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.pending_len())
+            .unwrap_or(0);
+        // Per-context count only: device-global queue holds foreign/legacy destroys
+        // and must not pollute this context's reclaim horizon (see scheme_two_contexts_reclaim_independently).
+        ctx_pending
     }
 }
 
@@ -1308,6 +1369,18 @@ impl crate::backend::DeviceTimelineReader for Dx12DeviceTimelineReader {
     }
 }
 
+struct Dx12ContextReclamationScope {
+    sc: types::SharedSubmissionContext,
+}
+
+impl crate::backend::ContextReclamationScope for Dx12ContextReclamationScope {
+    fn set_epoch(&self, epoch: Option<crate::timeline::TimelineValue>) {
+        if let Ok(mut sc) = self.sc.lock() {
+            sc.reclamation_context = epoch.map(|epoch| (std::thread::current().id(), epoch));
+        }
+    }
+}
+
 struct Dx12ContextDeferredDeletionFlush {
     ctx: ContextHandle,
     sc: types::SharedSubmissionContext,
@@ -1338,6 +1411,6 @@ impl crate::backend::ContextDeferredDeletionFlush for Dx12ContextDeferredDeletio
             }
             registry.drain_ready_slot_reclamations(&fences);
         }
-        self.ld.process_deletion_queue_up_to(device_retired);
+        self.ld.process_deletion_queue_up_to(device_retired, &fences);
     }
 }

--- a/src/backend/dx12/process_shared.rs
+++ b/src/backend/dx12/process_shared.rs
@@ -7,7 +7,7 @@
 
 use super::device;
 use super::types::DxgiAdapterInfo;
-use super::{env_allow_warp, is_debug_mode, WARP_ADAPTER_ID};
+use super::{env_allow_warp, env_enable_dred, is_debug_mode, WARP_ADAPTER_ID};
 use anyhow::{Context, Result};
 use std::sync::{Arc, Once, OnceLock};
 use windows::core::Interface;
@@ -37,11 +37,20 @@ pub(crate) fn process_shared() -> Result<Arc<Dx12ProcessShared>> {
 fn init_process_shared() -> Result<Dx12ProcessShared> {
     DEBUG_LAYER_INIT.call_once(|| {
         if is_debug_mode() {
+            // Must be set before the first D3D12 DLL load (including GetDebugInterface).
+            if env_enable_dred() {
+                super::diagnostic::prepare_dred_env();
+            }
+
             let mut debug_interface: Option<ID3D12Debug> = None;
             if unsafe { D3D12GetDebugInterface(&mut debug_interface) }.is_ok() {
                 if let Some(d) = debug_interface {
                     unsafe { d.EnableDebugLayer() };
                     tracing::info!("D3D12 debug layer enabled");
+
+                    if env_enable_dred() {
+                        super::diagnostic::enable_dred_settings();
+                    }
 
                     let enable_gbv =
                         std::env::var("GOLDY_DX12_GBV").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));

--- a/src/backend/dx12/render_commands.rs
+++ b/src/backend/dx12/render_commands.rs
@@ -25,9 +25,10 @@ pub(super) fn record_state(
     cmd: &ID3D12GraphicsCommandList7,
     commands: &[RenderCommand],
     device_handle: DeviceHandle,
+    ctx: super::ContextHandle,
     state: &Dx12State,
 ) -> anyhow::Result<()> {
-    let record = super::submit_session::record_state_from_backend(state, device_handle)?;
+    let record = super::submit_session::record_state_from_backend(state, ctx, device_handle)?;
     record_with_tables(cmd, commands, device_handle, &record)
 }
 
@@ -115,6 +116,11 @@ fn record_with_tables(
                 }
                 let mut layout = types::PushLayout::default();
                 shared::fill_frame_table_dispatch(&mut layout, *frame_table_base, raw_user);
+                shared::set_frame_table_slots(
+                    &mut layout,
+                    record.frame_table.selector_slot,
+                    record.frame_table.table_slot,
+                );
                 unsafe {
                     cmd.SetGraphicsRoot32BitConstants(
                         0,

--- a/src/backend/dx12/render_target.rs
+++ b/src/backend/dx12/render_target.rs
@@ -6,6 +6,7 @@ use super::barriers;
 use super::types::RenderTargetState;
 use super::utils::{depth_format_to_dxgi, execute_command_lists_and_signal_device, format_to_dxgi, wait_for_fence};
 use super::{render_commands, DeviceHandle, Dx12State, RenderTargetHandle};
+use crate::backend::ContextHandle;
 use crate::backend::RenderCommand;
 use crate::types::{Color, DepthFormat, TextureFormat};
 use anyhow::{Context, Result};
@@ -221,11 +222,12 @@ pub(super) fn destroy(state: &mut Dx12State, target: RenderTargetHandle) {
 pub(super) fn record_render_pass_to_list_with_record(
     record: &super::submit_session::Dx12RecordState<'_>,
     device_handle: DeviceHandle,
+    recording_ctx: Option<ContextHandle>,
     target: RenderTargetHandle,
     commands: &[RenderCommand],
     cmd_list: &ID3D12GraphicsCommandList7,
     frame_table_prologue_already_recorded: bool,
-) -> Result<bool> {
+) -> Result<(bool, Option<u32>)> {
     let logical_device = record.devices.get(&device_handle).context("Invalid device handle")?;
 
     let render_targets_read = record.render_targets.read().unwrap();
@@ -340,18 +342,26 @@ pub(super) fn record_render_pass_to_list_with_record(
     }
 
     let (staging_data, lowered, has_bindings) = super::frame_table::prepare_render_commands(record, commands)?;
+    let mut prologue_row = None;
     if has_bindings {
         if frame_table_prologue_already_recorded {
             super::frame_table::sync_table_row_to_device(record, device_handle, cmd_list, &staging_data)?;
-        } else {
-            super::frame_table::record_prologue(
+        } else if let Some(ctx) = recording_ctx {
+            prologue_row = Some(super::frame_table::record_prologue(
                 record.contexts,
+                ctx,
                 &record.frame_table,
                 &record.buffers.read().unwrap().entries,
-                device_handle,
                 cmd_list,
                 &staging_data,
-            )?;
+            )?);
+        } else {
+            prologue_row = Some(super::frame_table::record_prologue_legacy(
+                &record.frame_table,
+                &record.buffers.read().unwrap().entries,
+                cmd_list,
+                &staging_data,
+            )?);
         }
     }
 
@@ -369,28 +379,30 @@ pub(super) fn record_render_pass_to_list_with_record(
     );
     unsafe { barriers::barrier_textures(cmd_list, &[to_copy]) };
 
-    Ok(has_bindings)
+    Ok((has_bindings, prologue_row))
 }
 
 /// Record an offscreen render pass into an existing command list without closing/executing.
 #[allow(clippy::too_many_lines)]
 pub(super) fn record_render_pass_to_list(
-    state: &Dx12State,
+    state: &mut Dx12State,
     device_handle: DeviceHandle,
     target: RenderTargetHandle,
     commands: &[RenderCommand],
     cmd_list: &ID3D12GraphicsCommandList7,
     frame_table_prologue_already_recorded: bool,
 ) -> Result<bool> {
-    let record = super::submit_session::record_state_from_backend(state, device_handle)?;
-    record_render_pass_to_list_with_record(
+    let record = super::submit_session::record_state_for_legacy_render(state, device_handle)?;
+    let (has_bindings, _) = record_render_pass_to_list_with_record(
         &record,
         device_handle,
+        None,
         target,
         commands,
         cmd_list,
         frame_table_prologue_already_recorded,
-    )
+    )?;
+    Ok(has_bindings)
 }
 
 /// Render commands to a render target.
@@ -411,24 +423,26 @@ pub(super) fn render(
     // Upgrading render_to_target to a pool would eliminate the wait but is not yet done.
     unsafe { logical_device.command_allocator.Reset() }.context("Failed to reset command allocator")?;
 
-    let render_targets_read = state.render_targets.read().unwrap();
-    let render_target = render_targets_read
-        .entries
-        .get(&target)
-        .context("Invalid render target handle")?;
+    let cmd = {
+        let render_targets_read = state.render_targets.read().unwrap();
+        let render_target = render_targets_read
+            .entries
+            .get(&target)
+            .context("Invalid render target handle")?;
 
-    if render_target.device_handle != device_handle {
-        anyhow::bail!("Render target belongs to a different device");
-    }
+        if render_target.device_handle != device_handle {
+            anyhow::bail!("Render target belongs to a different device");
+        }
 
-    let cmd = &render_target.command_list;
-    let cmd_gfx: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(cmd) };
+        render_target.command_list.clone()
+    };
+    let cmd_gfx: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(&cmd) };
 
     unsafe { cmd_gfx.Reset(&logical_device.command_allocator, None) }.context("Failed to reset command list")?;
 
-    let _ = record_render_pass_to_list(state, device_handle, target, commands, cmd, false)?;
+    let _ = record_render_pass_to_list(state, device_handle, target, commands, &cmd, false)?;
 
-    let cmd_gfx: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(cmd) };
+    let cmd_gfx: &ID3D12GraphicsCommandList = unsafe { std::mem::transmute(&cmd) };
     unsafe { cmd_gfx.Close() }.context("Failed to close command list")?;
 
     let logical_device = state.devices.get(&device_handle).context("Invalid device handle")?;

--- a/src/backend/dx12/submit_session.rs
+++ b/src/backend/dx12/submit_session.rs
@@ -94,16 +94,43 @@ impl<'a> Dx12SubmitScope<'a> {
 
 pub(crate) fn record_state_from_backend<'a>(
     state: &'a Dx12State,
+    ctx: ContextHandle,
     device_handle: DeviceHandle,
 ) -> Result<Dx12RecordState<'a>> {
     let frame_table = Arc::clone(
-        state
-            .frame_tables
+        &state
+            .contexts
             .read()
             .unwrap()
-            .get(&device_handle)
-            .with_context(|| format!("frame table not initialized for device {device_handle}"))?,
+            .get(&ctx)
+            .with_context(|| format!("Invalid context handle {ctx}"))?
+            .lock()
+            .unwrap()
+            .frame_table,
     );
+    Ok(Dx12RecordState {
+        ld: state
+            .devices
+            .get(&device_handle)
+            .with_context(|| format!("Invalid device {device_handle}"))?,
+        devices: &state.devices,
+        contexts: &state.contexts,
+        frame_table,
+        buffers: &state.buffers,
+        shaders: &state.shaders,
+        pipelines: &state.pipelines,
+        compute_pipelines: &state.compute_pipelines,
+        render_targets: &state.render_targets,
+        textures: &state.textures,
+        samplers: &state.samplers,
+    })
+}
+
+pub(crate) fn record_state_for_legacy_render<'a>(
+    state: &'a mut Dx12State,
+    device_handle: DeviceHandle,
+) -> Result<Dx12RecordState<'a>> {
+    let frame_table = super::frame_table::ensure_legacy_frame_table(state, device_handle)?;
     Ok(Dx12RecordState {
         ld: state
             .devices
@@ -152,20 +179,15 @@ impl Dx12SubmitSession {
                 .get(&ctx)
                 .with_context(|| format!("Invalid context handle {ctx}"))?,
         );
-        let device_handle = sc.lock().unwrap().device;
+        let (device_handle, frame_table) = {
+            let sc_guard = sc.lock().unwrap();
+            (sc_guard.device, Arc::clone(&sc_guard.frame_table))
+        };
         let ld = Arc::clone(
             state
                 .devices
                 .get(&device_handle)
                 .with_context(|| format!("Invalid device handle {device_handle}"))?,
-        );
-        let frame_table = Arc::clone(
-            state
-                .frame_tables
-                .read()
-                .unwrap()
-                .get(&device_handle)
-                .with_context(|| format!("frame table not initialized for device {device_handle}"))?,
         );
         let devices: HashMap<DeviceHandle, SharedLogicalDevice> = state
             .devices

--- a/src/backend/dx12/surface.rs
+++ b/src/backend/dx12/surface.rs
@@ -381,7 +381,8 @@ pub(super) fn acquire(
     let retired = super::context::device_retired(state, device_handle);
     if let Some(device) = state.devices.get(&device_handle) {
         let _tz = crate::tracy_zone!("surface.acquire.deletion_queue");
-        device.process_deletion_queue_up_to(retired);
+        let fences = state.context_fences.read().unwrap();
+        device.process_deletion_queue_up_to(retired, &fences);
     }
 
     let surface = state
@@ -481,6 +482,7 @@ pub(super) fn render(
     surface_handle: SurfaceHandle,
     image: SwapchainImageHandle,
     present_slot: u32,
+    ctx: super::ContextHandle,
     commands: &[RenderCommand],
 ) -> Result<()> {
     let surface = state.surfaces.get(&surface_handle).context("Invalid surface handle")?;
@@ -611,25 +613,31 @@ pub(super) fn render(
     }
 
     let (staging_data, lowered, has_bindings) =
-        super::frame_table::prepare_render_commands_state(state, device_handle, commands)?;
+        super::frame_table::prepare_render_commands_state(state, ctx, device_handle, commands)?;
     if has_bindings {
-        super::frame_table::record_prologue(
+        let ft = {
+            let contexts_read = state.contexts.read().unwrap();
+            let sc_arc = contexts_read.get(&ctx).context("Invalid context handle")?.clone();
+            drop(contexts_read);
+            let sc_guard = sc_arc.lock().unwrap();
+            let ft = std::sync::Arc::clone(&sc_guard.frame_table);
+            drop(sc_guard);
+            ft
+        };
+        // Per-context frame-table slots are bound once at context init; no
+        // per-submit rebinding needed.
+        let _row = super::frame_table::record_prologue(
             &state.contexts,
-            state
-                .frame_tables
-                .read()
-                .unwrap()
-                .get(&device_handle)
-                .context("frame table not initialized")?,
+            ctx,
+            &ft,
             &state.buffers.read().unwrap().entries,
-            device_handle,
             cmd,
             &staging_data,
         )?;
     }
 
     // Execute render commands
-    render_commands::record_state(cmd, &lowered, device_handle, state)?;
+    render_commands::record_state(cmd, &lowered, device_handle, ctx, state)?;
 
     // RENDER_TARGET -> PRESENT (enhanced barrier, per MS DirectX-Graphics-Samples).
     // SYNC_NONE + NO_ACCESS: no subsequent work on this resource in this command list.

--- a/src/backend/dx12/types.rs
+++ b/src/backend/dx12/types.rs
@@ -477,10 +477,14 @@ pub(crate) struct Dx12SubmissionContext {
     pub staging_belt: super::staging::StagingBelt,
     /// Pool that recycles texture-upload staging buffers across frames on this context.
     pub texture_staging_pool: super::staging::TextureStagingPool,
-    /// Per-context deferred deletion queue — only resources exclusively bound to this
-    /// context's timeline (e.g. temporary dispatch-batch arg buffers).  Drained at each
-    /// submit by this context's own completed fence value, never by `device_retired`.
+    /// Per-context deferred deletion queue — resources whose lifetime is bounded by this
+    /// context's timeline (dispatch-batch arg buffers, user buffers destroyed with context
+    /// attribution). Drained by this context's own completed fence value.
     pub deletion_queue: DeletionQueue,
+    /// Thread-scoped reclamation epoch from [`ContextReclamationScope::set_epoch`].
+    pub reclamation_context: Option<(std::thread::ThreadId, u64)>,
+    /// Per-context frame-table GPU resources and ring state (bindless slots 0/1).
+    pub frame_table: SharedFrameTableDevice,
 }
 
 /// A retained (closed but not reset) command list available for re-execution.
@@ -555,6 +559,26 @@ pub(crate) struct PendingSlotReclamation {
     pub slot: DeferredSlot,
     /// `(context_handle, min_seq_that_must_retire)`
     pub requirements: Vec<(super::ContextHandle, u64)>,
+}
+
+/// GPU buffer resources held until bindless slot requirements retire.
+pub(crate) struct PendingBufferGpuRelease {
+    pub requirements: Vec<(super::ContextHandle, u64)>,
+    pub resource: Direct3D12::ID3D12Resource,
+    pub upload_buffer: Option<Direct3D12::ID3D12Resource>,
+    pub coherent_readback: Option<Direct3D12::ID3D12Resource>,
+    pub reserved_tiles: Option<Vec<Option<(Direct3D12::ID3D12Heap, u64)>>>,
+}
+
+fn slot_requirements_met(
+    requirements: &[(super::ContextHandle, u64)],
+    context_fences: &HashMap<super::ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
+) -> bool {
+    requirements.iter().all(|(ctx_id, required_seq)| {
+        context_fences
+            .get(ctx_id)
+            .is_none_or(|(_, fence)| unsafe { fence.GetCompletedValue() >= *required_seq })
+    })
 }
 
 /// Deferred deletion queue for a DX12 device.
@@ -644,6 +668,28 @@ impl DescriptorRegistry {
         }
     }
 
+    /// Union of per-context last-seen seqs for all bindless slots owned by `handle`.
+    /// Must be called before [`Self::reclaim_buffer_slots`] removes `slot_last_seen` entries.
+    pub(crate) fn snapshot_buffer_slot_requirements(&self, handle: BufferHandle) -> Vec<(super::ContextHandle, u64)> {
+        let rr = &self.resource_registry;
+        let mut merged: HashMap<super::ContextHandle, u64> = HashMap::new();
+        let mut slots = Vec::new();
+        if let Some(&offset) = rr.buffer_offsets.get(&handle) {
+            slots.push(offset);
+        }
+        if let Some(&offset) = rr.buffer_srv_offsets.get(&handle) {
+            slots.push(offset);
+        }
+        for slot in slots {
+            if let Some(map) = self.slot_last_seen.get(&DeferredSlot::CbvSrvUav(slot)) {
+                for (ctx, seq) in map.iter() {
+                    merged.entry(*ctx).and_modify(|v| *v = (*v).max(*seq)).or_insert(*seq);
+                }
+            }
+        }
+        merged.into_iter().collect()
+    }
+
     /// Reclaim all descriptor slots for a destroyed buffer handle.
     pub(crate) fn reclaim_buffer_slots(&mut self, handle: BufferHandle) {
         let slots = self.resource_registry.extract_buffer_slots(handle);
@@ -679,14 +725,7 @@ impl DescriptorRegistry {
     ) {
         let mut i = 0;
         while i < self.pending_slot_reclamations.len() {
-            let ready = self.pending_slot_reclamations[i]
-                .requirements
-                .iter()
-                .all(|(ctx_id, required_seq)| {
-                    context_fences
-                        .get(ctx_id)
-                        .is_none_or(|(_, fence)| unsafe { fence.GetCompletedValue() >= *required_seq })
-                });
+            let ready = slot_requirements_met(&self.pending_slot_reclamations[i].requirements, context_fences);
             if ready {
                 let entry = self.pending_slot_reclamations.swap_remove(i);
                 self.resource_registry.free_deferred_slot(entry.slot);
@@ -694,6 +733,30 @@ impl DescriptorRegistry {
                 i += 1;
             }
         }
+    }
+
+    /// Minimum context timeline value that must retire before a buffer's GPU resource can be
+    /// released. Extends the thread-local [`reclamation_barrier`] with every live
+    /// `slot_last_seen` entry for this buffer's bindless slots so cross-context shader access
+    /// cannot outlive the D3D12 resource.
+    pub(crate) fn bindless_retirement_fence_for_buffer(&self, handle: BufferHandle, barrier: u64) -> u64 {
+        let rr = &self.resource_registry;
+        let mut fence = barrier;
+        let mut slots = Vec::new();
+        if let Some(&offset) = rr.buffer_offsets.get(&handle) {
+            slots.push(offset);
+        }
+        if let Some(&offset) = rr.buffer_srv_offsets.get(&handle) {
+            slots.push(offset);
+        }
+        for slot in slots {
+            if let Some(map) = self.slot_last_seen.get(&DeferredSlot::CbvSrvUav(slot)) {
+                for (_, seq) in map.iter() {
+                    fence = fence.max(*seq);
+                }
+            }
+        }
+        fence
     }
 }
 
@@ -765,6 +828,10 @@ pub(crate) struct LogicalDevice {
     /// Deferred deletion queue — resources are dropped only after the GPU finishes
     /// the command list that was last submitted when the resource was queued.
     pub deletion_queue: Mutex<DeletionQueue>,
+    /// Buffer GPU memory held until bindless slot `slot_last_seen` requirements retire.
+    pub pending_buffer_gpu_releases: Mutex<Vec<PendingBufferGpuRelease>>,
+    /// Shared with [`Dx12State::device_removed`] — first `u64::MAX` fence triggers DRED once.
+    pub device_removed: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Descriptor registry: `ResourceRegistry` + slot reference-tracking.
     /// `Arc` so Phase 5 can clone it out of `LogicalDevice` before dropping the
     /// global backend lock.
@@ -778,6 +845,8 @@ pub(crate) struct LogicalDevice {
     /// Phase 5 lock-free submit clones this `Arc` and holds it only across the GPU
     /// enqueue, matching Vulkan's `queue_lock` and Metal's present/compute pairing.
     pub queue_lock: Arc<Mutex<()>>,
+    /// Frame table for legacy `render_to_target` (no submission context).
+    pub legacy_frame_table: Mutex<Option<SharedFrameTableDevice>>,
 }
 
 /// Shared logical device handle — cloned out of `Dx12State` before dropping the global lock.
@@ -791,16 +860,18 @@ pub(crate) type SharedSubmissionContext = Arc<Mutex<Dx12SubmissionContext>>;
 /// graphs without the global backend mutex.
 pub(crate) type SharedContextMap = Arc<std::sync::RwLock<HashMap<super::ContextHandle, SharedSubmissionContext>>>;
 
-/// Per-device frame-table GPU state — shared via `Arc` for lock-free submit recording.
+/// Per-context frame-table GPU state — cloned into submit sessions at context creation.
 pub(crate) type SharedFrameTableDevice = Arc<super::frame_table::FrameTableDevice>;
 
-/// Frame tables keyed by device — cloned into [`super::submit_session::Dx12SubmitSession`].
-pub(crate) type SharedFrameTableMap = Arc<std::sync::RwLock<HashMap<super::DeviceHandle, SharedFrameTableDevice>>>;
-
 impl LogicalDevice {
-    pub(crate) fn process_deletion_queue_up_to(&self, completed: u64) {
+    pub(crate) fn process_deletion_queue_up_to(
+        &self,
+        completed: u64,
+        context_fences: &HashMap<super::ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
+    ) {
         let batch = self.deletion_queue.lock().unwrap().drain_up_to_completed(completed);
         if batch.is_empty() {
+            self.drain_pending_buffer_gpu_releases(context_fences);
             return;
         }
         let descriptors_arc = Arc::clone(&self.descriptors);
@@ -808,9 +879,31 @@ impl LogicalDevice {
         for resource in batch {
             destroy_pending_deletion(self, &mut registry, resource);
         }
+        drop(registry);
+        self.drain_pending_buffer_gpu_releases(context_fences);
     }
 
-    pub(crate) fn flush_deletion_queue(&self) {
+    /// Drop deferred buffer GPU memory once every referencing context has retired.
+    pub(crate) fn drain_pending_buffer_gpu_releases(
+        &self,
+        context_fences: &HashMap<super::ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
+    ) {
+        let mut pending = self.pending_buffer_gpu_releases.lock().unwrap();
+        let mut i = 0;
+        while i < pending.len() {
+            if slot_requirements_met(&pending[i].requirements, context_fences) {
+                let entry = pending.swap_remove(i);
+                release_buffer_gpu_resources(self, entry);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    pub(crate) fn flush_deletion_queue(
+        &self,
+        context_fences: &HashMap<super::ContextHandle, (DeviceHandle, Direct3D12::ID3D12Fence)>,
+    ) {
         // Called only at device teardown, after wait_for_gpu ensures all GPU work has
         // completed. Slots queued here via reclaim_*_slots will have empty requirements
         // (slot_last_seen was cleared as contexts were destroyed before the device) and
@@ -826,7 +919,34 @@ impl LogicalDevice {
         for resource in batch {
             destroy_pending_deletion(self, &mut registry, resource);
         }
+        drop(registry);
+        self.drain_pending_buffer_gpu_releases(context_fences);
     }
+}
+
+fn release_buffer_gpu_resources(ld: &LogicalDevice, entry: PendingBufferGpuRelease) {
+    let PendingBufferGpuRelease {
+        requirements: _,
+        resource,
+        upload_buffer,
+        coherent_readback,
+        reserved_tiles,
+    } = entry;
+    if let Some(tiles) = reserved_tiles {
+        let mut pool = ld.tile_heap_pool.lock().unwrap();
+        super::tiles::teardown_reserved_mappings(&ld.command_queue, &mut pool, &resource, &tiles);
+    }
+    let fv = ld.timeline_next.fetch_add(1, Ordering::Relaxed);
+    let signaled = super::utils::with_queue_lock(ld, || {
+        unsafe { ld.command_queue.Signal(&ld.fence, fv) }
+            .map_err(|e| anyhow::anyhow!("Failed to signal device fence for buffer deletion: {e:?}"))
+    });
+    if signaled.is_ok() {
+        let _ = super::utils::wait_for_fence_on_device(&ld.fence, fv, Some(ld));
+    }
+    drop(resource);
+    drop(upload_buffer);
+    drop(coherent_readback);
 }
 
 pub(crate) fn destroy_pending_deletion(
@@ -842,20 +962,20 @@ pub(crate) fn destroy_pending_deletion(
             coherent_readback,
             reserved_tiles,
         } => {
+            let requirements = registry.snapshot_buffer_slot_requirements(buffer_handle);
             registry.reclaim_buffer_slots(buffer_handle);
-            if let Some(tiles) = reserved_tiles {
-                let mut pool = ld.tile_heap_pool.lock().unwrap();
-                super::tiles::teardown_reserved_mappings(&ld.command_queue, &mut pool, &resource, &tiles);
+            let release = PendingBufferGpuRelease {
+                requirements: requirements.clone(),
+                resource,
+                upload_buffer,
+                coherent_readback,
+                reserved_tiles,
+            };
+            if requirements.is_empty() {
+                release_buffer_gpu_resources(ld, release);
+            } else {
+                ld.pending_buffer_gpu_releases.lock().unwrap().push(release);
             }
-            // Flush the queue so the unmap is processed before releasing the resource.
-            // Without this, the driver can crash (device removal) on Release.
-            let fv = ld.timeline_next.fetch_add(1, Ordering::Relaxed);
-            if unsafe { ld.command_queue.Signal(&ld.fence, fv) }.is_ok() {
-                let _ = super::utils::wait_for_fence(&ld.fence, fv);
-            }
-            drop(resource);
-            drop(upload_buffer);
-            drop(coherent_readback);
         }
         PendingDeletion::BufferView { buffer_handle } => {
             registry.reclaim_buffer_slots(buffer_handle);
@@ -1230,8 +1350,5 @@ pub(super) struct Dx12State {
     /// Set to `true` when a TDR / device-removal is detected (fence completed with `u64::MAX`
     /// or `GetDeviceRemovedReason` returns a non-ok HRESULT).
     /// Polled by [`GpuBackend::is_device_lost`] without holding any lock.
-    pub device_removed: std::sync::atomic::AtomicBool,
-    /// Per-device frame-table GPU resources (reserved bindless slots 0/1).
-    #[cfg(all(feature = "dx12", target_os = "windows"))]
-    pub frame_tables: SharedFrameTableMap,
+    pub device_removed: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }

--- a/src/backend/dx12/utils.rs
+++ b/src/backend/dx12/utils.rs
@@ -194,6 +194,13 @@ pub(super) fn execute_command_lists_and_signal_device(
     Ok(fence_value)
 }
 
+/// Run `f` while holding [`LogicalDevice::queue_lock`] (the queue is externally synchronized).
+pub(super) fn with_queue_lock<R>(logical_device: &LogicalDevice, f: impl FnOnce() -> R) -> R {
+    let queue_lock = Arc::clone(&logical_device.queue_lock);
+    let _guard = queue_lock.lock().unwrap();
+    f()
+}
+
 /// Execute command lists and signal a context fence under [`LogicalDevice::queue_lock`].
 pub(super) fn execute_command_lists_and_signal_context(
     logical_device: &LogicalDevice,
@@ -213,13 +220,48 @@ pub(super) fn execute_command_lists_and_signal_context(
 /// Wait for a fence to reach the specified value.
 /// This is a low-level helper for GPU synchronization.
 pub(super) fn wait_for_fence(fence: &ID3D12Fence, value: u64) -> Result<()> {
-    if unsafe { fence.GetCompletedValue() } < value {
+    wait_for_fence_on_device(fence, value, None)
+}
+
+/// Like [`wait_for_fence`] but logs DRED on first `u64::MAX` when `ld` is provided.
+pub(super) fn wait_for_fence_on_device(
+    fence: &ID3D12Fence,
+    value: u64,
+    ld: Option<&super::types::LogicalDevice>,
+) -> Result<()> {
+    let completed = unsafe { fence.GetCompletedValue() };
+    if completed == u64::MAX {
+        if let Some(ld) = ld {
+            super::diagnostic::first_touch_device_removed(
+                &ld.device,
+                &ld.device_removed,
+                "dx12::utils::wait_for_fence_on_device",
+                value,
+                completed,
+            );
+        }
+        anyhow::bail!("GPU device removed while waiting for fence value {value}");
+    }
+    if completed < value {
         let event = unsafe { CreateEventA(None, false, false, None) }.context("Failed to create event")?;
 
         unsafe { fence.SetEventOnCompletion(value, event) }.context("Failed to set event on completion")?;
 
         unsafe { WaitForSingleObject(event, INFINITE) };
         unsafe { CloseHandle(event) }.ok();
+    }
+    let completed_after = unsafe { fence.GetCompletedValue() };
+    if completed_after == u64::MAX {
+        if let Some(ld) = ld {
+            super::diagnostic::first_touch_device_removed(
+                &ld.device,
+                &ld.device_removed,
+                "dx12::utils::wait_for_fence_on_device",
+                value,
+                completed_after,
+            );
+        }
+        anyhow::bail!("GPU device removed after waiting for fence value {value}");
     }
     Ok(())
 }

--- a/src/backend/metal/compute.rs
+++ b/src/backend/metal/compute.rs
@@ -700,6 +700,14 @@ pub(super) fn record_commands_to_buffer(
                     prologue_row.unwrap_or(0) * crate::frame_table::FRAME_TABLE_ROW_STRIDE + frame_table_base;
                 let mut layout = PushLayout::default();
                 shared::fill_frame_table_dispatch(&mut layout, absolute_base, raw_user);
+                // Metal's frame table is device-level at fixed arg slots (selector
+                // unused; table at slot 1); the slots still travel via push words
+                // so the shared shader preamble reads them uniformly.
+                shared::set_frame_table_slots(
+                    &mut layout,
+                    crate::frame_table::FRAME_TABLE_SELECTOR_SLOT,
+                    crate::frame_table::FRAME_TABLE_DEVICE_SLOT,
+                );
                 let layout_bytes = layout.as_bytes();
                 guard
                     .compute
@@ -774,6 +782,11 @@ pub(super) fn record_commands_to_buffer(
                             let mut patched = PushLayout::default();
                             bytemuck::bytes_of_mut(&mut patched).copy_from_slice(layout_slice);
                             patched._reserved[0] = patched._reserved[0].wrapping_add(row_offset);
+                            shared::set_frame_table_slots(
+                                &mut patched,
+                                crate::frame_table::FRAME_TABLE_SELECTOR_SLOT,
+                                crate::frame_table::FRAME_TABLE_DEVICE_SLOT,
+                            );
                             enc.set_bytes(
                                 RESOURCE_SLOT_BUFFER,
                                 std::mem::size_of::<PushLayout>() as u64,

--- a/src/backend/metal/render_commands.rs
+++ b/src/backend/metal/render_commands.rs
@@ -69,6 +69,12 @@ pub(super) fn record(
                     prologue_row.unwrap_or(0) * crate::frame_table::FRAME_TABLE_ROW_STRIDE + frame_table_base;
                 let mut layout = PushLayout::default();
                 shared::fill_frame_table_dispatch(&mut layout, absolute_base, raw_user);
+                // Metal's frame table is device-level at fixed arg slots.
+                shared::set_frame_table_slots(
+                    &mut layout,
+                    crate::frame_table::FRAME_TABLE_SELECTOR_SLOT,
+                    crate::frame_table::FRAME_TABLE_DEVICE_SLOT,
+                );
                 let layout_bytes = layout.as_bytes();
                 encoder.set_vertex_bytes(
                     RESOURCE_SLOT_BUFFER,

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -93,6 +93,44 @@ pub fn fill_frame_table_dispatch(layout: &mut PushLayout, dispatch_base: u32, us
     }
 }
 
+/// `PushLayout._reserved` word carrying the submitting context's selector
+/// bindless slot (`_rs1` in generated shader wrappers).
+pub const FRAME_TABLE_SELECTOR_SLOT_WORD: usize = 1;
+/// `PushLayout._reserved` word carrying the submitting context's table
+/// bindless slot (`_rs2` in generated shader wrappers).
+pub const FRAME_TABLE_TABLE_SLOT_WORD: usize = 2;
+
+/// Record-time fill of the submitting context's per-context frame-table
+/// bindless slots (`_rs1`/`_rs2`).
+///
+/// Context-agnostic lowering (task-graph analysis) leaves these words zero;
+/// each backend sets them when recording for a known context so concurrent
+/// contexts on one device never share mutable descriptor slots.
+#[inline]
+pub fn set_frame_table_slots(layout: &mut PushLayout, selector_slot: u32, table_slot: u32) {
+    layout._reserved[FRAME_TABLE_SELECTOR_SLOT_WORD] = selector_slot;
+    layout._reserved[FRAME_TABLE_TABLE_SLOT_WORD] = table_slot;
+}
+
+/// Patch the frame-table slot words of every entry in a `DispatchBatch`
+/// argument blob (entries are `DISPATCH_BATCH_STRIDE` bytes apart).
+///
+/// `DispatchBatch` arg data is built during context-agnostic lowering with the
+/// slot words zeroed; backends call this at record time for the submitting
+/// context.
+pub fn patch_dispatch_batch_frame_table_slots(arg_data: &mut [u8], count: usize, selector_slot: u32, table_slot: u32) {
+    let sel_off = (MAX_BINDLESS_SLOTS * 2) + (MAX_USER_SLOTS * 4) + FRAME_TABLE_SELECTOR_SLOT_WORD * 4;
+    let tab_off = (MAX_BINDLESS_SLOTS * 2) + (MAX_USER_SLOTS * 4) + FRAME_TABLE_TABLE_SLOT_WORD * 4;
+    for i in 0..count {
+        let base = i * DISPATCH_BATCH_STRIDE;
+        if base + TOTAL_PUSH_BYTES > arg_data.len() {
+            break;
+        }
+        arg_data[base + sel_off..base + sel_off + 4].copy_from_slice(&selector_slot.to_ne_bytes());
+        arg_data[base + tab_off..base + tab_off + 4].copy_from_slice(&table_slot.to_ne_bytes());
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Slot allocator
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/backend/vulkan/buffer.rs
+++ b/src/backend/vulkan/buffer.rs
@@ -1195,21 +1195,15 @@ pub(super) fn resize(
 /// index for deferred deletion after in-flight GPU work completes.
 /// For views, only the descriptor index is deferred — the underlying VkBuffer/memory
 /// belongs to the parent and is not freed.
-pub(super) fn destroy(
-    devices: &HashMap<DeviceHandle, types::SharedLogicalDevice>,
-    buffers: &SharedBufferTable,
-    buffer_handle: BufferHandle,
-) {
-    if let Some(buffer) = buffers.write().unwrap().entries.remove(&buffer_handle) {
-        if let Some(device) = devices.get(&buffer.device_handle) {
-            let barrier = device.timeline_next.load(Ordering::Relaxed).saturating_sub(1);
+pub(super) fn destroy(state: &super::types::VulkanState, buffer_handle: BufferHandle) {
+    if let Some(buffer) = state.buffers.write().unwrap().entries.remove(&buffer_handle) {
+        if let Some(device) = state.devices.get(&buffer.device_handle) {
+            let ctx_h = super::context::destroy_attribution_context(state, buffer.device_handle);
+            let barrier = super::context::reclamation_barrier(state, buffer.device_handle, ctx_h);
 
             if buffer.is_view {
-                device
-                    .deletion_queue
-                    .lock()
-                    .unwrap()
-                    .queue(barrier, types::PendingDeletion::BufferView { buffer_handle });
+                let deletion = types::PendingDeletion::BufferView { buffer_handle };
+                queue_pending_deletion(state, device, ctx_h, barrier, deletion);
                 return;
             }
 
@@ -1234,23 +1228,43 @@ pub(super) fn destroy(
             } else {
                 None
             };
-            device.deletion_queue.lock().unwrap().queue(
-                barrier,
-                types::PendingDeletion::Buffer {
-                    buffer_handle,
-                    buffer: buffer.buffer,
-                    memory: if buffer.is_sparse {
-                        vk::DeviceMemory::null()
-                    } else {
-                        buffer.memory
-                    },
-                    staging_buffer: buffer.staging_buffer,
-                    staging_memory: buffer.staging_memory,
-                    sparse_teardown,
+            let deletion = types::PendingDeletion::Buffer {
+                buffer_handle,
+                buffer: buffer.buffer,
+                memory: if buffer.is_sparse {
+                    vk::DeviceMemory::null()
+                } else {
+                    buffer.memory
                 },
-            );
+                staging_buffer: buffer.staging_buffer,
+                staging_memory: buffer.staging_memory,
+                sparse_teardown,
+            };
+            queue_pending_deletion(state, device, ctx_h, barrier, deletion);
         }
     }
+}
+
+/// Queue buffer teardown on the context deletion queue when attribution is known.
+///
+/// Per-context buffer destroys are drained only on explicit-wait paths
+/// (`wait_until`, `flush_deferred_deletions`, context destroy) — not on the
+/// submit hot path — so retained command buffers can keep resubmitting against
+/// recorded bindings after the Rust `Buffer` has been dropped.
+fn queue_pending_deletion(
+    state: &super::types::VulkanState,
+    device: &types::SharedLogicalDevice,
+    ctx_h: Option<super::ContextHandle>,
+    barrier: u64,
+    deletion: types::PendingDeletion,
+) {
+    if let Some(ctx_h) = ctx_h {
+        if let Some(sc_arc) = state.contexts.read().unwrap().get(&ctx_h) {
+            sc_arc.lock().unwrap().deletion_queue.queue(barrier, deletion);
+            return;
+        }
+    }
+    device.deletion_queue.lock().unwrap().queue(barrier, deletion);
 }
 
 /// Create a view into a sub-region of an existing buffer.

--- a/src/backend/vulkan/compute.rs
+++ b/src/backend/vulkan/compute.rs
@@ -740,17 +740,6 @@ pub(super) fn submit_with_scope(
         };
         r.context("Failed queue_submit2 for empty compute submit")?;
         {
-            let completed = scope.completed_timeline_value();
-            let ctx_batch: Vec<_> = scope.sc.lock().unwrap().deletion_queue.drain_up_to(completed);
-            if let Some(ld) = view.devices.get(&device_handle) {
-                let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
-                let mut registry = descriptors_arc.lock().unwrap();
-                for r in ctx_batch {
-                    super::types::destroy_pending_deletion(ld, &mut registry, r);
-                }
-            }
-        }
-        {
             scope.sc.lock().unwrap().last_submitted_seq = signal_value;
         }
         return Ok(signal_value);
@@ -928,9 +917,9 @@ pub(super) fn submit_with_scope(
                 GpuCommand::FrameTableStaging { data } => {
                     super::frame_table::record_prologue(
                         view.contexts,
-                        view.frame_tables,
+                        ctx,
+                        &scope.frame_table,
                         view.buffers,
-                        device_handle,
                         logical_device,
                         cmd,
                         data,
@@ -966,6 +955,11 @@ pub(super) fn submit_with_scope(
                         })?;
                         let mut layout = PushLayout::default();
                         shared::fill_frame_table_dispatch(&mut layout, *frame_table_base, raw_user);
+                        shared::set_frame_table_slots(
+                            &mut layout,
+                            scope.frame_table.selector_slot,
+                            scope.frame_table.table_slot,
+                        );
                         unsafe {
                             logical_device.device.cmd_push_constants(
                                 cmd,
@@ -1033,9 +1027,18 @@ pub(super) fn submit_with_scope(
                     let pipeline_layout = current_pipeline
                         .and_then(|h| compute_pipelines_read.entries.get(&h))
                         .map(|p| p.layout);
+                    // Arg data is built during context-agnostic lowering; patch in
+                    // this context's frame-table slots (`_rs1`/`_rs2`) at record time.
+                    let mut patched_args = arg_data.to_vec();
+                    crate::backend::shared::patch_dispatch_batch_frame_table_slots(
+                        &mut patched_args,
+                        *count as usize,
+                        scope.frame_table.selector_slot,
+                        scope.frame_table.table_slot,
+                    );
                     for i in 0..*count as usize {
                         let base = i * stride;
-                        let layout_bytes = &arg_data[base..base + push_size];
+                        let layout_bytes = &patched_args[base..base + push_size];
                         let wg_off = base + push_size;
                         let wg_x = u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into().unwrap());
                         let wg_y = u32::from_ne_bytes(arg_data[wg_off + 4..wg_off + 8].try_into().unwrap());
@@ -1593,19 +1596,12 @@ pub(super) fn submit_with_scope(
     }
 
     {
-        let completed = scope.completed_timeline_value();
-        let ctx_batch = scope.sc.lock().unwrap().deletion_queue.drain_up_to(completed);
         if let Some(ld) = view.devices.get(&device_handle) {
             let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
-            {
-                let mut registry = descriptors_arc.lock().unwrap();
-                for r in ctx_batch {
-                    super::types::destroy_pending_deletion(ld, &mut registry, r);
-                }
-                let completed_values =
-                    super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
-                registry.drain_ready_slot_reclamations(&completed_values);
-            }
+            let mut registry = descriptors_arc.lock().unwrap();
+            let completed_values =
+                super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
+            registry.drain_ready_slot_reclamations(&completed_values);
         }
     }
 
@@ -1937,21 +1933,23 @@ pub(super) fn submit_graph_with_scope(
     let mut texture_upload_idx = 0usize;
     let mut rendered_targets: Vec<RenderTargetHandle> = Vec::new();
     let mut frame_table_prologue_in_cb = false;
+    let mut frame_table_row: Option<u32> = None;
 
     for graph_cmd in commands {
         match graph_cmd {
             GraphCommand::Compute(gpu_cmd) => match gpu_cmd {
                 GpuCommand::FrameTableStaging { data } => {
                     frame_table_prologue_in_cb = true;
-                    super::frame_table::record_prologue(
+                    let row = super::frame_table::record_prologue(
                         view.contexts,
-                        view.frame_tables,
+                        ctx,
+                        &scope.frame_table,
                         view.buffers,
-                        device_handle,
                         logical_device,
                         cmd,
                         data,
                     )?;
+                    frame_table_row = Some(row);
                 }
                 GpuCommand::SetPipeline(handle) => {
                     let _tz = tracy_zone!("vk.set_pipeline");
@@ -1985,6 +1983,11 @@ pub(super) fn submit_graph_with_scope(
                         })?;
                         let mut layout = PushLayout::default();
                         shared::fill_frame_table_dispatch(&mut layout, *frame_table_base, raw_user);
+                        shared::set_frame_table_slots(
+                            &mut layout,
+                            scope.frame_table.selector_slot,
+                            scope.frame_table.table_slot,
+                        );
                         unsafe {
                             logical_device.device.cmd_push_constants(
                                 cmd,
@@ -2054,9 +2057,18 @@ pub(super) fn submit_graph_with_scope(
                     let pipeline_layout = current_compute_pipeline
                         .and_then(|h| compute_pipelines_read.entries.get(&h))
                         .map(|p| p.layout);
+                    // Arg data is built during context-agnostic lowering; patch in
+                    // this context's frame-table slots (`_rs1`/`_rs2`) at record time.
+                    let mut patched_args = arg_data.to_vec();
+                    crate::backend::shared::patch_dispatch_batch_frame_table_slots(
+                        &mut patched_args,
+                        *count as usize,
+                        scope.frame_table.selector_slot,
+                        scope.frame_table.table_slot,
+                    );
                     for i in 0..*count as usize {
                         let base = i * stride;
-                        let layout_bytes = &arg_data[base..base + push_size];
+                        let layout_bytes = &patched_args[base..base + push_size];
                         let wg_off = base + push_size;
                         let wg_x = u32::from_ne_bytes(arg_data[wg_off..wg_off + 4].try_into().unwrap());
                         let wg_y = u32::from_ne_bytes(arg_data[wg_off + 4..wg_off + 8].try_into().unwrap());
@@ -2499,15 +2511,16 @@ pub(super) fn submit_graph_with_scope(
                             &sync_data,
                         )?;
                     } else {
-                        super::frame_table::record_prologue(
+                        let row = super::frame_table::record_prologue(
                             view.contexts,
-                            view.frame_tables,
+                            ctx,
+                            &scope.frame_table,
                             view.buffers,
-                            device_handle,
                             logical_device,
                             cmd,
                             &staging_data,
                         )?;
+                        frame_table_row = Some(row);
                     }
                 }
 
@@ -2528,6 +2541,7 @@ pub(super) fn submit_graph_with_scope(
                             &pipelines_read.entries,
                             &buffers_read.entries,
                             cur_pipe,
+                            (scope.frame_table.selector_slot, scope.frame_table.table_slot),
                         )
                     },
                 )?;
@@ -2634,12 +2648,14 @@ pub(super) fn submit_graph_with_scope(
 
     let retain_plan = if let Some(key) = retain_key {
         let ft = &scope.frame_table;
-        let frame_table_row = super::frame_table::extract_staging_from_graph(commands)
-            .and_then(|_| super::frame_table::last_prologue_row(ft));
-        if let Some(row) = frame_table_row {
+        let pin_row_index = super::frame_table::extract_staging_from_graph(commands)
+            .is_some()
+            .then_some(frame_table_row)
+            .flatten();
+        if let Some(row) = pin_row_index {
             super::frame_table::pin_row(ft, row)?;
         }
-        Some((key, frame_table_row))
+        Some((key, pin_row_index))
     } else {
         None
     };
@@ -2723,19 +2739,12 @@ pub(super) fn submit_graph_with_scope(
     }
 
     {
-        let completed = scope.completed_timeline_value();
-        let ctx_batch = scope.sc.lock().unwrap().deletion_queue.drain_up_to(completed);
         if let Some(ld) = view.devices.get(&device_handle) {
             let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
-            {
-                let mut registry = descriptors_arc.lock().unwrap();
-                for r in ctx_batch {
-                    super::types::destroy_pending_deletion(ld, &mut registry, r);
-                }
-                let completed_values =
-                    super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
-                registry.drain_ready_slot_reclamations(&completed_values);
-            }
+            let mut registry = descriptors_arc.lock().unwrap();
+            let completed_values =
+                super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
+            registry.drain_ready_slot_reclamations(&completed_values);
         }
     }
 
@@ -2848,19 +2857,12 @@ pub(super) fn try_resubmit_retained_with_scope(
     }
 
     {
-        let completed = scope.completed_timeline_value();
-        let ctx_batch = scope.sc.lock().unwrap().deletion_queue.drain_up_to(completed);
         if let Some(ld) = view.devices.get(&device_handle) {
             let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
-            {
-                let mut registry = descriptors_arc.lock().unwrap();
-                for r in ctx_batch {
-                    super::types::destroy_pending_deletion(ld, &mut registry, r);
-                }
-                let completed_values =
-                    super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
-                registry.drain_ready_slot_reclamations(&completed_values);
-            }
+            let mut registry = descriptors_arc.lock().unwrap();
+            let completed_values =
+                super::types::snapshot_context_completed_values(&ld.device, view.contexts, device_handle);
+            registry.drain_ready_slot_reclamations(&completed_values);
         }
     }
     {
@@ -2871,24 +2873,17 @@ pub(super) fn try_resubmit_retained_with_scope(
 }
 
 fn evict_retained_on_context(
-    contexts: &std::collections::HashMap<super::ContextHandle, super::types::SharedSubmissionContext>,
-    frame_tables: &std::collections::HashMap<super::DeviceHandle, super::types::SharedFrameTableDevice>,
+    frame_table: &super::frame_table::FrameTableDevice,
     ctx: super::ContextHandle,
     key: u64,
+    contexts: &super::types::SharedContextMap,
 ) {
-    if let Some(sc_arc) = contexts.get(&ctx) {
+    if let Some(sc_arc) = contexts.read().unwrap().get(&ctx) {
         let mut sc = sc_arc.lock().unwrap();
         if let Some(old) = sc.retained_compute_cbs.remove(&key) {
             if let Some(row) = old.frame_table_row {
-                let device = sc.device;
-                if let Some(ft) = frame_tables.get(&device) {
-                    super::frame_table::unpin_row(ft, row);
-                }
+                super::frame_table::unpin_row(frame_table, row);
             }
-            // Defer the CB free until the GPU has retired its last submission.
-            // Pushing directly to free_cmd_buffers is unsafe because the CB may
-            // still be in-flight; using timeline_cmd_buffers ensures vkFreeCommandBuffers
-            // is only called once the GPU timeline passes last_signal_value.
             sc.timeline_cmd_buffers
                 .entry(old.last_signal_value)
                 .or_default()
@@ -2897,44 +2892,33 @@ fn evict_retained_on_context(
     }
 }
 
-/// Evict every retained dispatch CB on contexts for `device_handle` that pins `row`.
-pub(super) fn evict_retained_pinning_row(
+pub(super) fn evict_retained_pinning_row_for_context(
     contexts: &super::types::SharedContextMap,
-    frame_tables: &super::types::SharedFrameTableMap,
-    device_handle: super::DeviceHandle,
+    frame_table: &super::frame_table::FrameTableDevice,
+    ctx: super::ContextHandle,
     row: u32,
 ) {
-    let contexts = contexts.read().unwrap();
-    let frame_tables = frame_tables.read().unwrap();
-    let ctxs: Vec<super::ContextHandle> = contexts
-        .iter()
-        .filter(|(_, sc_arc)| sc_arc.lock().unwrap().device == device_handle)
-        .map(|(h, _)| *h)
-        .collect();
-    for ctx in ctxs {
-        let keys: Vec<u64> = {
-            let sc_arc = contexts.get(&ctx).expect("context handle in device scan");
-            sc_arc
-                .lock()
-                .unwrap()
-                .retained_compute_cbs
-                .iter()
-                .filter(|(_, g)| g.frame_table_row == Some(row))
-                .map(|(k, _)| *k)
-                .collect()
+    let keys: Vec<u64> = {
+        let contexts_read = contexts.read().unwrap();
+        let Some(sc_arc) = contexts_read.get(&ctx) else {
+            return;
         };
-        for key in keys {
-            evict_retained_on_context(&contexts, &frame_tables, ctx, key);
-        }
+        let sc = sc_arc.lock().unwrap();
+        sc.retained_compute_cbs
+            .iter()
+            .filter(|(_, g)| g.frame_table_row == Some(row))
+            .map(|(k, _)| *k)
+            .collect()
+    };
+    for key in keys {
+        evict_retained_on_context(frame_table, ctx, key, contexts);
     }
 }
 
 /// Evict the retained dispatch CB for `key`, returning the `VkCommandBuffer` to `free_cmd_buffers`.
 pub(super) fn evict_retained_with_scope(scope: &VulkanSubmitScope<'_>, ctx: super::ContextHandle, key: u64) {
     scope.assert_ctx(ctx);
-    let contexts = scope.view.contexts.read().unwrap();
-    let frame_tables = scope.view.frame_tables.read().unwrap();
-    evict_retained_on_context(&contexts, &frame_tables, ctx, key);
+    evict_retained_on_context(&scope.frame_table, ctx, key, scope.view.contexts);
 }
 
 pub(super) fn evict_retained(state: &super::types::VulkanState, ctx: super::ContextHandle, key: u64) {

--- a/src/backend/vulkan/context.rs
+++ b/src/backend/vulkan/context.rs
@@ -37,7 +37,7 @@ pub(super) fn device_retired(state: &VulkanState, device: DeviceHandle) -> u64 {
 }
 
 pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<ContextHandle> {
-    let ld = state.devices.get(&device).context("Invalid device handle")?;
+    let ld = state.devices.get(&device).context("Invalid device handle")?.clone();
 
     let mut timeline_sem_type = vk::SemaphoreTypeCreateInfo::default()
         .semaphore_type(vk::SemaphoreType::TIMELINE)
@@ -73,6 +73,10 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
 
     let id = state.next_context_id;
     state.next_context_id = state.next_context_id.saturating_add(1);
+
+    let instance = state.instance.clone();
+    let frame_table = super::frame_table::init_context(state, &instance, device, &ld)?;
+
     state.contexts.write().unwrap().insert(
         id,
         Arc::new(Mutex::new(SubmissionContext {
@@ -89,6 +93,7 @@ pub(super) fn create(state: &mut VulkanState, device: DeviceHandle) -> Result<Co
             staging_belt: super::staging::StagingBelt::new(super::staging::DEFAULT_STAGING_CHUNK_SIZE),
             texture_staging_pool: super::staging::TextureStagingPool::new(),
             deletion_queue: super::types::DeletionQueue::new(),
+            frame_table,
         })),
     );
     Ok(id)
@@ -153,16 +158,17 @@ pub(super) fn destroy(state: &mut VulkanState, ctx: ContextHandle) {
         for cb in sc.free_cmd_buffers.drain(..) {
             ld.device.free_command_buffers(command_pool, &[cb]);
         }
+        let mut rows_to_unpin = Vec::new();
         for (_, retained) in sc.retained_compute_cbs.drain() {
-            if let Some(row) = retained.frame_table_row {
-                if let Some(ft) = state.frame_tables.read().unwrap().get(&device) {
-                    super::frame_table::unpin_row(ft, row);
-                }
-            }
+            rows_to_unpin.push(retained.frame_table_row);
             ld.device.free_command_buffers(command_pool, &[retained.command_buffer]);
+        }
+        for row in rows_to_unpin.into_iter().flatten() {
+            super::frame_table::unpin_row(&sc.frame_table, row);
         }
         ld.device.destroy_command_pool(sc.command_pool, None);
         ld.device.destroy_semaphore(sc.timeline_semaphore, None);
+        super::frame_table::destroy_context(state, ld, &sc.frame_table);
     }
 }
 
@@ -245,4 +251,46 @@ pub(super) fn context_device(state: &VulkanState, ctx: ContextHandle) -> DeviceH
         .lock()
         .unwrap()
         .device
+}
+
+fn contexts_on_device(state: &VulkanState, device: DeviceHandle) -> Vec<ContextHandle> {
+    state
+        .contexts
+        .read()
+        .unwrap()
+        .iter()
+        .filter_map(|(&h, sc_arc)| {
+            let sc = sc_arc.lock().unwrap();
+            (sc.device == device).then_some(h)
+        })
+        .collect()
+}
+
+/// When exactly one live context exists on `device`, return it for destroy attribution.
+pub(super) fn sole_context_on_device(state: &VulkanState, device: DeviceHandle) -> Option<ContextHandle> {
+    let mut on_device = contexts_on_device(state, device);
+    if on_device.len() == 1 {
+        on_device.pop()
+    } else {
+        None
+    }
+}
+
+/// Context to receive a user-initiated buffer destroy when attribution is unambiguous.
+pub(super) fn destroy_attribution_context(state: &VulkanState, device: DeviceHandle) -> Option<ContextHandle> {
+    sole_context_on_device(state, device)
+}
+
+/// Timeline barrier for deferred buffer destruction on `device`.
+pub(super) fn reclamation_barrier(state: &VulkanState, device: DeviceHandle, ctx: Option<ContextHandle>) -> u64 {
+    if let Some(ctx) = ctx {
+        if let Some(sc_arc) = state.contexts.read().unwrap().get(&ctx) {
+            return sc_arc.lock().unwrap().last_submitted_seq;
+        }
+    }
+    state
+        .devices
+        .get(&device)
+        .map(|d| d.timeline_next.load(Ordering::Relaxed).saturating_sub(1))
+        .unwrap_or(0)
 }

--- a/src/backend/vulkan/device.rs
+++ b/src/backend/vulkan/device.rs
@@ -457,13 +457,14 @@ pub(super) fn create(state: &mut VulkanState, adapter_id: u32) -> Result<DeviceH
             pipeline_cache,
             vk_timestamp_compute_and_graphics: physical_device.vk_timestamp_compute_and_graphics,
             vk_timestamp_period_ns: physical_device.vk_timestamp_period_ns,
+            legacy_frame_table: Mutex::new(None),
         }),
     );
 
     tracing::info!("Created Vulkan device {} for adapter {}", handle, adapter_id);
-    let ld = state.devices.get(&handle).unwrap().clone();
-    let instance = state.instance.clone();
-    super::frame_table::init_device(state, &instance, handle, &ld)?;
+    if let Some(ld) = state.devices.get(&handle) {
+        super::frame_table::reserve_device_bindless_slots(ld);
+    }
     Ok(handle)
 }
 
@@ -483,6 +484,14 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
         "destroying Vulkan device"
     );
     if let Some(logical_device) = state.devices.remove(&device_handle) {
+        let wait_result = unsafe { logical_device.device.device_wait_idle() };
+
+        if !matches!(wait_result, Err(vk::Result::ERROR_DEVICE_LOST)) {
+            if let Some(ft) = logical_device.legacy_frame_table.lock().unwrap().take() {
+                super::frame_table::destroy_context(state, &logical_device, &ft);
+            }
+        }
+
         unsafe {
             let wait_result = logical_device.device.device_wait_idle();
 
@@ -578,8 +587,6 @@ pub(super) fn destroy(state: &mut VulkanState, device_handle: DeviceHandle) {
                     sc.texture_staging_pool.destroy_all(&logical_device);
                 }
             }
-
-            super::frame_table::destroy_device(state, device_handle, &logical_device);
 
             // Destroy buffers owned by this device
             let buffer_handles: Vec<_> = state

--- a/src/backend/vulkan/frame_table.rs
+++ b/src/backend/vulkan/frame_table.rs
@@ -1,51 +1,61 @@
 //! Vulkan frame-table buffers and prologue (staging upload + device-local copy).
 
 use super::types::{
-    self, BufferState, LogicalDevice, SharedBufferTable, SharedContextMap, SharedFrameTableDevice, SharedFrameTableMap,
-    SharedPipelineTable, VulkanState,
+    self, BufferState, LogicalDevice, SharedBufferTable, SharedContextMap, SharedFrameTableDevice, SharedPipelineTable,
+    VulkanState,
 };
 use super::utils::find_memory_type;
 use super::BufferHandle;
 use crate::backend::GpuCommand;
 use crate::frame_table::{
-    FRAME_TABLE_DEVICE_SLOT, FRAME_TABLE_MAX_ROWS, FRAME_TABLE_ROW_STRIDE, FRAME_TABLE_SELECTOR_SLOT,
-    FRAME_TABLE_STAGING_BYTES, FRAME_TABLE_TABLE_U32S, FRAME_TABLE_USER_SLOT_BASE,
+    FRAME_TABLE_MAX_ROWS, FRAME_TABLE_ROW_STRIDE, FRAME_TABLE_STAGING_BYTES, FRAME_TABLE_TABLE_U32S,
+    FRAME_TABLE_USER_SLOT_BASE,
 };
 use anyhow::{Context, Result};
 use ash::vk;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-/// Per-device frame-table GPU resources.
+/// Per-context frame-table GPU resources and ring state.
 pub(crate) struct FrameTableDevice {
     pub selector: BufferHandle,
     pub device_table: BufferHandle,
+    /// Bindless storage slot of this context's selector cell (shader `_rs1`).
+    pub selector_slot: u32,
+    /// Bindless storage slot of this context's device-local table (shader `_rs2`).
+    pub table_slot: u32,
     pub staging: vk::Buffer,
     pub staging_memory: vk::DeviceMemory,
     pub staging_mapped: usize,
     pub submission_counter: AtomicU32,
     /// Bitmask of rows pinned by retained command buffers (must not be overwritten).
     pub pinned_rows: AtomicU32,
-    /// Last `submission_counter` value that wrote each row (ring reuse guard).
-    pub last_sub_for_row: [AtomicU32; FRAME_TABLE_MAX_ROWS as usize],
 }
 
-/// Create frame-table buffers at reserved bindless storage slots 0 and 1.
-pub(crate) fn init_device(
+/// Reserve user bindless slots once per device (low protocol slots stay unused).
+pub(crate) fn reserve_device_bindless_slots(ld: &LogicalDevice) {
+    ld.descriptors
+        .lock()
+        .unwrap()
+        .resource_registry
+        .ensure_storage_start(FRAME_TABLE_USER_SLOT_BASE);
+}
+
+/// Create per-context frame-table buffers at per-context bindless storage slots.
+///
+/// Slots come from the device's descriptor registry (like any other buffer), so
+/// concurrent contexts never share mutable descriptor slots and no rebinding at
+/// execute time is needed. The slot indices reach shaders via push constants
+/// (`_rs1`/`_rs2`).
+pub(crate) fn init_context(
     state: &mut VulkanState,
     instance: &ash::Instance,
     device_handle: super::DeviceHandle,
     ld: &LogicalDevice,
-) -> Result<()> {
-    let selector =
-        create_scattered_u32_buffer_at_slot(state, instance, device_handle, ld, FRAME_TABLE_SELECTOR_SLOT, 1)?;
-    let device_table = create_scattered_u32_buffer_at_slot(
-        state,
-        instance,
-        device_handle,
-        ld,
-        FRAME_TABLE_DEVICE_SLOT,
-        FRAME_TABLE_TABLE_U32S as u32,
-    )?;
+) -> Result<SharedFrameTableDevice> {
+    let (selector, selector_slot) = create_scattered_u32_buffer_registered(state, instance, device_handle, ld, 1)?;
+    let (device_table, table_slot) =
+        create_scattered_u32_buffer_registered(state, instance, device_handle, ld, FRAME_TABLE_TABLE_U32S as u32)?;
 
     let (staging, staging_memory, staging_mapped) = create_upload_table_buffer(instance, ld)?;
 
@@ -66,40 +76,114 @@ pub(crate) fn init_device(
         .unwrap()
         .element_stride = Some(4);
 
-    {
-        let dev = state.devices.get(&device_handle).context("init frame table")?;
-        dev.descriptors
-            .lock()
-            .unwrap()
-            .resource_registry
-            .ensure_storage_start(FRAME_TABLE_USER_SLOT_BASE);
+    let ft = SharedFrameTableDevice::new(FrameTableDevice {
+        selector,
+        device_table,
+        selector_slot,
+        table_slot,
+        staging,
+        staging_memory,
+        staging_mapped,
+        submission_counter: AtomicU32::new(0),
+        pinned_rows: AtomicU32::new(0),
+    });
+
+    let buffers = state.buffers.read().unwrap();
+    bind_to_bindless_heap(ld, &ft, &buffers.entries)?;
+
+    Ok(ft)
+}
+
+/// Lazy-init the device-owned frame table used by legacy `render_to_target`.
+pub(crate) fn ensure_legacy_frame_table(
+    state: &mut VulkanState,
+    instance: &ash::Instance,
+    device_handle: super::DeviceHandle,
+) -> Result<SharedFrameTableDevice> {
+    let ld = state
+        .devices
+        .get(&device_handle)
+        .context("Invalid device handle")?
+        .clone();
+    let mut guard = ld.legacy_frame_table.lock().unwrap();
+    if let Some(ft) = guard.as_ref() {
+        return Ok(std::sync::Arc::clone(ft));
     }
+    let ft = init_context(state, instance, device_handle, &ld)?;
+    *guard = Some(std::sync::Arc::clone(&ft));
+    Ok(ft)
+}
 
-    state.frame_tables.write().unwrap().insert(
-        device_handle,
-        std::sync::Arc::new(FrameTableDevice {
-            selector,
-            device_table,
-            staging,
-            staging_memory,
-            staging_mapped,
-            submission_counter: AtomicU32::new(0),
-            pinned_rows: AtomicU32::new(0),
-            last_sub_for_row: std::array::from_fn(|_| AtomicU32::new(0)),
-        }),
-    );
-
+/// Write this context's selector/table descriptors at its per-context slots.
+///
+/// Called once at context init; the slots are context-private for the context's
+/// lifetime, so no rebinding at execute time is ever needed.
+pub(crate) fn bind_to_bindless_heap(
+    ld: &LogicalDevice,
+    ft: &FrameTableDevice,
+    buffers: &HashMap<BufferHandle, BufferState>,
+) -> Result<()> {
+    let Some(descriptor_set) = ld.bindless_descriptor_set else {
+        return Ok(());
+    };
+    let selector = buffers.get(&ft.selector).context("frame table selector")?;
+    let device_table = buffers.get(&ft.device_table).context("frame table device table")?;
+    write_storage_at_slot(&ld.device, descriptor_set, ft.selector_slot, selector.buffer, 4)?;
+    write_storage_at_slot(
+        &ld.device,
+        descriptor_set,
+        ft.table_slot,
+        device_table.buffer,
+        (FRAME_TABLE_TABLE_U32S * 4) as u64,
+    )?;
     Ok(())
 }
 
-/// Destroy frame-table staging resources owned outside `state.buffers`.
-pub(crate) fn destroy_device(state: &mut VulkanState, device_handle: super::DeviceHandle, ld: &LogicalDevice) {
-    if let Some(ft) = state.frame_tables.write().unwrap().remove(&device_handle) {
-        unsafe {
-            ld.device.destroy_buffer(ft.staging, None);
-            ld.device.free_memory(ft.staging_memory, None);
+fn write_storage_at_slot(
+    device: &ash::Device,
+    descriptor_set: vk::DescriptorSet,
+    bindless_slot: u32,
+    buffer: vk::Buffer,
+    range: u64,
+) -> Result<()> {
+    let buffer_info = vk::DescriptorBufferInfo::default()
+        .buffer(buffer)
+        .offset(0)
+        .range(range.max(1));
+    let write = vk::WriteDescriptorSet::default()
+        .dst_set(descriptor_set)
+        .dst_binding(types::bindless_bindings::STORAGE_BUFFERS)
+        .dst_array_element(bindless_slot)
+        .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
+        .buffer_info(std::slice::from_ref(&buffer_info));
+    unsafe {
+        device.update_descriptor_sets(std::slice::from_ref(&write), &[]);
+    }
+    Ok(())
+}
+
+/// Destroy per-context frame-table resources: staging, the selector and table
+/// buffers, and their per-context bindless slots.
+///
+/// Caller guarantees the context's GPU work has fully retired.
+pub(crate) fn destroy_context(state: &VulkanState, ld: &LogicalDevice, ft: &FrameTableDevice) {
+    unsafe {
+        ld.device.destroy_buffer(ft.staging, None);
+        ld.device.free_memory(ft.staging_memory, None);
+    }
+    let mut buffers = state.buffers.write().unwrap();
+    for handle in [ft.selector, ft.device_table] {
+        if let Some(entry) = buffers.entries.remove(&handle) {
+            unsafe {
+                ld.device.destroy_buffer(entry.buffer, None);
+                ld.device.free_memory(entry.memory, None);
+            }
         }
     }
+    drop(buffers);
+    let mut registry = ld.descriptors.lock().unwrap();
+    registry.reclaim_buffer_slots(ft.selector);
+    registry.reclaim_buffer_slots(ft.device_table);
 }
 
 fn create_upload_table_buffer(
@@ -141,14 +225,13 @@ fn create_upload_table_buffer(
     Ok((buffer, memory, ptr as usize))
 }
 
-fn create_scattered_u32_buffer_at_slot(
+fn create_scattered_u32_buffer_registered(
     state: &mut VulkanState,
     instance: &ash::Instance,
     device_handle: super::DeviceHandle,
     ld: &LogicalDevice,
-    bindless_slot: u32,
     num_u32s: u32,
-) -> Result<BufferHandle> {
+) -> Result<(BufferHandle, u32)> {
     let logical_size = (num_u32s as u64) * 4;
     let allocation_size = logical_size.max(256);
 
@@ -180,25 +263,13 @@ fn create_scattered_u32_buffer_at_slot(
 
     unsafe { ld.device.bind_buffer_memory(buffer, memory, 0) }.context("frame table buffer bind_buffer_memory")?;
 
-    if let Some(descriptor_set) = ld.bindless_descriptor_set {
-        let buffer_info = vk::DescriptorBufferInfo::default()
-            .buffer(buffer)
-            .offset(0)
-            .range(logical_size.max(1));
-
-        let write = vk::WriteDescriptorSet::default()
-            .dst_set(descriptor_set)
-            .dst_binding(types::bindless_bindings::STORAGE_BUFFERS)
-            .dst_array_element(bindless_slot)
-            .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
-            .buffer_info(std::slice::from_ref(&buffer_info));
-
-        unsafe {
-            ld.device.update_descriptor_sets(std::slice::from_ref(&write), &[]);
-        }
-    }
-
     let handle = state.buffers.write().unwrap().alloc_handle();
+    let bindless_slot = ld
+        .descriptors
+        .lock()
+        .unwrap()
+        .resource_registry
+        .register_buffer(handle, true);
     state.buffers.write().unwrap().entries.insert(
         handle,
         BufferState {
@@ -224,11 +295,10 @@ fn create_scattered_u32_buffer_at_slot(
             texture_copy_footprint: None,
         },
     );
-    Ok(handle)
+    Ok((handle, bindless_slot))
 }
 
 fn prologue_pre_copy_barrier(device: &ash::Device, cmd: vk::CommandBuffer) {
-    // Wait for prior submission's table reads before overwriting device-local rows.
     let mem_barrier = vk::MemoryBarrier2::default()
         .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER | vk::PipelineStageFlags2::ALL_GRAPHICS)
         .src_access_mask(vk::AccessFlags2::SHADER_READ | vk::AccessFlags2::SHADER_WRITE)
@@ -314,56 +384,32 @@ pub(crate) fn unpin_row(ft: &FrameTableDevice, row: u32) {
     ft.pinned_rows.fetch_and(!bit, Ordering::AcqRel);
 }
 
-/// Row used by the most recent prologue (before counter bump on next submission).
-pub(crate) fn last_prologue_row(ft: &FrameTableDevice) -> Option<u32> {
-    let sub = ft.submission_counter.load(Ordering::Relaxed);
-    if sub == 0 {
-        None
-    } else {
-        Some((sub - 1) % FRAME_TABLE_MAX_ROWS)
-    }
-}
-
-fn assert_row_available(ft: &FrameTableDevice, sub: u32, row: u32) -> Result<()> {
-    let pinned = ft.pinned_rows.load(Ordering::Acquire);
-    if pinned & (1 << row) != 0 {
+fn assert_row_available(ft: &FrameTableDevice, row: u32) -> Result<()> {
+    if ft.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0 {
         anyhow::bail!(
-            "frame table row {row} is still pinned after evicting retained graphs \
-             (sub={sub}); retained command list lifecycle bug"
+            "frame table row {row} is still pinned after evicting retained graphs; \
+             retained command buffer lifecycle bug"
         );
-    }
-    if sub >= FRAME_TABLE_MAX_ROWS {
-        let prev = ft.last_sub_for_row[row as usize].load(Ordering::Acquire);
-        let gap = sub - prev;
-        if gap < FRAME_TABLE_MAX_ROWS {
-            anyhow::bail!(
-                "frame table row capacity exceeded: row {row} may still be in flight \
-                 (sub={sub}, last_sub_for_row={prev}, need gap >= {FRAME_TABLE_MAX_ROWS})"
-            );
-        }
     }
     Ok(())
 }
 
-/// CPU staging write before a retained resubmit (row bump + table bytes; GPU copy is in the CB).
-fn write_staging_for_submission_on(
+/// CPU staging write before a submission (row bump + table bytes; GPU copy is in the CB).
+fn write_staging_for_submission(
     contexts: &SharedContextMap,
-    frame_tables: &SharedFrameTableMap,
-    device_handle: super::DeviceHandle,
+    ctx: super::ContextHandle,
     ft: &FrameTableDevice,
     data: &[u32],
 ) -> Result<u32> {
     let sub = ft.submission_counter.fetch_add(1, Ordering::Relaxed);
     let row = sub % FRAME_TABLE_MAX_ROWS;
-    let row_pinned = ft.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0;
-    if row_pinned {
-        super::compute::evict_retained_pinning_row(contexts, frame_tables, device_handle, row);
+    if ft.pinned_rows.load(Ordering::Acquire) & (1 << row) != 0 {
+        super::compute::evict_retained_pinning_row_for_context(contexts, ft, ctx, row);
     }
+    assert_row_available(ft, row)?;
     let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
     let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
     let staging_ptr = ft.staging_mapped as *mut u32;
-    assert_row_available(ft, sub, row)?;
-    ft.last_sub_for_row[row as usize].store(sub, Ordering::Release);
     unsafe {
         let payload_dst =
             staging_ptr.add(crate::frame_table::FRAME_TABLE_STAGING_SELECTOR_U32S + row as usize * row_u32s);
@@ -373,37 +419,59 @@ fn write_staging_for_submission_on(
     Ok(row)
 }
 
-/// CPU staging write + GPU copy prologue (split borrows for standalone render).
-pub(crate) fn record_prologue_for_tables(
-    contexts: &SharedContextMap,
-    frame_tables: &SharedFrameTableMap,
+/// CPU staging write for legacy standalone render (no context eviction).
+fn write_staging_standalone(ft: &FrameTableDevice, data: &[u32]) -> Result<u32> {
+    let sub = ft.submission_counter.fetch_add(1, Ordering::Relaxed);
+    let row = sub % FRAME_TABLE_MAX_ROWS;
+    assert_row_available(ft, row)?;
+    let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
+    let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
+    let staging_ptr = ft.staging_mapped as *mut u32;
+    unsafe {
+        let payload_dst =
+            staging_ptr.add(crate::frame_table::FRAME_TABLE_STAGING_SELECTOR_U32S + row as usize * row_u32s);
+        std::ptr::copy_nonoverlapping(data.as_ptr(), payload_dst, copy_u32s);
+        std::ptr::write(staging_ptr.add(row as usize), row);
+    }
+    Ok(row)
+}
+
+/// CPU staging write + GPU copy prologue for legacy `render_to_target`.
+pub(crate) fn record_prologue_legacy(
+    frame_table: &FrameTableDevice,
     buffers: &SharedBufferTable,
-    device_handle: super::DeviceHandle,
     ld: &LogicalDevice,
     cmd: vk::CommandBuffer,
     data: &[u32],
-) -> Result<()> {
-    let frame_tables_read = frame_tables.read().unwrap();
-    let ft = frame_tables_read
-        .get(&device_handle)
-        .context("frame table not initialized")?;
-    let row = write_staging_for_submission_on(contexts, frame_tables, device_handle, ft, data)?;
+) -> Result<u32> {
+    let row = write_staging_standalone(frame_table, data)?;
     let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
     let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
-    record_table_copies(ft, buffers, ld, cmd, row, copy_u32s, true)
+    record_table_copies(frame_table, buffers, ld, cmd, row, copy_u32s, true)?;
+    Ok(row)
 }
 
 /// CPU staging write + GPU copy prologue.
+///
+/// The prologue copies the active row index into this context's selector buffer.
+/// That buffer is shared across all command buffers on the context; correctness
+/// assumes every submission for the context runs on the same FIFO queue so
+/// command buffers retire in submit order and a later prologue cannot clobber
+/// the selector while an earlier buffer's dispatches are still executing.
 pub(crate) fn record_prologue(
     contexts: &SharedContextMap,
-    frame_tables: &SharedFrameTableMap,
+    ctx: super::ContextHandle,
+    frame_table: &FrameTableDevice,
     buffers: &SharedBufferTable,
-    device_handle: super::DeviceHandle,
     ld: &LogicalDevice,
     cmd: vk::CommandBuffer,
     data: &[u32],
-) -> Result<()> {
-    record_prologue_for_tables(contexts, frame_tables, buffers, device_handle, ld, cmd, data)
+) -> Result<u32> {
+    let row = write_staging_for_submission(contexts, ctx, frame_table, data)?;
+    let row_u32s = FRAME_TABLE_ROW_STRIDE as usize;
+    let copy_u32s = data.len().min(row_u32s).min(FRAME_TABLE_TABLE_U32S);
+    record_table_copies(frame_table, buffers, ld, cmd, row, copy_u32s, true)?;
+    Ok(row)
 }
 
 /// Refresh the active row in the device-local table without advancing the selector.

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -267,7 +267,6 @@ impl VulkanBackend {
             compute_fence_pool: Arc::new(Mutex::new(HashMap::new())),
             device_lost: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             enable_validation,
-            frame_tables: Arc::new(RwLock::new(HashMap::new())),
         };
 
         Ok(Self { state })
@@ -329,6 +328,14 @@ impl crate::backend::GpuBackendTimelineWait for VulkanBackend {
         }
         if let Some(ld) = self.state.devices.get(&device_handle) {
             let drain_to = value.min(retired);
+            let ctx_batch: Vec<_> = self
+                .state
+                .contexts
+                .read()
+                .unwrap()
+                .get(&ctx)
+                .map(|sc| sc.lock().unwrap().deletion_queue.drain_up_to(drain_to))
+                .unwrap_or_default();
             let drained = {
                 let _drain = crate::tracy_zone!("vk.wait_until.deletion_queue.drain");
                 ld.deletion_queue.lock().unwrap().drain_up_to(drain_to)
@@ -337,7 +344,7 @@ impl crate::backend::GpuBackendTimelineWait for VulkanBackend {
                 let _destroy = crate::tracy_zone!("vk.wait_until.deletion_queue.destroy");
                 let descriptors_arc = std::sync::Arc::clone(&ld.descriptors);
                 let mut registry = descriptors_arc.lock().unwrap();
-                for r in drained {
+                for r in ctx_batch.into_iter().chain(drained) {
                     types::destroy_pending_deletion(ld, &mut registry, r);
                 }
                 let completed_values =
@@ -501,7 +508,7 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn destroy_buffer(&mut self, buffer_handle: BufferHandle) {
-        buffer::destroy(&self.state.devices, &self.state.buffers, buffer_handle);
+        buffer::destroy(&self.state, buffer_handle);
     }
 
     fn write_buffer(&mut self, buffer_handle: BufferHandle, offset: u64, data: &[u8]) -> Result<()> {
@@ -671,7 +678,7 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn free_readback_buffer(&mut self, buffer: BufferHandle) {
-        buffer::destroy(&self.state.devices, &self.state.buffers, buffer);
+        buffer::destroy(&self.state, buffer);
     }
 
     fn query_texture_copy_footprint(
@@ -850,17 +857,13 @@ impl GpuBackend for VulkanBackend {
         target: RenderTargetHandle,
         commands: &[RenderCommand],
     ) -> Result<()> {
-        let contexts = &self.state.contexts;
-        let pipelines = &self.state.pipelines;
-        let buffers = &self.state.buffers;
-        let devices = &self.state.devices;
-        let frame_tables = &self.state.frame_tables;
+        let instance = self.state.instance.clone();
+        let frame_table = frame_table::ensure_legacy_frame_table(&mut self.state, &instance, device_handle)?;
         let render_resources = render_target::RenderToResources {
-            contexts,
-            devices,
-            frame_tables,
-            buffers,
-            pipelines,
+            devices: &self.state.devices,
+            frame_table: &frame_table,
+            buffers: &self.state.buffers,
+            pipelines: &self.state.pipelines,
         };
         render_target::render_to(
             render_resources,
@@ -869,8 +872,8 @@ impl GpuBackend for VulkanBackend {
             target,
             commands,
             |cmd, cmds, logical_device, current_pipeline| {
-                let pipelines_read = pipelines.read().unwrap();
-                let buffers_read = buffers.read().unwrap();
+                let pipelines_read = self.state.pipelines.read().unwrap();
+                let buffers_read = self.state.buffers.read().unwrap();
                 render_commands::record(
                     cmd,
                     cmds,
@@ -878,6 +881,7 @@ impl GpuBackend for VulkanBackend {
                     &pipelines_read.entries,
                     &buffers_read.entries,
                     current_pipeline,
+                    (frame_table.selector_slot, frame_table.table_slot),
                 )
             },
         )
@@ -954,6 +958,7 @@ impl GpuBackend for VulkanBackend {
             frame.surface,
             frame.image,
             frame.present_slot,
+            frame.context,
             timeline_sem,
             commands,
         )?;
@@ -1465,11 +1470,12 @@ impl GpuBackend for VulkanBackend {
     }
 
     fn deferred_deletion_pending_count(&self, ctx: ContextHandle) -> usize {
-        let device_handle = self.context_device(ctx);
         self.state
-            .devices
-            .get(&device_handle)
-            .map(|d| d.deletion_queue.lock().unwrap().len())
+            .contexts
+            .read()
+            .unwrap()
+            .get(&ctx)
+            .map(|sc| sc.lock().unwrap().deletion_queue.len())
             .unwrap_or(0)
     }
 }

--- a/src/backend/vulkan/render_commands.rs
+++ b/src/backend/vulkan/render_commands.rs
@@ -18,6 +18,7 @@ pub(super) fn record(
     pipelines: &std::collections::HashMap<PipelineHandle, types::PipelineState>,
     buffers: &std::collections::HashMap<BufferHandle, types::BufferState>,
     current_pipeline: &mut Option<PipelineHandle>,
+    frame_table_slots: (u32, u32),
 ) -> anyhow::Result<()> {
     for command in commands {
         match command {
@@ -79,6 +80,7 @@ pub(super) fn record(
                 if let Some(pipeline) = current_pipeline.and_then(|p| pipelines.get(&p)) {
                     let mut layout = PushLayout::default();
                     shared::fill_frame_table_dispatch(&mut layout, *frame_table_base, raw_user);
+                    shared::set_frame_table_slots(&mut layout, frame_table_slots.0, frame_table_slots.1);
                     unsafe {
                         logical_device.device.cmd_push_constants(
                             cmd,

--- a/src/backend/vulkan/render_target.rs
+++ b/src/backend/vulkan/render_target.rs
@@ -544,9 +544,8 @@ where
 }
 
 pub(super) struct RenderToResources<'a> {
-    pub(super) contexts: &'a super::types::SharedContextMap,
     pub(super) devices: &'a HashMap<DeviceHandle, super::types::SharedLogicalDevice>,
-    pub(super) frame_tables: &'a super::types::SharedFrameTableMap,
+    pub(super) frame_table: &'a super::types::SharedFrameTableDevice,
     pub(super) buffers: &'a super::types::SharedBufferTable,
     pub(super) pipelines: &'a super::types::SharedPipelineTable,
 }
@@ -580,11 +579,9 @@ where
         .context("Failed to begin command buffer")?;
 
     if has_bindings {
-        super::frame_table::record_prologue_for_tables(
-            resources.contexts,
-            resources.frame_tables,
+        super::frame_table::record_prologue_legacy(
+            resources.frame_table,
             resources.buffers,
-            device_handle,
             logical_device,
             cmd,
             &staging_data,

--- a/src/backend/vulkan/submit_session.rs
+++ b/src/backend/vulkan/submit_session.rs
@@ -6,8 +6,8 @@
 use super::compute;
 use super::types::{
     SharedBufferTable, SharedComputeFencePool, SharedComputePipelineTable, SharedContextMap, SharedFrameTableDevice,
-    SharedFrameTableMap, SharedLogicalDevice, SharedPipelineTable, SharedRenderTargetTable, SharedSubmissionContext,
-    SharedTextureTable, VulkanState,
+    SharedLogicalDevice, SharedPipelineTable, SharedRenderTargetTable, SharedSubmissionContext, SharedTextureTable,
+    VulkanState,
 };
 use super::{ContextHandle, DeviceHandle, GpuCommand, GraphCommand, SubmitSync};
 use crate::timeline::TimelineValue;
@@ -27,7 +27,6 @@ pub(crate) struct VulkanSubmitView<'a> {
     pub render_targets: &'a SharedRenderTargetTable,
     pub textures: &'a SharedTextureTable,
     pub compute_fence_pool: &'a SharedComputeFencePool,
-    pub frame_tables: &'a SharedFrameTableMap,
     pub device_lost: &'a Arc<AtomicBool>,
 }
 
@@ -43,7 +42,6 @@ impl VulkanState {
             render_targets: &self.render_targets,
             textures: &self.textures,
             compute_fence_pool: &self.compute_fence_pool,
-            frame_tables: &self.frame_tables,
             device_lost: &self.device_lost,
         }
     }
@@ -88,7 +86,6 @@ pub(crate) struct VulkanSubmitSession {
     render_targets: SharedRenderTargetTable,
     textures: SharedTextureTable,
     compute_fence_pool: SharedComputeFencePool,
-    frame_tables: SharedFrameTableMap,
     device_lost: Arc<AtomicBool>,
 }
 
@@ -102,15 +99,10 @@ impl VulkanSubmitSession {
                 .get(&ctx)
                 .with_context(|| format!("Invalid context handle {ctx}"))?,
         );
-        let device_handle = sc.lock().unwrap().device;
-        let frame_table = Arc::clone(
-            state
-                .frame_tables
-                .read()
-                .unwrap()
-                .get(&device_handle)
-                .with_context(|| format!("frame table not initialized for device {device_handle}"))?,
-        );
+        let (device_handle, frame_table) = {
+            let sc_guard = sc.lock().unwrap();
+            (sc_guard.device, Arc::clone(&sc_guard.frame_table))
+        };
         let devices: HashMap<DeviceHandle, SharedLogicalDevice> = state
             .devices
             .iter()
@@ -130,7 +122,6 @@ impl VulkanSubmitSession {
             render_targets: Arc::clone(&state.render_targets),
             textures: Arc::clone(&state.textures),
             compute_fence_pool: Arc::clone(&state.compute_fence_pool),
-            frame_tables: Arc::clone(&state.frame_tables),
             device_lost: Arc::clone(&state.device_lost),
         }))
     }
@@ -150,7 +141,6 @@ impl VulkanSubmitSession {
                 render_targets: &self.render_targets,
                 textures: &self.textures,
                 compute_fence_pool: &self.compute_fence_pool,
-                frame_tables: &self.frame_tables,
                 device_lost: &self.device_lost,
             },
             frame_table: Arc::clone(&self.frame_table),
@@ -172,15 +162,10 @@ pub(crate) fn scope_from_state(state: &VulkanState, ctx: ContextHandle) -> Resul
             .get(&ctx)
             .with_context(|| format!("Invalid context handle {ctx}"))?,
     );
-    let device_handle = sc.lock().unwrap().device;
-    let frame_table = Arc::clone(
-        state
-            .frame_tables
-            .read()
-            .unwrap()
-            .get(&device_handle)
-            .with_context(|| format!("frame table not initialized for device {device_handle}"))?,
-    );
+    let (device_handle, frame_table) = {
+        let sc_guard = sc.lock().unwrap();
+        (sc_guard.device, Arc::clone(&sc_guard.frame_table))
+    };
     Ok(VulkanSubmitScope {
         ctx,
         device_handle,

--- a/src/backend/vulkan/surface.rs
+++ b/src/backend/vulkan/surface.rs
@@ -893,11 +893,11 @@ pub(super) fn render(
     surface_handle: SurfaceHandle,
     image: SwapchainImageHandle,
     present_slot: u32,
+    ctx: super::ContextHandle,
     timeline_sem: vk::Semaphore,
     commands: &[RenderCommand],
 ) -> Result<()> {
     let devices = &state.devices;
-    let frame_tables = &state.frame_tables;
     let buffers = &state.buffers;
     let pipelines = &state.pipelines;
     let surfaces = &mut state.surfaces;
@@ -993,12 +993,23 @@ pub(super) fn render(
             logical_device.device.cmd_pipeline_barrier2(cmd, &dep_info);
         }
 
+        let frame_table = {
+            let contexts_read = state.contexts.read().unwrap();
+            let sc_arc = contexts_read.get(&ctx).context("Invalid context handle")?.clone();
+            drop(contexts_read);
+            let sc_guard = sc_arc.lock().unwrap();
+            let ft = std::sync::Arc::clone(&sc_guard.frame_table);
+            drop(sc_guard);
+            ft
+        };
         if has_bindings {
-            super::frame_table::record_prologue_for_tables(
+            // Per-context frame-table slots are bound once at context init; no
+            // per-submit rebinding needed.
+            super::frame_table::record_prologue(
                 &state.contexts,
-                frame_tables,
+                ctx,
+                &frame_table,
                 buffers,
-                device_handle,
                 logical_device,
                 cmd,
                 &staging_data,
@@ -1138,6 +1149,7 @@ pub(super) fn render(
                 &pipelines_read.entries,
                 &buffers_read.entries,
                 &mut current_pipeline,
+                (frame_table.selector_slot, frame_table.table_slot),
             )?;
         }
 

--- a/src/backend/vulkan/types.rs
+++ b/src/backend/vulkan/types.rs
@@ -617,6 +617,8 @@ pub(crate) struct SubmissionContext {
     /// surface acquire).  As a result the submit hot path no longer touches the
     /// device-level queue at all, which is required for Phase 5 (lock-free submit).
     pub deletion_queue: DeletionQueue,
+    /// Per-context frame-table GPU resources and ring state (bindless slots 0/1).
+    pub frame_table: SharedFrameTableDevice,
 }
 
 /// A logical Vulkan device with associated resources.
@@ -698,6 +700,9 @@ pub(crate) struct LogicalDevice {
     /// Timestamp query support (`VkPhysicalDeviceLimits::timestamp_compute_and_graphics`).
     pub vk_timestamp_compute_and_graphics: bool,
     pub vk_timestamp_period_ns: f32,
+
+    /// Frame table for legacy `render_to_target` (no submission context).
+    pub legacy_frame_table: Mutex<Option<SharedFrameTableDevice>>,
 }
 
 /// A Vulkan command buffer retained for resubmission.
@@ -1341,11 +1346,8 @@ pub(super) type SharedComputeFencePool = Arc<ComputeFencePool>;
 /// Per-context map — read/write independently of the global backend mutex (Phase 5b-iii).
 pub(crate) type SharedContextMap = Arc<RwLock<HashMap<super::ContextHandle, SharedSubmissionContext>>>;
 
-/// Per-device frame-table GPU resources — cloned into submit sessions.
+/// Per-context frame-table GPU resources — cloned into submit sessions at context creation.
 pub(crate) type SharedFrameTableDevice = Arc<super::frame_table::FrameTableDevice>;
-
-/// Frame tables keyed by device — cloned into [`super::submit_session::VulkanSubmitSession`].
-pub(crate) type SharedFrameTableMap = Arc<RwLock<HashMap<DeviceHandle, SharedFrameTableDevice>>>;
 
 /// Map plus monotonic handle allocator for a single resource kind.
 ///
@@ -1426,6 +1428,4 @@ pub(super) struct VulkanState {
     /// `true` when `VK_EXT_debug_utils` was loaded (i.e. validation layers are
     /// active).  Guards `set_texture_debug_name` so we never call a null fp.
     pub enable_validation: bool,
-    /// Per-device frame-table GPU resources (selector, device table, upload staging).
-    pub frame_tables: SharedFrameTableMap,
 }

--- a/src/frame_table.rs
+++ b/src/frame_table.rs
@@ -4,11 +4,16 @@
 //! before each submission; shader preambles resolve `index = table[selector][base + k]`
 //! instead of reading baked push-constant words.
 
-/// Bindless heap slot for the per-submission selector cell (`u32`).
+/// Metal argument-buffer slot for the (unused) selector cell.
+///
+/// On DX12/Vulkan the selector/table slots are **per-context** (allocated from
+/// the device descriptor registry) and reach shaders via push constants
+/// `_rs1`/`_rs2`; these constants only describe Metal's fixed device-level
+/// argument-buffer layout.
 pub const FRAME_TABLE_SELECTOR_SLOT: u32 = 0;
-/// Bindless heap slot for the device-local index table (`Scattered<u32>`).
+/// Metal argument-buffer slot for the device-local index table (`Scattered<u32>`).
 pub const FRAME_TABLE_DEVICE_SLOT: u32 = 1;
-/// First bindless slot available to program resources (selector + table are reserved).
+/// First bindless slot available to program resources (low protocol slots reserved).
 pub const FRAME_TABLE_USER_SLOT_BASE: u32 = 2;
 
 /// Maximum bindless indices routed through the table per submission row.

--- a/src/parcel.rs
+++ b/src/parcel.rs
@@ -1023,7 +1023,8 @@ impl Init {
     /// Reserve zero-initialized space for `count` elements of type `T`.
     pub fn zeros<T: StructuredBufferElement>(count: u64) -> Self {
         let stride = std::mem::size_of::<T>() as u32;
-        let bytes = vec![0u8; (count * stride as u64) as usize];
+        let bytes_len = count.saturating_mul(stride as u64);
+        let bytes = vec![0u8; bytes_len as usize];
         Self::Data { bytes, count, stride }
     }
 }

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -233,7 +233,8 @@ impl Submission {
 
     /// Block until this submission's GPU work has completed.
     pub fn wait(&self, ctx: &Context) -> Result<(), GoldyError> {
-        ctx.wait_until(self.data.timeline)
+        ctx.wait_until(self.data.timeline)?;
+        Ok(())
     }
 }
 

--- a/src/slang/virtual_main.rs
+++ b/src/slang/virtual_main.rs
@@ -1109,7 +1109,7 @@ impl WrapperBuilder {
             ParamKind::Resource => {
                 let k = *bindless_idx;
                 *bindless_idx += 1;
-                let extract = format!("goldy_frame_table_index(_rs0, {}u)", k);
+                let extract = format!("goldy_frame_table_index(_rs0, {}u, _rs1, _rs2)", k);
                 let init_expr = resource_init_expr(&param.ty, &extract);
                 self.push_body_stmt(&format!("    {} {} = {};", param.ty, param.name, init_expr));
                 self.push_call(&param.name);
@@ -1124,7 +1124,7 @@ impl WrapperBuilder {
             ParamKind::Broadcast => {
                 let k = *bindless_idx;
                 *bindless_idx += 1;
-                let extract = format!("goldy_frame_table_index(_rs0, {}u)", k);
+                let extract = format!("goldy_frame_table_index(_rs0, {}u, _rs1, _rs2)", k);
                 self.push_body_stmt(&format!(
                     "    {} {} = goldy_broadcast<{}>({});",
                     param.ty, param.name, param.ty, extract
@@ -1277,8 +1277,9 @@ fn emit_wrapper(entry: &EntryDef) -> String {
     let mut wb = WrapperBuilder::new();
 
     // Always emit all 8 bindless words (_bw0.._bw7), 8 user words (_uw0.._uw7),
-    // and frame-table dispatch base (_rs0 = PushLayout._reserved[0]) so that
-    // push constant offsets are fixed regardless of how many params are used.
+    // frame-table dispatch base (_rs0 = PushLayout._reserved[0]), and the
+    // per-context frame-table slots (_rs1/_rs2 = _reserved[1]/_reserved[2]) so
+    // that push constant offsets are fixed regardless of how many params are used.
     for i in 0..8u32 {
         wb.push_sig(&format!("uniform uint _bw{}", i));
     }
@@ -1286,6 +1287,8 @@ fn emit_wrapper(entry: &EntryDef) -> String {
         wb.push_sig(&format!("uniform uint _uw{}", i));
     }
     wb.push_sig("uniform uint _rs0");
+    wb.push_sig("uniform uint _rs1");
+    wb.push_sig("uniform uint _rs2");
 
     for item in &entry.params {
         match item {
@@ -1770,7 +1773,7 @@ void cs_main(Scattered<uint> data, ThreadId id) {
         assert!(result.contains("uniform uint _uw0"), "Missing _uw0");
         assert!(result.contains("SV_DispatchThreadID"), "Missing SV_DispatchThreadID");
         assert!(
-            result.contains("goldy_scattered<uint>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains("goldy_scattered<uint>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"),
             "Missing scattered init"
         );
         assert!(result.contains("ThreadId id = ThreadId(_sv0)"), "Missing SV init");
@@ -1794,7 +1797,7 @@ void cs_main(Scattered<uint> data, ThreadId id, uint base) {
         let result = transform_virtual_main(src);
         // Bindless region: slot 0 via frame table.
         assert!(
-            result.contains("goldy_scattered<uint>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains("goldy_scattered<uint>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"),
             "Missing scattered from frame table slot 0"
         );
         // User region: _uw0 for uint base.
@@ -1987,12 +1990,16 @@ void cs_main(TimeUniforms cfg, Scattered<uint> data, ThreadId id) {
         assert!(result.contains("[shader(\"compute\")]"), "Missing compute attr");
         // cfg at bindless[0] → _bw0 low half.
         assert!(
-            result.contains("TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains(
+                "TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"
+            ),
             "Missing broadcast init"
         );
         // data at bindless[1] → _bw0 high half.
         assert!(
-            result.contains("Scattered<uint> data = goldy_scattered<uint>(goldy_frame_table_index(_rs0, 1u))"),
+            result.contains(
+                "Scattered<uint> data = goldy_scattered<uint>(goldy_frame_table_index(_rs0, 1u, _rs1, _rs2))"
+            ),
             "Missing resource init"
         );
     }
@@ -2011,7 +2018,9 @@ float4 fs_main(TimeUniforms cfg, FullscreenVarying input) : SV_Target {
         let result = transform_virtual_main(src);
         // cfg becomes broadcast (bindless slot 0).
         assert!(
-            result.contains("TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains(
+                "TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"
+            ),
             "Missing broadcast init"
         );
         // input is the stage varying (PassThrough) — no bindless slot for it.
@@ -2032,7 +2041,9 @@ VSOutput vs_main(TimeUniforms cfg, VIn input) {
         let result = transform_virtual_main(src);
         // cfg → broadcast at bindless[0].
         assert!(
-            result.contains("TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains(
+                "TimeUniforms cfg = goldy_broadcast<TimeUniforms>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"
+            ),
             "Missing broadcast init"
         );
         // VIn input → passthrough (vertex attribute struct).
@@ -2056,15 +2067,15 @@ void cs_main(Interpolated<float4> src_tex, Filter samp, Scattered<float4> dst, T
         // All three resource params use frame-table slots.
         assert!(result.contains("uniform uint _rs0"), "Missing _rs0");
         assert!(
-            result.contains("goldy_interpolated<float4>(goldy_frame_table_index(_rs0, 0u))"),
+            result.contains("goldy_interpolated<float4>(goldy_frame_table_index(_rs0, 0u, _rs1, _rs2))"),
             "Missing src_tex init"
         );
         assert!(
-            result.contains("goldy_filter(goldy_frame_table_index(_rs0, 1u))"),
+            result.contains("goldy_filter(goldy_frame_table_index(_rs0, 1u, _rs1, _rs2))"),
             "Missing samp init"
         );
         assert!(
-            result.contains("goldy_scattered<float4>(goldy_frame_table_index(_rs0, 2u))"),
+            result.contains("goldy_scattered<float4>(goldy_frame_table_index(_rs0, 2u, _rs1, _rs2))"),
             "Missing dst init"
         );
         // SV param keeps its SV semantic.

--- a/src/task_graph/graph.rs
+++ b/src/task_graph/graph.rs
@@ -1652,7 +1652,8 @@ impl TaskGraph {
         );
 
         let tv = submit_resolved_ir(&mut self.schedule_cache, context, session, &self.ir, None)?;
-        if wait_for_transient_completion && self.needs_transient_gpu_wait() {
+        let needs_wait = wait_for_transient_completion && (self.needs_transient_gpu_wait() || self.has_render_passes());
+        if needs_wait {
             context.wait_until(tv).map_err(|e| anyhow::anyhow!(e))?;
         }
         Ok(tv)
@@ -1797,7 +1798,9 @@ impl TaskGraph {
         if has_render {
             let g = analysis::emit_graph_commands(&self.ir, schedule, Some(resolver));
             let tv = session.submit_graph(context.backend_handle(), &g, None)?;
-            if wait_for_transient_completion && self.needs_transient_gpu_wait() {
+            let needs_wait =
+                wait_for_transient_completion && (self.needs_transient_gpu_wait() || self.has_render_passes());
+            if needs_wait {
                 context.wait_until(tv).map_err(|e| anyhow::anyhow!(e))?;
             }
             return Ok(tv);


### PR DESCRIPTION
Re-derives the frame-table management refactor from no-imperative commit 76996092 onto the pre-worker frame-table base, since the two branches have long diverged. The frame-table concern (per-context bindless descriptor slots so concurrent contexts do not share mutable slots) is orthogonal to the FIFO-present decision, but the original commit was recorded on top of ~39 worker/present-era commits, producing broad conflicts.

Adopted from the commit:
- device-keyed frame table -> per-context frame_table (init_context / destroy_context; legacy_frame_table on LogicalDevice for render_to_target) for both DX12 and Vulkan; removed device-level frame_tables / SharedFrameTableMap.
- deferred buffer GPU release gated on bindless-slot retirement (PendingBufferGpuRelease, snapshot_buffer_slot_requirements, bindless_retirement_fence_for_buffer, drain_pending_buffer_gpu_releases).
- reclamation_context thread-scoped epoch.
- context_fences threaded through the deletion-queue drain path.
- device_removed shared as Arc<AtomicBool> + DRED first-touch diagnostics; added wait_for_fence_on_device / with_queue_lock helpers.

Dropped (worker/present-era, absent on this base):
- submission_worker, pending_present_finishes, pending_gpu_profiles fields and the pending_submit / submission_worker code paths.
- the incidental host_wait.rs / submission_worker.rs no-op hunks.
- unrelated shared_device test-infra migration (reverted the three test files to base; that belongs to a separate cherry-pick).

Library builds clean for dx12+vulkan.